### PR TITLE
Settings update

### DIFF
--- a/core/context.py
+++ b/core/context.py
@@ -7,7 +7,7 @@ from typing import Any, ContextManager, Collection, Callable, Dict
 
 from .errors import ReentranceError
 
-__all__ = ['SupressMissing', 'Lower', 'Upper']
+__all__ = []
 
 
 class FuncReplacerABC(ContextManager[None], ABC):

--- a/core/context.py
+++ b/core/context.py
@@ -48,15 +48,12 @@ class FuncReplacerABC(ContextManager[None], metaclass=_FuncReplacerMeta):
 
     .. code:: python
 
-        # Define a subclass
+        # Define and instantiate a subclass
         >>> class Context(FuncReplacerABC):
         ...     replace_func = ('__int__', ...)
         ...
         ...     @staticmethod
         ...     def decorate(func): return ...
-
-        # Instantiate the new subclass
-        >>> manager = Context(...)
 
         # Opening the context manager multiple times is completely fine
         >>> with manager:

--- a/core/context.py
+++ b/core/context.py
@@ -247,7 +247,10 @@ class SupressMissing(FuncReplacerABC):
         return wrapper
 
 
-class Lower(FuncReplacerABC):
+# Work in progress context managers
+
+
+class _Lower(FuncReplacerABC):
     """A reusable, but non-reentrant, context manager for temporary converting all keys to lower case."""  # noqa: E501
 
     replace_func = ('__delitem__', '__setitem__', '__getitem__', '__contains__',
@@ -266,7 +269,7 @@ class Lower(FuncReplacerABC):
         return wrapper
 
 
-class Upper(FuncReplacerABC):
+class _Upper(FuncReplacerABC):
     """A reusable, but non-reentrant, context manager for temporary converting all keys to upper case."""  # noqa: E501
 
     replace_func = ('__delitem__', '__setitem__', '__getitem__', '__contains__',

--- a/core/context.py
+++ b/core/context.py
@@ -3,7 +3,7 @@
 import threading
 from abc import abstractmethod, ABCMeta
 from types import MappingProxyType
-from weakref import WeakKeyDictionary
+from weakref import WeakValueDictionary
 from functools import wraps
 from typing import (Any, Collection, Callable, Dict, Tuple, NoReturn, ContextManager,
                     Type, Optional, ClassVar, MutableMapping, Mapping)
@@ -17,13 +17,13 @@ class _FuncReplacerMeta(ABCMeta):
     """The metaclass of :class:`FuncReplacerABC`.
 
     Used for setting the :attr:`FuncReplacerABC._type_cache` class variable,
-    a :class:`~weakref.WeakKeyDictionary` for keeping track of all class instance singletons.
+    a :class:`~weakref.WeakValueDictionary` for keeping track of all class instance singletons.
 
     """
 
     def __new__(mcls, name, bases, namespace, **kwargs):
         cls = super().__new__(mcls, name, bases, namespace, **kwargs)
-        cls._type_cache = WeakKeyDictionary()
+        cls._type_cache = WeakValueDictionary()
         return cls
 
 

--- a/core/context.py
+++ b/core/context.py
@@ -85,8 +85,6 @@ class FuncReplacerABC(ContextManager[None], metaclass=_FuncReplacerMeta):
 
     """
 
-    __slots__ = ('_lock', '_open', 'obj', 'func_old', 'func_new')
-
     #: A class variable for keeping track of all :class:`FuncReplacerABC` instances.
     #: Used for ensuring all instances are singletons with respect to the passed object type.
     _type_cache: ClassVar[MutableMapping[type, 'FuncReplacerABC']]
@@ -250,9 +248,10 @@ class SupressMissing(FuncReplacerABC):
 
 
 class Lower(FuncReplacerABC):
-    """A reusable, but non-reentrant, context manager for temporary converting all keys passed to :meth:`__delitem__`, :meth:`__setitem__` and :meth:`__getitem__` to lower case."""  # noqa: E501
+    """A reusable, but non-reentrant, context manager for temporary converting all keys to lower case."""  # noqa: E501
 
-    replace_func = ('__delitem__', '__setitem__', '__getitem__')
+    replace_func = ('__delitem__', '__setitem__', '__getitem__', '__contains__',
+                    'get', 'pop', 'popitem', 'setdefault')
 
     @staticmethod
     def decorate(func):
@@ -268,9 +267,10 @@ class Lower(FuncReplacerABC):
 
 
 class Upper(FuncReplacerABC):
-    """A reusable, but non-reentrant, context manager for temporary converting all keys passed to :meth:`__delitem__`, :meth:`__setitem__` and :meth:`__getitem__` to upper case."""  # noqa: E501
+    """A reusable, but non-reentrant, context manager for temporary converting all keys to upper case."""  # noqa: E501
 
-    replace_func = ('__delitem__', '__setitem__', '__getitem__')
+    replace_func = ('__delitem__', '__setitem__', '__getitem__', '__contains__',
+                    'get', 'pop', 'popitem', 'setdefault')
 
     @staticmethod
     def decorate(func):

--- a/core/context.py
+++ b/core/context.py
@@ -1,0 +1,191 @@
+"""A module with various context managers."""
+
+import threading
+from abc import ABC, abstractmethod
+from functools import wraps
+from typing import Any, ContextManager, Collection, Callable, Dict
+
+from .errors import ReentranceError
+
+__all__ = ['SupressMissing', 'Lower', 'Upper']
+
+
+class FuncReplacerABC(ContextManager[None], ABC):
+    """An abstract context manager for temporary replacing one or more methods of a class.
+
+    Subclasses will have to defined two attributes:
+
+    * :attr:`FuncReplacerABC.replace_func`: A :class:`~collections.abc.Collection` with the
+      names of all to-be replaced methods.
+    * :meth:`FuncReplacerABC.decorate`: A static method for altering/replacing the methods.
+
+    Instances of this class are thread-safe (note that this does *not* include
+    :meth:`FuncReplacerABC.__init__` itself), resuable, but non-reentrant:
+
+    .. code:: python
+
+        >>> class Context(FuncReplacerABC):
+        ...     ...
+
+        >>> manager = Context()
+
+        # Opening the context manager multiple times is completelly fine
+        >>> with manager:
+        ...     ...
+        >>> with manager:
+        ...     ...
+        >>> with manager:
+        ...     ...
+
+        # This is not fine
+        >>> with manager:
+            >>> with manager:
+            ...     ...
+        ReentranceError("'Context' instances cannot not be entered in a reentrant manner")
+
+    """
+
+    #: A private instance variable for ensuring the thread safety of
+    #: :meth:`__enter__` and :meth:`__exit__` calls.
+    _lock: threading.Lock
+
+    #: A private instance variable for keeping track of (potentially reentrant)
+    #: :meth:`__enter__` calls.
+    _open: bool
+
+    #: An instance variable containing object whose methods are to-be replaced upon
+    #: calling :meth:`__enter__`.
+    obj: type
+
+    #: An instance variable containing a dictionary mapping the names of the to-be replaced
+    #: functions to the old functions.
+    func_old: Dict[str, Callable]
+
+    #: An instance variable containing a dictionary mapping the names of the to-be replaced
+    #: functions to the new functions.
+    func_new: Dict[str, Callable]
+
+    @property
+    @abstractmethod
+    def replace_func(self) -> Collection[str]:
+        """A class variable defining all to-be replaced attributes for when the context manager has been entered.
+
+        This attribute should be defined in a subclass as following:
+
+        .. code:: python
+
+            >>> class SubClass(FuncReplacerABC):
+            ...     replace_func = ('name1', 'name2', 'name3', ...)  # Any Collection is fine
+
+        """
+        raise NotImplementedError('Trying to get an abstract attribute')
+
+    @staticmethod
+    @abstractmethod
+    def decorate(func: Callable) -> Callable:
+        """Decorate all functions defined in :attr:`replace_func`."""
+        raise NotImplementedError('Trying to call an abstract attribute')
+
+    def __init__(self, obj: type) -> None:
+        """Initialize the context manager.
+
+        Note that, contrary to :meth:`__enter__` and :meth:`__exit__`,
+        this method is *not* thread-safe.
+
+        """
+        self._lock = threading.Lock()
+        self._open = False
+
+        # Ensure that obj is a class, not a class instance
+        type_obj = obj if isinstance(obj, type) else type(obj)
+        self.obj = type_obj
+
+        # Define the old and new method
+        self.func_old = {name: getattr(type_obj, name) for name in self.replace_func}
+        self.func_new = {name: self.decorate(func) for name, func in self.func_old.items()}
+
+    def __eq__(self, obj: Any) -> bool:
+        """Implement :code:`self == obj`."""
+        if type(self) is not type(obj):
+            return False
+        return self.obj is getattr(obj, 'obj', None)
+
+    def __repr__(self) -> str:
+        """Implement :code:`repr(self)` and :code:`str(self)`."""
+        return f'{self.__class__.__name__}(obj={self.obj!r})'
+
+    def __enter__(self) -> None:
+        """Enter the context manager: modify all methods in :attr:`func_new` at the class level."""
+        # Precaution against calling __enter__() in a recursive manner
+        with self._lock:
+            if self._open:
+                raise ReentranceError(f"{self.__class__.__name__!r} instances cannot "
+                                      "not be entered in a reentrant manner")
+
+            for name, func in self.func_new.items():
+                setattr(self.obj, name, func)
+            self._open = False
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        """Exit the context manager: restore all methods in :attr:`func_old` at the class level."""
+        if exc_type is ReentranceError:
+            return
+
+        with self._lock:
+            for name, func in self.func_old.items():
+                setattr(self.obj, name, func)
+            self._open = False
+
+
+class SupressMissing(FuncReplacerABC):
+    """A reusable, but non-reentrant, context manager for temporary disabling the :meth:`__missing__` magic method.
+
+    See :meth:`Settings.supress_missing` for more details.
+
+    """  # noqa
+
+    replace_func = ('__missing__',)
+
+    @staticmethod
+    def decorate(func):
+        """Decorate *func* such that calling it raises a :exc:`KeyError`."""
+        @wraps(func)
+        def wrapper(self, name):
+            raise KeyError(name)
+        return wrapper
+
+
+class Lower(FuncReplacerABC):
+    """A reusable, but non-reentrant, context manager for temporary converting all keys passed to :meth:`__delitem__`, :meth:`__setitem__` and :meth:`__getitem__` to lower case."""
+
+    replace_func = ('__delitem__', '__setitem__', '__getitem__')
+
+    @staticmethod
+    def decorate(func):
+        """Decorate *func* such that the passed key is converted to lower case before being called."""
+        @wraps(func)
+        def wrapper(self, key, *args, **kwargs):
+            try:
+                key_low = key.lower()
+            except (AttributeError, TypeError):
+                key_low = key
+            return func(self, key_low, *args, **kwargs)
+        return wrapper
+
+
+class Upper(FuncReplacerABC):
+    """A reusable, but non-reentrant, context manager for temporary converting all keys passed to :meth:`__delitem__`, :meth:`__setitem__` and :meth:`__getitem__` to upper case."""
+
+    replace_func = ('__delitem__', '__setitem__', '__getitem__')
+
+    @staticmethod
+    def decorate(func):
+        """Decorate *func* such that the passed key is converted to upper case before being called."""
+        @wraps(func)
+        def wrapper(self, key, *args, **kwargs):
+            try:
+                key_upper = key.upper()
+            except (AttributeError, TypeError):
+                key_upper = key
+            return func(self, key_upper, *args, **kwargs)
+        return wrapper

--- a/core/context.py
+++ b/core/context.py
@@ -5,7 +5,7 @@ from abc import abstractmethod, ABCMeta
 from types import MappingProxyType
 from weakref import WeakKeyDictionary
 from functools import wraps
-from typing import (Any, Collection, Callable, Dict, Tuple, NoReturn,
+from typing import (Any, Collection, Callable, Dict, Tuple, NoReturn, ContextManager,
                     Type, Optional, ClassVar, MutableMapping, Mapping)
 
 from .errors import ReentranceError
@@ -27,7 +27,7 @@ class _FuncReplacerMeta(ABCMeta):
         return cls
 
 
-class FuncReplacerABC(metaclass=_FuncReplacerMeta):
+class FuncReplacerABC(ContextManager[None], metaclass=_FuncReplacerMeta):
     """An abstract context manager for temporary replacing one or more methods of a class.
 
     Subclasses will have to defined two attributes:

--- a/core/context.py
+++ b/core/context.py
@@ -124,7 +124,7 @@ class FuncReplacerABC(ContextManager[None], ABC):
 
             for name, func in self.func_new.items():
                 setattr(self.obj, name, func)
-            self._open = False
+            self._open = True
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:
         """Exit the context manager: restore all methods in :attr:`func_old` at the class level."""

--- a/core/context.py
+++ b/core/context.py
@@ -71,6 +71,8 @@ class FuncReplacerABC(ContextManager[None], metaclass=_FuncReplacerMeta):
         >>> with manager:
         ...     with manager:
         ...         ...
+        Traceback (most recent call last):
+          ...
         ReentranceError: "'Context' instances cannot not be entered in a reentrant manner"
 
         # Class instances are singletons with respect to the passed object type
@@ -82,9 +84,12 @@ class FuncReplacerABC(ContextManager[None], metaclass=_FuncReplacerMeta):
 
         # Fiddling with attributes is not fine
         >>> del manager.obj
+        Traceback (most recent call last):
+          ...
         AttributeError: attribute 'obj' of 'Context' objects is not writable
 
     """
+
     #: A class variable for keeping track of all :class:`FuncReplacerABC` instances.
     #: Used for ensuring all instances are singletons with respect to the passed object type.
     _type_cache: ClassVar[MutableMapping[type, 'FuncReplacerABC']]
@@ -102,11 +107,11 @@ class FuncReplacerABC(ContextManager[None], metaclass=_FuncReplacerMeta):
     obj: type
 
     #: An instance variable containing a read-only :class:`~collections.abc.Mapping` whichs
-    #: maps the names of the to-be replaced functions to the old functions.
+    #: maps the names of the to-be replaced methods to the original methods.
     func_old: Mapping[str, Callable]
 
     #: An instance variable containing a read-only :class:`~collections.abc.Mapping` whichs
-    #: maps the names of the to-be replaced functions to the new functions.
+    #: maps the names of the to-be replaced methods to the new methods.
     func_new: Mapping[str, Callable]
 
     # Abstract methods and attributes
@@ -177,23 +182,23 @@ class FuncReplacerABC(ContextManager[None], metaclass=_FuncReplacerMeta):
         return (type(self), (self.obj,))
 
     def __copy__(self: FT) -> FT:
-        """Implement :code:`copy.copy`."""
+        """Implement :func:`copy.copy(self)<copy.copy>`."""
         return self
 
     def __deepcopy__(self: FT, memo: Optional[Dict[int, Any]] = None) -> FT:
-        """Implement :code:`copy.deepcopy`."""
+        """Implement :func:`copy.deepcopy(self, memo=memo)<copy.deepcopy>`."""
         return self
 
     def __repr__(self) -> str:
-        """Implement :code:`repr(self)` and :code:`str(self)`."""
+        """Implement :func:`repr(self)<repr>` and :func:`str(self)<str>`."""
         return f'{self.__class__.__name__}(obj={self.obj!r})'
 
     def __setattr__(self, name: str, value: Any) -> NoReturn:
-        """Implement :code:`setattr(self, name, value)`."""
+        """Implement :func:`setattr(self, name, value)<setattr>`."""
         raise self._attributeError(name)  # Attributes are read-only
 
     def __delattr__(self, name: str) -> NoReturn:
-        """Implement :code:`delattr(self, name)`."""
+        """Implement :func:`delattr(self, name)<delattr>`."""
         raise self._attributeError(name)  # Attributes are read-only
 
     def _attributeError(self, name: str) -> AttributeError:

--- a/core/errors.py
+++ b/core/errors.py
@@ -1,4 +1,4 @@
-__all__ = ['PlamsError', 'FileError', 'ResultsError', 'JobError', 'PTError', 'UnitsError', 'MoleculeError']
+__all__ = ['PlamsError', 'FileError', 'ResultsError', 'JobError', 'PTError', 'UnitsError', 'MoleculeError', 'ReentranceError']
 
 class PlamsError(Exception):
     """General PLAMS error."""
@@ -26,4 +26,8 @@ class UnitsError(PlamsError):
 
 class MoleculeError(PlamsError):
     """|Molecule| related error."""
+    pass
+
+class ReentranceError(PlamsError):
+    """An exception to-be raised when accesing a non-reentrant context manager in a reentrant manner."""
     pass

--- a/core/settings.py
+++ b/core/settings.py
@@ -283,7 +283,7 @@ class Settings(dict, metaclass=_SettingsMeta):
 
     @classmethod
     def upper(cls):
-        """A reusable, but non-reentrant, context manager for temporary converting all keys passed to :meth:`__delitem__`, :meth:`__setitem__` and :meth:`__getitem__` to upper case.
+        """A reusable, but non-reentrant, context manager for temporary converting all keys passed to :meth:`__delitem__`, :meth:`__setitem__` and :meth:`__getitem__` (among others) to upper case.
 
         Example:
 
@@ -308,7 +308,7 @@ class Settings(dict, metaclass=_SettingsMeta):
 
     @classmethod
     def lower(cls):
-        """A reusable, but non-reentrant, context manager for temporary converting all keys passed to :meth:`__delitem__`, :meth:`__setitem__` and :meth:`__getitem__` to lower case.
+        """A reusable, but non-reentrant, context manager for temporary converting all keys passed to :meth:`__delitem__`, :meth:`__setitem__` and :meth:`__getitem__` (among others) to lower case.
 
         Example:
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -1,7 +1,7 @@
 import textwrap
 import contextlib
 
-from .context import SupressMissing, Lower, Upper
+from .context import SupressMissing
 
 __all__ = ['Settings', 'ig']
 
@@ -10,8 +10,6 @@ class _SettingsMeta(type):
     def __new__(mcls, name, bases, namespace, **kwargs):
         cls = super().__new__(mcls, name, bases, namespace, **kwargs)
         cls._supress_missing = SupressMissing(cls)
-        cls._lower = Lower(cls)
-        cls._upper = Upper(cls)
         return cls
 
 
@@ -50,8 +48,6 @@ class Settings(dict, metaclass=_SettingsMeta):
 
     # To-be replaced with SupressMissing, Lower and Upper instances by the metaclass
     _supress_missing: SupressMissing
-    _lower: Lower
-    _upper: Upper
 
     def __init__(self, *args, **kwargs):
         cls = type(self)
@@ -280,55 +276,6 @@ class Settings(dict, metaclass=_SettingsMeta):
         """
         return cls._supress_missing
 
-
-    @classmethod
-    def upper(cls):
-        """A reusable, but non-reentrant, context manager for temporary converting all keys passed to :meth:`__delitem__`, :meth:`__setitem__` and :meth:`__getitem__` (among others) to upper case.
-
-        Example:
-
-        .. code:: python
-
-            >>> s = Settings()
-
-            >>> s.FOO = 'bar'  # __setitem__
-            >>> print(s.foo)
-            foo:    bar
-
-            >>> print(s.fOO)  # __getitem__
-            bar
-
-            >>> del s.FOO
-            >>> print('FOO' in s)  # __delitem__
-            False
-
-        """
-        return cls._upper
-
-
-    @classmethod
-    def lower(cls):
-        """A reusable, but non-reentrant, context manager for temporary converting all keys passed to :meth:`__delitem__`, :meth:`__setitem__` and :meth:`__getitem__` (among others) to lower case.
-
-        Example:
-
-        .. code:: python
-
-            >>> s = Settings()
-
-            >>> s.foo = 'bar'  # __setitem__
-            >>> print(s)
-            FOO:    bar
-
-            >>> print(s.FoO)  # __getitem__
-            bar
-
-            >>> del s.foo  # __delitem__
-            >>> print('foo' in s)
-            False
-
-        """
-        return cls._lower
 
     def get_nested(self, key_tuple, supress_missing=False):
         """Retrieve a nested value by, recursively, iterating through this instance using the keys in *key_tuple*.

--- a/unit_tests/test_ignore_missing.py
+++ b/unit_tests/test_ignore_missing.py
@@ -1,6 +1,6 @@
 from threading import Thread
 
-from scm.plams import Settings
+from scm.plams import Settings, ReentranceError
 from scm.plams.core.settings import SupressMissing
 
 glob_var = {
@@ -76,3 +76,17 @@ def test_supress_missing():
     finally:
         for i in range(1, 5):
             glob_var[i] = set()
+
+
+def test_reentrance():
+    """Test that :meth:`Settings.supress_missing` cannot be entered in a reentrant manner."""
+    s = Settings()
+
+    try:
+        with s.supress_missing():
+            with s.supress_missing():
+                pass
+    except ReentranceError:
+        pass
+    else:
+        raise AssertionError("Failed to raise a 'ReentranceError'")

--- a/unit_tests/test_ignore_missing.py
+++ b/unit_tests/test_ignore_missing.py
@@ -1,7 +1,7 @@
 from threading import Thread
 
 from scm.plams import Settings, ReentranceError
-from scm.plams.core.settings import SupressMissing
+from scm.plams.core.context import SupressMissing
 
 glob_var = {
     0: tuple(),

--- a/unit_tests/test_ignore_missing.py
+++ b/unit_tests/test_ignore_missing.py
@@ -1,0 +1,78 @@
+from threading import Thread
+
+from scm.plams import Settings
+from scm.plams.core.settings import SupressMissing
+
+glob_var = {
+    0: tuple(),
+    1: set(),
+    2: set(),
+    3: set(),
+    4: set()
+}
+
+
+class _SupressMissing(SupressMissing):
+    @property
+    def id(self):
+        return id(self.obj.__missing__)
+
+    def __enter__(self):
+        """Enter the context manager: modify :meth:`.Settings.__missing__` at the class level."""
+        global glob_var
+        with self.lock:
+            glob_var[1].add(self.id)
+            setattr(self.obj, '__missing__', self.missing_new)
+            glob_var[2].add(self.id)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Exit the context manager: restore :meth:`.Settings.__missing__` at the class level."""
+        global glob_var
+        with self.lock:
+            glob_var[3].add(self.id)
+            setattr(self.obj, '__missing__', self.missing)
+            glob_var[4].add(self.id)
+
+
+class _Settings(Settings):
+    ...
+
+
+_Settings._supress_missing = _SupressMissing(_Settings)
+glob_var[0] = (id(_Settings.__missing__),)
+
+
+def _supress_missing():
+    s = _Settings()
+    with s.supress_missing():
+        pass
+    with s.supress_missing():
+        pass
+    with s.supress_missing():
+        pass
+    with s.supress_missing():
+        pass
+
+
+def test_supress_missing():
+    """Tests for :meth:`Settings.supress_missing`."""
+    try:
+        thread_list = [Thread(target=_supress_missing) for _ in range(100)]
+        for t in thread_list:
+            t.start()
+        for t in thread_list:
+            t.join()
+
+        global glob_var
+        for v in glob_var.values():
+            assert len(v) == 1
+
+        ref_id = glob_var[0][0]
+        assert ref_id in glob_var[1]  # The ID of the unaltered __missing__ method
+        assert ref_id not in glob_var[2]  # The ID of the altered __missing__ method
+        assert ref_id not in glob_var[3]  # The ID of the altered __missing__ method
+        assert ref_id in glob_var[4]  # The ID of the unaltered __missing__ method
+
+    finally:
+        for i in range(1, 5):
+            glob_var[i] = set()


### PR DESCRIPTION
See https://github.com/SCM-NV/PLAMS/issues/80.

Changes
---------
* Added a threading safeguard to the ``SupressMissing`` context manager using [``threading.Lock``](https://docs.python.org/3/library/threading.html#threading.Lock).
* Added a single ``SupressMissing`` instance to ``Settings`` as a class variable. ``Settings.supress_missing()`` wil therefore now always return a singleton.
* Replaced all explicit references to ``Settings`` with ``cls = type(self)``. 
This should make subclassing much easier by treating the class type as a variable.
* Replaced ``dict.func_name`` with ``super().func_name``.
* Added tests for the thread-safeguard functionality.
* Raise a ``ReentranceError`` when calling ``SupressMissing.__enter__()`` in a [reentrant](https://docs.python.org/3/library/contextlib.html#reentrant-context-managers) manner.
* Created a separate module for context managers (``scm.plams.core.context``).