### PR TITLE
Crystal: Fix Input Error in Ordered Input Sections

### DIFF
--- a/interfaces/thirdparty/crystal.py
+++ b/interfaces/thirdparty/crystal.py
@@ -108,14 +108,14 @@ class CrystalJob(SingleJob):
             elif isinstance(value, str) and key in [*_geom_keys,*_basis_keys,*_option_keys]:
                 ret += '{}\n'.format(value.upper())
 
-            elif key is '':
-                ret += '{}\n'.format(value.upper())
-
             elif isinstance(value, list):
                 if not key is '':
                     ret += '{}\n'.format(key)
                 for el in value:
-                    ret += '{}\n'.format(el)
+                    ret += '{}\n'.format(str(el).upper())
+
+            elif key is '':
+                ret += '{}\n'.format(str(value).upper())
 
             elif value is '' or value is True:
                 ret += '{}\n'.format(key)


### PR DESCRIPTION
My Crystal interface throws an error when passing non-strings to an ordered (e.g. `settings.input.options.asdf._1`) input section, because I was calling `upper()` on them.

Fixed this by converting list elements and single elements to strings before using `.upper()`.

While doing this, I also noticed that lists were not handled properly due to wrong ordering of the `elif` statements. Fixed that.

Btw: Is there some testing suite that I could use when contributing in the future? Till now I only run my private tests... Could prevent small things like this one.