### PR TITLE
Fixed inconsistent units between atomic and lattice vector coordinates.

### DIFF
--- a/src/scm/plams/core/basemol.py
+++ b/src/scm/plams/core/basemol.py
@@ -1116,7 +1116,8 @@ class Molecule (object):
         if self.lattice:
             s += '  Lattice:\n'
             for vec in self.lattice:
-                s += '    {:16.10f} {:16.10f} {:16.10f}\n'.format(*vec)
+                v = [Units.convert(x, 'bohr', 'angstrom') for x in vec]
+                s += '    {:16.10f} {:16.10f} {:16.10f}\n'.format(*v)
         return s
 
 
@@ -1252,7 +1253,8 @@ class Molecule (object):
         for at in self.atoms:
             f.write(str(at) + '\n')
         for i,vec in enumerate(self.lattice):
-            f.write('VEC'+str(i+1) + '%14.6f %14.6f %14.6f\n'%tuple(vec))
+            v = [Units.convert(x, 'bohr', 'angstrom') for x in vec]
+            f.write('VEC'+str(i+1) + '%14.6f %14.6f %14.6f\n'%tuple(v))
 
 
     def readmol(self, f, frame):


### PR DESCRIPTION
Printing Molecule objects was producing atomic coordinates in angstrom
with lattice vectors in bohr. The same inconsistent behavior occurred
when writing to xyz files.

Now atomic and vector coordinates are both printed in angstrom.