### PR TITLE
Fixed issue of 1D and 2D lattice vectors in tools.ase

### DIFF
--- a/src/scm/plams/tools/ase.py
+++ b/src/scm/plams/tools/ase.py
@@ -1,11 +1,13 @@
 from ..core.basemol import Molecule,Atom
+from numpy import zeros as npz
+from numpy import array as npa
 
 __all__ = ['toASE','fromASE']
 
 try:
     from ase import Atom as aseAtom
     from ase import Atoms as aseAtoms
-except ModuleNotFoundError:
+except ImportError:
     __all__ = []
 
 
@@ -30,7 +32,7 @@ def toASE(molecule):
         aseMol.append(aseAtom(atom.atnum, atom.coords))
 
     #get lattice info if any
-    lattice = []
+    lattice = npz((3,3))
     pbc = [False,False,False]
     for i,vec in enumerate(molecule.lattice):
 
@@ -39,7 +41,7 @@ def toASE(molecule):
             raise ValueError("Non-Number in Lattice Vectors, not compatible with ASE")
 
         pbc[i] = True
-        lattice.append(vec)
+        lattice[i] = npa(vec)
 
     #save lattice info to aseMol
     if any(pbc):


### PR DESCRIPTION
Previous behavior would yield wrong results in 1D and 2D molecules or just crash if molecule.lattice is shorter then 3x3. Depending on the way the PLAMS Molecule is made, the lattice can actually be shorter than 3x3. This case did not appear in my test cases, now I stumbled upon it.