### PR TITLE
Allow `readpdb()` and `writepdb()` to take any path-like object

### DIFF
--- a/interfaces/molecule/rdkit.py
+++ b/interfaces/molecule/rdkit.py
@@ -632,7 +632,7 @@ def readpdb(pdb_file, removeHs=False, proximityBonding=False, return_rdmol=False
     Generate a molecule from a PDB file
 
     :param pdb_file: The PDB file to read
-    :type pdb_file: str or file
+    :type pdb_file: path- or file-like
     :param bool removeHs: Hydrogens are removed if True
     :param bool proximityBonding: Enables automatic proximity bonding
     :param bool return_rdmol: return a RDKit molecule if true, otherwise a PLAMS molecule
@@ -655,7 +655,7 @@ def writepdb(mol, pdb_file=sys.stdout):
     :parameter mol: molecule to be exported to PDB
     :type mol: |Molecule| or rdkit.Chem.Mol
     :param pdb_file: The PDB file to write to, or a filename
-    :type pdb_file: str or file
+    :type pdb_file: path- or file-like
     """
     try:
         pdb_file = open(pdb_file, 'w')

--- a/interfaces/molecule/rdkit.py
+++ b/interfaces/molecule/rdkit.py
@@ -639,8 +639,11 @@ def readpdb(pdb_file, removeHs=False, proximityBonding=False, return_rdmol=False
     :return: The molecule
     :rtype: |Molecule| or rdkit.Chem.Mol
     """
-    if isinstance(pdb_file, str):
+    try:
         pdb_file = open(pdb_file, 'r')
+    except TypeError:
+        pass
+
     pdb_mol = Chem.MolFromPDBBlock(pdb_file.read(), removeHs=removeHs, proximityBonding=proximityBonding)
     return pdb_mol if return_rdmol else from_rdmol(pdb_mol)
 
@@ -654,9 +657,12 @@ def writepdb(mol, pdb_file=sys.stdout):
     :param pdb_file: The PDB file to write to, or a filename
     :type pdb_file: str or file
     """
-    mol = to_rdmol(mol)
-    if isinstance(pdb_file, str):
+    try:
         pdb_file = open(pdb_file, 'w')
+    except TypeError:
+        pass
+
+    mol = to_rdmol(mol)
     pdb_file.write(Chem.MolToPDBBlock(mol))
 
 

--- a/interfaces/molecule/rdkit.py
+++ b/interfaces/molecule/rdkit.py
@@ -642,7 +642,7 @@ def readpdb(pdb_file, removeHs=False, proximityBonding=False, return_rdmol=False
     try:
         pdb_file = open(pdb_file, 'r')
     except TypeError:
-        pass
+        pass  # pdb_file is a file-like object... hopefully
 
     pdb_mol = Chem.MolFromPDBBlock(pdb_file.read(), removeHs=removeHs, proximityBonding=proximityBonding)
     return pdb_mol if return_rdmol else from_rdmol(pdb_mol)
@@ -660,7 +660,7 @@ def writepdb(mol, pdb_file=sys.stdout):
     try:
         pdb_file = open(pdb_file, 'w')
     except TypeError:
-        pass
+        pass  # pdb_file is a file-like object... hopefully
 
     mol = to_rdmol(mol)
     pdb_file.write(Chem.MolToPDBBlock(mol))


### PR DESCRIPTION
Previously the `readpdb()` and `writepdb()` could take either a string or file-like object as argument.
The scope of the former type has been expanded; both functions can now take any [path-like](https://docs.python.org/3/glossary.html#term-path-like-object) object as argument.