### PR TITLE
Cp2kJob bug fix: Try to run CP2K with 'mpirun' before attempting 'srun'

### DIFF
--- a/interfaces/thirdparty/cp2k.py
+++ b/interfaces/thirdparty/cp2k.py
@@ -358,8 +358,6 @@ class Cp2kJob(SingleJob):
             coord_sec += (" {:}"*4).format(atom.symbol, *atom.coords)
         inp.coord._h = coord_sec
 
-
-
     def get_runscript(self):
         """
         Run parallel version of Cp2k using srun.

--- a/interfaces/thirdparty/cp2k.py
+++ b/interfaces/thirdparty/cp2k.py
@@ -364,15 +364,17 @@ class Cp2kJob(SingleJob):
         """
         Run parallel version of Cp2k using srun.
         """
-        # try to cp2k using srun
-        try:
-            subprocess.run(["srun", "--help"], stdout=subprocess.DEVNULL)
-            ret = 'srun cp2k.popt'
-        except OSError:
-            ret = 'cp2k.popt'
+        # Try to run cp2k using mpirun and otherwise srun (if available)
+        command_tuple = ('mpirun', 'srun')
+        ret = 'cp2k.popt'
+        for command in command_tuple:
+            try:
+                subprocess.run([command, "--help"], stdout=subprocess.DEVNULL)
+                ret = command + 'cp2k.popt'
+            except OSError:
+                pass
 
         ret += ' -i {} -o {}'.format(self._filename('inp'), self._filename('out'))
-
         return ret
 
     def check(self):


### PR DESCRIPTION
Earlier today i encountered an issue when running MD simulation with PLAMS+CP2K, more specifically with the generated .xyz file. The observed issues were:

- Non-latin characters
- Duplicate frames
- Headers in the middle of a Cartesian coordinate block


After some digging the problem was traced back [Cpk2Job.get_runscript()](https://github.com/SCM-NV/PLAMS/blob/master/interfaces/thirdparty/cp2k.py#L363) method, which by default creates a .run file using with the `srun cp2k.popt ...` syntax, slurm being the true culprit. Swapping slurm for openmpi (`mpirun cp2k.popt ...`) immediately fixed the issue.

With the changes proposed below [Cpk2Job.get_runscript()](https://github.com/SCM-NV/PLAMS/blob/master/interfaces/thirdparty/cp2k.py#L363) will now first try to run CP2K with mpirun, then with srun and if all else fails resort to running CP2K in a non-parallel fashion (just as was implemented before).

@felipeZ As you're quite a bit more familiar with CP2K, do you have any comments on the proposed change?