### PR TITLE
ADFResults: Energy Contributions

### DIFF
--- a/interfaces/adfsuite/adf.py
+++ b/interfaces/adfsuite/adf.py
@@ -113,12 +113,15 @@ class ADFResults(SCMResults):
         Return a dictionary with energy decomposition terms, expressed in *unit*.
 
         The following keys are present in the returned dictionary: ``Electrostatic``, ``Kinetic``, ``Coulomb``, ``XC``. The sum of all the values is equal to the value returned by :meth:`get_energy`.
+        Note that additional contributions might be included, those are up to now: ``Dispersion``.
         """
         ret = {}
         ret['Electrostatic'] = self._get_single_value('Energy', 'Electrostatic Energy', unit)
         ret['Kinetic'] = self._get_single_value('Energy', 'Kinetic Energy', unit)
         ret['Coulomb'] = self._get_single_value('Energy', 'Elstat Interaction', unit)
         ret['XC'] = self._get_single_value('Energy', 'XC Energy', unit)
+        if ('Energy', 'Dispersion Energy') in self._kf:
+            ret['Dispersion'] = self._get_single_value('Energy', 'Dispersion Energy', unit)
         return ret
 
 


### PR DESCRIPTION
The `ADFResults.get_energy_decomposition` method claimed to get all contributions of the total bonding energy. If using a dispersion correction scheme (I only tested D3 variants), an additional entry is found in the KF file. Without this, the sum of the returned values is not equal to the total bonding energy.

This is a one-line change so far, as I am not sure what else might contribute to the total bonding energy. Perhaps there is some internal documentation where someone could look this up or check the ADF code directly?

Not sure how this will be affected by the shift to the AMS engine, but right now all KF files I found have this. So at least for usability with the current release I suggest to add all additional energy terms in such `if` clauses.