### PR TITLE
ASE Atoms - PLAMS Molecule Interface

### DIFF
--- a/src/scm/plams/tools/ase.py
+++ b/src/scm/plams/tools/ase.py
@@ -1,0 +1,74 @@
+from ase import Atom as aseAtom
+from ase import Atoms as aseAtoms
+from ..core.basemol import Molecule,Atom
+
+__all__ = ['toASE','fromASE']
+
+def toASE(molecule):
+    """
+    Converts a PLAMS molecule to an ASE molecule. The following attributes are converted, conserving the order of atoms:
+    -Coordinates
+    -Atomic Number (Symbol is derived automaticaly)
+    -Periodicity and Cell Vectors
+    """
+    aseMol = aseAtoms()
+
+    #iterate over PLAMS atoms
+    for atom in molecule:
+
+        #check if coords only consists of floats or ints
+        if not all(isinstance(x, (int,float)) for x in atom.coords):
+            raise ValueError("Non-Number in Atomic Coordinates, not compatible with ASE")
+
+        #append atom to aseMol
+        aseMol.append(aseAtom(atom.atnum, atom.coords))
+
+    #get lattice info if any
+    lattice = []
+    pbc = [False,False,False]
+    for i,vec in enumerate(molecule.lattice):
+
+        #check if lattice only consists of floats or ints
+        if not all(isinstance(x, (int,float)) for x in vec):
+            raise ValueError("Non-Number in Lattice Vectors, not compatible with ASE")
+
+        pbc[i] = True
+        lattice.append(vec)
+    
+    #save lattice info to aseMol
+    if any(pbc):
+        aseMol.set_pbc(pbc)
+        aseMol.set_cell(lattice)
+
+    return aseMol
+
+
+
+
+def fromASE(molecule):
+    """
+    Converts an ASE molecule to a PLAMS molecule. The following attributes are converted, conserving the order of atoms:
+    -Coordinates
+    -Atomic Number (Symbol is derived automaticaly)
+    -Periodicity and Cell Vectors
+    """
+    plamsMol = Molecule()
+
+    #iterate over ASE atoms
+    for atom in molecule:
+        #add atom to plamsMol
+        plamsMol.add_atom(Atom(atnum=atom.number, coords=tuple(atom.position)))
+
+    #add Lattice if any
+    if any(molecule.get_pbc()):
+        lattice = []
+        #loop over three booleans
+        for i,boolean in enumerate(molecule.get_pbc().tolist()):
+            if boolean:
+                lattice.append(tuple(molecule.get_cell()[i]))
+
+        #write lattice to plamsMol
+        plamsMol.lattice = lattice.copy()
+
+
+    return plamsMol


### PR DESCRIPTION
Hey,
I wrote two small functions to convert ASE Atoms objects to PLAMS Molecule objects and vice versa. They are very similar, so there is no big problem.
Since the extended XYZ format of ASE and the SCM-XYZ format are not compatible this makes the integration of workflows with PLAMS and ASE and their related codes easier and it is less code then to write a file-converter.

Right now only atomic numbers (symbols are linked in both modules), coordinates and lattice vectors are converted, the atom ordering is preserved.

Hope this helps someone else too.
Patrick