### PR TITLE
Mol numpy

### DIFF
--- a/mol/molecule.py
+++ b/mol/molecule.py
@@ -559,6 +559,7 @@ class Molecule (object):
 
             This method does not check if *matrix* is a proper rotation matrix.
         """
+        matrix = np.array(matrix).reshape(3,3)
         self.lattice = [tuple(np.dot(matrix,i)) for i in self.lattice]
 
 

--- a/mol/molecule.py
+++ b/mol/molecule.py
@@ -750,7 +750,7 @@ class Molecule (object):
         length = Units.convert(length, length_unit, 'angstrom')
         angle = Units.convert(angle, angle_unit, 'radian')
 
-        xy_array = self.to_array()[:, 0:2].T
+        xy_array = self.as_array().T[0:2]
         if xy_array[0].ptp() > length:
             raise MoleculeError('wrap: x-extension of the molecule is larger than length')
 
@@ -824,9 +824,9 @@ class Molecule (object):
 
         lattice_np = np.array(self.lattice)
         frac_coords_transf = np.linalg.inv(lattice_np.T)
-        deformed_lattice = np.dot(lattice_np, np.eye(n) + np.array(strain))
+        deformed_lattice = np.dot(lattice_np, np.eye(n) + strain)
 
-        xyz_array = self.to_array()
+        xyz_array = self.as_array()
         fractional_coords = xyz_array@frac_coords_transf.T
 
         self.from_array(deformed_lattice@fractional_coords.T)
@@ -1353,7 +1353,7 @@ class Molecule (object):
         """Convert the cartesian coordinates of a |Molecule|, containing n atoms, into a (≤n)*3 numpy array.
 
         :param |Molecule| self: A |Molecule| with n atoms.
-        :param ''None'' or list atom_subset: An iterable (e.g. list, tuple or generator) consisting of ≤n atoms (|Atom|).
+        :param ''None'' or iterable atom_subset: An iterable (e.g. list, tuple or generator) consisting of ≤n atoms (|Atom|).
             Allows one to convert a subset of atoms within *self* into a numpy array.
         :return np.ndarray: A (≤n)*3 numpy array with the cartesian coordinates of *self*.
         """
@@ -1369,7 +1369,7 @@ class Molecule (object):
 
         :param |Molecule| self: A |Molecule| with n atoms.
         :param np.ndarray xyz_array: A (≤n)*3 numpy array with the cartesian coordinates of *self*.
-        :param ''None'' or list atom_subset: An iterable (e.g. list, tuple or generator) consisting of ≤n atoms (|Atom|).
+        :param ''None'' or iterable atom_subset: An iterable (e.g. list, tuple or generator) consisting of ≤n atoms (|Atom|).
             Allows one to update the cartesian coordinates of a subset of atoms wthin *self*.
         """
         ar = xyz_array.T

--- a/mol/molecule.py
+++ b/mol/molecule.py
@@ -695,7 +695,7 @@ class Molecule (object):
 
         *point* should be an iterable container of length 3 (for example: tuple, |Atom|, list, numpy array). *unit* describes unit of values stored in *point*. Returned value is expressed in *result_unit*.
         """
-        at = self.closest_atom_np(point, unit)
+        at = self.closest_atom(point, unit)
         return at.distance_to(point, unit, result_unit)
 
 
@@ -1353,7 +1353,7 @@ class Molecule (object):
         """Convert the cartesian coordinates of a |Molecule|, containing n atoms, into a (≤n)*3 numpy array.
 
         :param |Molecule| self: A |Molecule| with n atoms.
-        :param ''None'' or list atom_subset: An iterable container (e.g. list or tuple) consisting of ≤n atoms (|Atom|).
+        :param ''None'' or list atom_subset: An iterable (e.g. list, tuple or generator) consisting of ≤n atoms (|Atom|).
             Allows one to convert a subset of atoms within *self* into a numpy array.
         :return np.ndarray: A (≤n)*3 numpy array with the cartesian coordinates of *self*.
         """
@@ -1369,7 +1369,7 @@ class Molecule (object):
 
         :param |Molecule| self: A |Molecule| with n atoms.
         :param np.ndarray xyz_array: A (≤n)*3 numpy array with the cartesian coordinates of *self*.
-        :param ''None'' or list atom_subset: An iterable container (e.g. list or tuple) consisting of ≤n atoms (|Atom|).
+        :param ''None'' or list atom_subset: An iterable (e.g. list, tuple or generator) consisting of ≤n atoms (|Atom|).
             Allows one to update the cartesian coordinates of a subset of atoms wthin *self*.
         """
         ar = xyz_array.T

--- a/mol/molecule.py
+++ b/mol/molecule.py
@@ -6,7 +6,7 @@ import os
 
 try:
     from scipy.spatial.distance import cdist
-except ImportError:
+except ModuleNotFoundError:
     pass
 
 from .atom import Atom

--- a/mol/molecule.py
+++ b/mol/molecule.py
@@ -826,11 +826,10 @@ class Molecule (object):
         frac_coords_transf = np.linalg.inv(lattice_np.T)
         deformed_lattice = np.dot(lattice_np, np.eye(n) + np.array(strain))
 
-        for atom in self.atoms:
-            coord_np = np.array(atom.coords)
-            fractional_coords = np.matmul(frac_coords_transf, coord_np.T)
-            atom.coords = tuple(np.matmul(fractional_coords,deformed_lattice))
+        xyz_array = self.to_array()
+        fractional_coords = xyz_array@frac_coords_transf.T
 
+        self.from_array(deformed_lattice@fractional_coords.T)
         self.lattice = [tuple(vec) for vec in deformed_lattice.tolist()]
 
 

--- a/mol/molecule.py
+++ b/mol/molecule.py
@@ -713,7 +713,7 @@ class Molecule (object):
         try:
             dist_array = cdist(xyz_array1, xyz_array2)
         except NameError:
-            dist_array = np.array([np.linalg.norm((i - xyz_array2), axis=1) for i in xyz_array1])
+            dist_array = np.array([np.linalg.norm(i - xyz_array2, axis=1) for i in xyz_array1])
 
         res = Units.convert(dist_array.min(), 'angstrom', result_unit)
         if return_atoms:
@@ -824,7 +824,7 @@ class Molecule (object):
 
         lattice_np = np.array(self.lattice)
         frac_coords_transf = np.linalg.inv(lattice_np.T)
-        deformed_lattice = np.dot(lattice_np, np.eye(n) + strain)
+        deformed_lattice = lattice_np.dot(np.eye(n) + strain)
 
         xyz_array = self.as_array()
         fractional_coords = xyz_array@frac_coords_transf.T

--- a/mol/molecule.py
+++ b/mol/molecule.py
@@ -4,6 +4,11 @@ import math
 import numpy as np
 import os
 
+try:
+    from scipy.spatial.distance import cdist
+except ImportError:
+    pass
+
 from .atom import Atom
 from .bond import Bond
 from .pdbtools import PDBHandler, PDBRecord

--- a/mol/molecule.py
+++ b/mol/molecule.py
@@ -1373,7 +1373,7 @@ class Molecule (object):
             Allows one to update the cartesian coordinates of a subset of atoms wthin *self*.
         """
         ar = xyz_array.T
-        if atom_subset is not None:
+        if atom_subset is None:
             for at, x, y, z in zip(self.atoms, ar[0], ar[1], ar[2]):
                 at.coords = (x, y, z)
         else:


### PR DESCRIPTION
Certain functions (i.e. Geometry operations) have been rewritten using numpy's vectorized operations. Depending on the specific function, and size of the molecule, this can result in speed-ups of up to several orders of magnitude. The largest speedups are observed for functions with many mathematical operations (_e.g._ [distance_to_mol()](https://github.com/SCM-NV/PLAMS/blob/mol_numpy/mol/molecule.py#L702): calculate n*m Euclidean norms), the speedup furthermore being proportional to the number of atoms in a |Molecule|.
Note: The input and output of all altered functions remains unchanged, ensuring backwards compatibility.

Changed functions:
- [translate()](https://github.com/SCM-NV/PLAMS/blob/mol_numpy/mol/molecule.py#L542)
- [rotate()](https://github.com/SCM-NV/PLAMS/blob/mol_numpy/mol/molecule.py#L565)
- [rotate_bond()](https://github.com/SCM-NV/PLAMS/blob/mol_numpy/mol/molecule.py#L630)
- [closest_atom()](https://github.com/SCM-NV/PLAMS/blob/mol_numpy/mol/molecule.py#L677)
- [distance_to_point()](https://github.com/SCM-NV/PLAMS/blob/mol_numpy/mol/molecule.py#L693) (implicitly, see [closest_atom()](https://github.com/SCM-NV/PLAMS/blob/mol_numpy/mol/molecule.py#L677))
- [distance_to_mol()](https://github.com/SCM-NV/PLAMS/blob/mol_numpy/mol/molecule.py#L702)
- [wrap()](https://github.com/SCM-NV/PLAMS/blob/mol_numpy/mol/molecule.py#L727)
- [get_center_of_mass()](https://github.com/SCM-NV/PLAMS/blob/mol_numpy/mol/molecule.py#L769)
- [apply_strain()](https://github.com/SCM-NV/PLAMS/blob/mol_numpy/mol/molecule.py#L809)


In addition, two new functions have been added to the scm.plams.mol.molecule module, factilitating the interconversion between |Molecule| and np.ndarray: 
- [as_array()](https://github.com/SCM-NV/PLAMS/blob/mol_numpy/mol/molecule.py#L1352): Convert the cartesian coordinates of a |Molecule|, containing n atoms, into a (≤n)*3 numpy array.
- [from_array()](https://github.com/SCM-NV/PLAMS/blob/mol_numpy/mol/molecule.py#L1367): Update the cartesian coordinates of a |Molecule|, containing n atoms, with coordinates provided by a (≤n)*3 numpy array.