### PR TITLE
 BugFix in plams-ams interface: inconsistent units between atomic and lattice vector coords

### DIFF
--- a/src/scm/plams/core/basemol.py
+++ b/src/scm/plams/core/basemol.py
@@ -1116,7 +1116,8 @@ class Molecule (object):
         if self.lattice:
             s += '  Lattice:\n'
             for vec in self.lattice:
-                s += '    {:16.10f} {:16.10f} {:16.10f}\n'.format(*vec)
+                v = [Units.convert(x, 'bohr', 'angstrom') for x in vec]
+                s += '    {:16.10f} {:16.10f} {:16.10f}\n'.format(*v)
         return s
 
 
@@ -1252,7 +1253,8 @@ class Molecule (object):
         for at in self.atoms:
             f.write(str(at) + '\n')
         for i,vec in enumerate(self.lattice):
-            f.write('VEC'+str(i+1) + '%14.6f %14.6f %14.6f\n'%tuple(vec))
+            v = [Units.convert(x, 'bohr', 'angstrom') for x in vec]
+            f.write('VEC'+str(i+1) + '%14.6f %14.6f %14.6f\n'%tuple(v))
 
 
     def readmol(self, f, frame):

--- a/src/scm/plams/core/basemol.py
+++ b/src/scm/plams/core/basemol.py
@@ -1116,8 +1116,7 @@ class Molecule (object):
         if self.lattice:
             s += '  Lattice:\n'
             for vec in self.lattice:
-                v = [Units.convert(x, 'bohr', 'angstrom') for x in vec]
-                s += '    {:16.10f} {:16.10f} {:16.10f}\n'.format(*v)
+                s += '    {:16.10f} {:16.10f} {:16.10f}\n'.format(*vec)
         return s
 
 
@@ -1253,8 +1252,7 @@ class Molecule (object):
         for at in self.atoms:
             f.write(str(at) + '\n')
         for i,vec in enumerate(self.lattice):
-            v = [Units.convert(x, 'bohr', 'angstrom') for x in vec]
-            f.write('VEC'+str(i+1) + '%14.6f %14.6f %14.6f\n'%tuple(v))
+            f.write('VEC'+str(i+1) + '%14.6f %14.6f %14.6f\n'%tuple(vec))
 
 
     def readmol(self, f, frame):

--- a/src/scm/plams/interfaces/adfsuite/ams.py
+++ b/src/scm/plams/interfaces/adfsuite/ams.py
@@ -10,6 +10,7 @@ from ...core.private import sha256
 from ...core.results import Results
 from ...core.settings import Settings
 from ...tools.kftools import KFFile
+from ...tools.units import Units
 
 
 
@@ -175,7 +176,9 @@ class AMSResults(Results):
             ret.properties.charge = sectdict['Charge']
 
         if 'nLatticeVectors' in sectdict:
-            ret.lattice = [tuple(sectdict['LatticeVectors'][i:i+3]) for i in range(0,len(sectdict['LatticeVectors']),3)]
+            ret.lattice = []
+            for i in range(0,len(sectdict['LatticeVectors']),3):
+                ret.lattice.append(tuple(Units.convert(sectdict['LatticeVectors'][i:i+3], 'bohr', 'angstrom')))
 
         if 'EngineAtomicInfo' in sectdict:
             suffixes = sectdict['EngineAtomicInfo'].splitlines()

--- a/src/scm/plams/interfaces/adfsuite/ams.py
+++ b/src/scm/plams/interfaces/adfsuite/ams.py
@@ -176,9 +176,7 @@ class AMSResults(Results):
             ret.properties.charge = sectdict['Charge']
 
         if 'nLatticeVectors' in sectdict:
-            ret.lattice = []
-            for i in range(0,len(sectdict['LatticeVectors']),3):
-                ret.lattice.append(tuple(Units.convert(sectdict['LatticeVectors'][i:i+3], 'bohr', 'angstrom')))
+            ret.lattice = Units.convert([tuple(sectdict['LatticeVectors'][i:i+3]) for i in range(0,len(sectdict['LatticeVectors']),3)], 'bohr', 'angstrom')
 
         if 'EngineAtomicInfo' in sectdict:
             suffixes = sectdict['EngineAtomicInfo'].splitlines()


### PR DESCRIPTION
The `read_molecule` method  was returning a `Molecule` object with atomic coordinates in angstrom and lattice vectors in bohr.