### PR TITLE
Bug fix: get_frequencies() now correctly points to the 'Vibrations' section

### DIFF
--- a/interfaces/adfsuite/ams.py
+++ b/interfaces/adfsuite/ams.py
@@ -217,7 +217,7 @@ class AMSResults(Results):
 
         The *engine* argument should be the identifier of the file you wish to read. To access a file called ``something.rkf`` you need to call this function with ``engine='something'``. The *engine* argument can be omitted if there's only one engine results file in the job folder.
         """
-        freqs = np.array(self._process_engine_results(lambda x: x.read('AMSResults', 'Frequencies[cm-1]'), engine))
+        freqs = np.array(self._process_engine_results(lambda x: x.read('Vibrations', 'Frequencies[cm-1]'), engine))
         return freqs * Units.conversion_ratio('cm^-1', unit)
 
 


### PR DESCRIPTION
[get_frequencies](https://github.com/SCM-NV/PLAMS/blob/282776d40e0f23b0e6b1758ef7feeeae6c60284e/interfaces/adfsuite/ams.py#L215) was mistakenly trying to pull vibrational frequencies from the AMSResults section instead of the Vibrations section. This has now been fixed.