### PR TITLE
Molecule() update

### DIFF
--- a/mol/molecule.py
+++ b/mol/molecule.py
@@ -1241,7 +1241,8 @@ class Molecule:
             count = at_len * 3
             shape = at_len, 3
         
-        xyz_array = np.fromiter(atom_subset, count=count, dtype=float)
+        atom_iterator = itertools.chain.from_iterable(at.coords for at in atom_subset)
+        xyz_array = np.fromiter(atom_iterator, count=count, dtype=float)
         xyz_array.shape = shape
         return xyz_array
 

--- a/mol/molecule.py
+++ b/mol/molecule.py
@@ -189,7 +189,7 @@ class Molecule:
                 if isinstance(adj, Atom):
                     self.add_bond(atom, adj)
                 else:
-                    self.add_bond(atom, adj[0], adj[1])
+                    self.add_bond(atom, *adj)
 
 
     def delete_atom(self, atom):
@@ -321,7 +321,7 @@ class Molecule:
         self.set_atoms_id(start=0)
         for b in self.bonds:
             i,j = b.atom1.id, b.atom2.id
-            ret[i][j] = ret[j][i] = b.order
+            ret[i, j] = ret[j, i] = b.order
         self.unset_atoms_id()
         return ret
 


### PR DESCRIPTION
* [`Molecule.as_array()`](https://github.com/SCM-NV/PLAMS/blob/75127bb74af4a3365f884fcdb54931ac21138933/mol/molecule.py#L1231) has been made 10-20% faster. No caveats here, it's now just plain faster.
* [`Molecule.__getitem__()`](https://github.com/SCM-NV/PLAMS/blob/75127bb74af4a3365f884fcdb54931ac21138933/mol/molecule.py#L1125) now checks for the `__index__()` method rather than [`int`](https://docs.python.org/3/library/functions.html#int) instances; see [PEP 357](https://www.python.org/dev/peps/pep-0357/). 
Most importantly, this allows one to use instances of `np.integer` for slicing without having to convert it into a (builtin) integer every single time.
* Exchanged a number of explicit instance checks with duck typing-based approaches. For example: checking for an iterable of length _n_ rather than, specifically, a [`tuple`](https://docs.python.org/3/library/stdtypes.html#tuple) of length _n_.