### PR TITLE
BUG: KFReader crashes if German umlaut in kf-file

### DIFF
--- a/src/scm/plams/tools/kftools.py
+++ b/src/scm/plams/tools/kftools.py
@@ -135,7 +135,10 @@ class KFReader(object):
         if step > 0:
             while step <= len(block):
                 new = struct.unpack(str(formatstring), block[:step])
-                new = tuple(map(lambda x: x.decode() if isinstance(x,bytes) else x, new))
+                try:
+                    new = tuple(map(lambda x: x.decode() if isinstance(x,bytes) else x, new))
+                except:
+                    new = tuple(map(lambda x: x.decode("Latin-1") if isinstance(x,bytes) else x, new))
                 ret.append(new)
                 block = block[step:]
         return ret


### PR DESCRIPTION
Sadly, our license prints an Umlaut "ä" (0xe4) to the kf files. On some systems this causes a crash of the KFReader like this:

>   File "/home/patrickm/git/myPlamsFork/src/scm/plams/tools/kftools.py", line 73, in read
    ret = self._get_data(self._read_block(f,i))[vtype-1][vstart-1:]
  File "/home/patrickm/git/myPlamsFork/src/scm/plams/tools/kftools.py", line 150, in _get_data
    contents = self._parse(datablock[hlen:], zip((i,d,s,b),(self.word,'d','s',self.word)))
  File "/home/patrickm/git/myPlamsFork/src/scm/plams/tools/kftools.py", line 139, in _parse
    new = tuple(map(lambda x: x.decode() if isinstance(x,bytes) else x, new))
  File "/home/patrickm/git/myPlamsFork/src/scm/plams/tools/kftools.py", line 139, in <lambda>
    new = tuple(map(lambda x: x.decode() if isinstance(x,bytes) else x, new))
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe4 in position 1249: invalid continuation byte

I managed to fix it using the submitted hack. There is probably a nicer way to do it, but I don't know it. So feel free to fix it differently and think of this as a bug-report.