### PR TITLE
Bug fix: name 'bond' is not defined

### DIFF
--- a/mol/bond.py
+++ b/mol/bond.py
@@ -91,7 +91,7 @@ class Bond:
             self.mol.resize_bond(self, moving_atom, length, unit)
         else:
             bond_v = np.array(self.as_vector(start=moving_atom))
-            trans_v = (1 - length/bond.length(unit)) * bond_v
+            trans_v = (1 - length/self.length(unit)) * bond_v
             moving_atom.translate(trans_v)
 
 


### PR DESCRIPTION
The [`Bond.resize()`](https://github.com/SCM-NV/PLAMS/blob/098bd207ad5d9a68bb97fa0a3266f1586900961a/mol/bond.py#L94) method was referring to an undefined variable by the name of `bond` (which should've been `self`).
