### PR TITLE
Enhancement and new features for CP2K interface

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -283,6 +283,7 @@ rst_epilog = """
 
 .. |Cp2kJob| replace:: :class:`Cp2kJob<scm.plams.interfaces.thirdparty.cp2k.Cp2kJob>`
 .. |Cp2kResults| replace:: :class:`Cp2kJob<scm.plams.interfaces.thirdparty.cp2k.Cp2kResults>`
+.. |Cp2kSettings2Mol| replace:: :class:`Cp2kJob<scm.plams.interfaces.thirdparty.cp2k.Cp2kSettings2Mol>`
 
 .. |DFTBPlusJob| replace:: :class:`~scm.plams.interfaces.thirdparty.dftbplus.DFTBPlusJob`
 .. |DFTBPlusResults| replace:: :class:`~scm.plams.interfaces.thirdparty.dftbplus.DFTBPlusResults`

--- a/doc/source/interfaces/cp2k.rst
+++ b/doc/source/interfaces/cp2k.rst
@@ -133,6 +133,11 @@ Calculations done without PLAMS can be loaded using the |load_external| function
 
 Just do ``Cp2kJob.load_external(path)`` to get the settings from the file.
 
+Molecule loading
+~~~~~~~~~~~~~~~~~~~~
+
+A |Molecule| can be recreated from a |Settings| instance using the |Cp2kSettings2Mol| function.
+
 
 API
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -140,3 +145,5 @@ API
 .. autoclass:: Cp2kJob()
 
 .. autoclass:: Cp2kResults()
+
+.. autofunction:: Cp2kSettings2Mol()

--- a/interfaces/thirdparty/cp2k.py
+++ b/interfaces/thirdparty/cp2k.py
@@ -13,9 +13,21 @@ __all__ = ['Cp2kJob', 'Cp2kResults']
 class Cp2kResults(Results):
     """A class for CP2K results"""
     def recreate_settings(self):
-        """Recreate job for |load_external|."""
+        """Recreate job for |load_external|.
+
+        If a keyword and a section with the same name appear, only the keyword is used.
+        This happens e.g. when reading restart files where ``kind.symbol.potential`` is given
+        as *Potential ABCD* and *&POTENTIAL .... &END POTENTIAL*.
+
+        Limited support of sections that have different formatting like *KIND* and *COORD*.
+        Check the resulting |Settings| instance if the information you want is there.
+        Be careful with reading restart files, since they are automatically generated
+        and not every case is handled well here.
+        You should get all the information but not sure if I know about all special cases of input.
+        """
 
         _reserved_keywords = ["KIND", "@SET", "@INCLUDE", "@IF"]
+        _different_keywords = ["COORD", "VELOCITY", "MASS", "FORCE"] #blocks of information
 
         def input_generator(f):
             """yield lines from input"""
@@ -37,6 +49,9 @@ class Cp2kResults(Results):
             #empty line
             if not string:
                 return True
+            #comment line:
+            elif string.startswith('#'):
+                return True
             #end section
             elif string.startswith('&END'):
                 return False
@@ -53,9 +68,32 @@ class Cp2kResults(Results):
                     while r:
                         r = parse(input_iter, res_dic['kind'][l[1].lower()])
                 return True
+            elif any("&"+k == string for k in _different_keywords):
+                #save the entire block as one string until &END
+                l[0] = l[0].replace('&','')
+                res_dic[l[0].lower()] = {'_h': ""}
+                r = True
+                while r:
+                    r = next(input_iter).strip()
+                    if "&" in r:
+                        r = False
+                        break
+                    res_dic[l[0].lower()]['_h'] += "\n"
+                    res_dic[l[0].lower()]['_h'] += r
+                return True
             #section
             elif string.startswith('&'):
                 l[0] = l[0].replace('&','')
+                #if section already exists as a key, use the key
+                if l[0].lower() in res_dic:
+                    #fast forward to the next &END
+                    r = True
+                    while r:
+                        r = next(input_iter).strip()
+                        if r.startswith('&END'):
+                            r = False
+                            break
+                    return True
                 res_dic[l[0].lower()] = {}
                 #if section has a header value
                 if len(l) > 1:


### PR DESCRIPTION
Hey,

sorry for the MR-Spam. I remembered yesterday evening that some sections will make trouble loading. So this MR should allow loading of restart files printed by CP2K. Including sections like *VELOCITY*, *COORD* and *FORCE*.

Also one can now build a molecule from such loaded restart files using `Cp2kSettings2Mol`.

Cheers,
Patrick