### PR TITLE
Fixed an issue where Settings.find_case() could raise an AttributeError or TypeError

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -191,8 +191,11 @@ class Settings(dict):
             return key
         lowkey = key.lower()
         for k in self:
-            if k.lower() == lowkey:
-                return k
+            try:
+                if k.lower() == lowkey:
+                    return k
+            except (AttributeError, TypeError):
+                pass
         return key
 
 


### PR DESCRIPTION
So yeah, ``Settings.find_case()`` is still broken.

``Settings.find_case()`` currently assumes that ALL keys in ``self`` are strings in the following part of the code.
``` python
for k in self:
    if k.lower() == lowkey:  # will crash if *k* is not a string
        return k
```

Added a ``try`` / ``except`` clause for to prevent exceptions in the following two cases:
* A key does not have the ``.lower`` attribute (_e.g._ ``k`` is not a string; raises a ``AttributeError``).
* The ``k.lower`` attribute is not callable (raises a ``TypeError``).