### PR TITLE
Ensure that Molecule.read() and Molecule.write() can handle PathLike objects

### DIFF
--- a/mol/molecule.py
+++ b/mol/molecule.py
@@ -1597,17 +1597,14 @@ class Molecule:
         """
 
         if inputformat is None:
-            fsplit = filename.rsplit('.',1)
-            if len(fsplit) == 2:
-                inputformat = fsplit[1]
-            else:
-                inputformat = 'xyz'
+            _, extension = os.path.splitext(filename)
+            inputformat = extension.strip('.') if extension else 'xyz'
         if inputformat in self.__class__._readformat:
             with open(filename, 'r') as f:
                 ret = self._readformat[inputformat](self, f, **other)
             return ret
         else:
-            raise MoleculeError('read: Unsupported file format')
+            raise MoleculeError(f"read: Unsupported file format '{inputformat}'")
 
 
     def write(self, filename, outputformat=None, **other):
@@ -1619,16 +1616,13 @@ class Molecule:
         """
 
         if outputformat is None:
-            fsplit = filename.rsplit('.',1)
-            if len(fsplit) == 2:
-                outputformat = fsplit[1]
-            else:
-                outputformat = 'xyz'
+            _, extension = os.path.splitext(filename)
+            outputformat = extension.strip('.') if extension else 'xyz'
         if outputformat in self.__class__._writeformat:
             with open(filename, 'w') as f:
                 self._writeformat[outputformat](self, f, **other)
         else:
-            raise MoleculeError('write: Unsupported file format')
+            raise MoleculeError(f"write: Unsupported file format '{outputformat}'")
 
     #Support for the ASE engine is added if available by interfaces.molecules.ase
     _readformat = {'xyz':readxyz, 'mol':readmol, 'mol2':readmol2, 'pdb':readpdb}


### PR DESCRIPTION
[``Molecule.read()``](https://www.scm.com/doc/plams/components/mol_api.html#scm.plams.mol.molecule.Molecule.read) and [``Molecule.write()``](https://www.scm.com/doc/plams/components/mol_api.html#scm.plams.mol.molecule.Molecule.write) can now accept any [path-like object](https://docs.python.org/3.8/glossary.html#term-path-like-object) and not just strings. Compatibility with the builtin [pathlib](https://docs.python.org/3/library/pathlib.html#module-pathlib) module would be the main advantage of the proposed changes.