### PR TITLE
Fixed an issue where Settings subclasses could not be converted into Settings and vice versa

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -43,9 +43,9 @@ class Settings(dict):
 
         for k, v in self.items():
             if isinstance(v, dict) and type(v) is not cls:
-                self[k] = Settings(v)
+                self[k] = cls(v)
             if isinstance(v, list):
-                self[k] = [Settings(i) if (isinstance(i, dict) and type(i) is not cls) else i for i in v]
+                self[k] = [cls(i) if (isinstance(i, dict) and type(i) is not cls) else i for i in v]
 
 
     def copy(self):

--- a/core/settings.py
+++ b/core/settings.py
@@ -39,11 +39,13 @@ class Settings(dict):
     """
     def __init__(self, *args, **kwargs):
         dict.__init__(self, *args, **kwargs)
-        for k,v in self.items():
-            if isinstance(v, dict) and not isinstance(v, Settings):
+        cls = type(self)
+
+        for k, v in self.items():
+            if isinstance(v, dict) and type(v) is not cls:
                 self[k] = Settings(v)
             if isinstance(v, list):
-                self[k] = [Settings(i) if (isinstance(i, dict) and not isinstance(i, Settings)) else i for i in v]
+                self[k] = [Settings(i) if (isinstance(i, dict) and type(i) is not cls) else i for i in v]
 
 
     def copy(self):


### PR DESCRIPTION
Quite recently the ``Settings.__init__()`` method was updated to check for the presence of (nested) ``Settings`` instances before calling the (recursive) constructor.

```python
def __init__(self, *args, **kwargs):
    ...
    for k,v in self.items():
        if isinstance(v, dict) and not isinstance(v, Settings):  # This line
    ...
```

However, the current implementation has the unintended side-effect that ``Settings`` subclass can no longer be properly converted into ``Settings`` and _vice versa_, as all subclass instances are also instances ``Settings``. 
Note that this issue only applies to nested settings (which, let's be honest, includes most instances).

```python
from scm.plams import Settings

# A Settings subclass
class SubClass(Settings): ...

# Crate a SubClass instance and convert it into Settings
s_sub = SubClass()
s_sub.a.b.c.d = True
s = Settings(s_sub)

# The good
type(s)
<class 'scm.plams.core.settings.Settings'>

# The bad
type(s.a)
<class '__main__.SubClass'>
```

So, does this pull request address the issue described above? 
Well, by directly evaluating the passed object's class (``type(obj) is type(self)``) rather than instance checking (``isinstance(obj, Settings)``). 
This works both for any subclasses and existing ``Settings`` instances still won't be haphazardly passed to ``Settings.__init__()``.