### PR TITLE
FIX: Loading a Job with Ghost Atoms

### DIFF
--- a/interfaces/adfsuite/adf.py
+++ b/interfaces/adfsuite/adf.py
@@ -192,10 +192,10 @@ class ADFResults(SCMResults):
                     with InputParser() as parser:
                         inp = parser.to_settings('adf', new_input)
                 except:
-                    log('Failed to recreate input settings from {}'.format(self._kf.path, 5))
+                    log('Failed to recreate input settings from {}'.format(self._kf.path), 5)
                     return None
             except:
-                log('Failed to recreate input settings from {}'.format(self._kf.path, 5))
+                log('Failed to recreate input settings from {}'.format(self._kf.path), 5)
                 return None
 
             s = Settings()

--- a/tools/periodic_table.py
+++ b/tools/periodic_table.py
@@ -155,6 +155,8 @@ class PeriodicTable:
         """Convert atomic symbol to atomic number."""
         if symbol.lower().capitalize() in cls.dummysymbols:
             return 0
+        elif symbol.lower().startswith('gh.'):
+            return 0
         try:
             number = cls.symtonum[symbol.capitalize()]
         except KeyError:


### PR DESCRIPTION
Loading an ADF job with ghost atoms (e.g. `Gh.C`) is not working, because the periodic table module does not support ghosted atoms. I hacked an `elif` clause. I think it is the best way to go, even though the elements are lost this way (replaced by `Xx`, the standard PLAMS special atom).

Passing the element would end up with a complete molecule, which is I think much more prone to misinterpretation.