### PR TITLE
Speed up KFReader on larger files and fix Unicode support

### DIFF
--- a/tools/kftools.py
+++ b/tools/kftools.py
@@ -202,22 +202,28 @@ class KFReader:
                             self._sections[key][var] = (vtype, vlb, vstart, vused)
 
             for k,v in self._data.items():
-                self._data[k] = sorted(v)
+                lbs = []
+                pbs = []
+                for lb, first, last in sorted(v):
+                    lbs.append(lb)
+                    pbs.append((first, last))
+                self._data[k] = (lbs, pbs)
 
 
     @staticmethod
     def _datablocks(lst, n=1):
-        """Transform a list of tuples ``[(x1,a1,b1),(x2,a2,b2),...]`` into an iterator over ``range(a1,b1)+range(a2,b2)+...`` Iteration starts from nth element of this list."""
-        i = bisect(list(zip(*lst))[0], n) - 1
-        lb, first, last = lst[i]
+        """Transform a tuple of lists ``([x1,x2,...], [(a1,b1),(a2,b2),...])`` into an iterator over ``range(a1,b1)+range(a2,b2)+...`` Iteration starts from nth element of this list."""
+        i = bisect(lst[0], n) - 1
+        lb = lst[0][i]
+        first, last = lst[1][i]
         ret = first + n - lb
-        while i < len(lst):
+        while i < len(lst[1]):
             while ret < last:
                 yield ret
                 ret += 1
             i += 1
-            if i < len(lst):
-                _, ret, last = lst[i]
+            if i < len(lst[1]):
+                ret, last = lst[1][i]
 
 
 

--- a/tools/kftools.py
+++ b/tools/kftools.py
@@ -144,7 +144,8 @@ class KFReader:
             formatstring += str(a) + t
 
         if step > 0:
-            return [struct.unpack(str(formatstring), block[pos:pos+step]) for pos in range(0, len(block) - step + 1, step)]
+            end = (len(block) // step) * step
+            return list(struct.iter_unpack(formatstring, block[:end]))
         else:
             return []
 


### PR DESCRIPTION
These changes eliminate two main sources of unnecessary overhead in KFReader:
- `_parse` used to do an isinstance(bytes) check on every single value (which are mostly floats). It also expensively decoded all strings, no matter if the caller was interested in them or not. Apart from being super slow, this also broke completely when there were any multibyte characters in the KF file. KF variable lengths are stored in bytes, not characters, so the data extraction/cutting needs to be done before decoding.
- `_datablocks` used to waste time creating a list of all logical block indices every time it was called.

Together, these changes make KFReader about 10x faster when processing common MD trajectories.