### PR TITLE
Add more `Settings` support for subclasses and case-insensitivity

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -82,7 +82,8 @@ class Settings(dict):
 
         This method is also used when :func:`python3:copy.copy` is called.
         """
-        ret = Settings()
+        cls = type(self)
+        ret = cls()
         for name in self:
             if isinstance(self[name], Settings):
                 ret[name] = self[name].copy()
@@ -218,6 +219,13 @@ class Settings(dict):
         return dict.popitem(self, self.find_case(key))
 
 
+    def setdefault(self, key, default=None):
+        """Like regular ``setdefault``, but ignore the case and if the value is a dict, convert it to |Settings|."""
+        cls = type(self)
+        if isinstance(default, dict) and type(default) is not cls:
+            default = cls(default)
+        return dict.setdefault(self, self.find_case(key), default)
+
 
     def as_dict(self):
         """Return a copy of this instance with all |Settings| replaced by regular Python dictionaries.
@@ -351,7 +359,8 @@ class Settings(dict):
                     ret[k] = v
 
         # Changes keys into tuples
-        ret = Settings()
+        cls = type(self)
+        ret = cls()
         _concatenate((), self)
         return ret
 
@@ -379,7 +388,8 @@ class Settings(dict):
               b:
                 c: 	True
         """
-        ret = Settings()
+        cls = type(self)
+        ret = cls()
         for key, value in self.items():
             s = ret
             for k1, k2 in zip(key[:-1], key[1:]):
@@ -417,7 +427,8 @@ class Settings(dict):
 
         The behaviour of this method can be suppressed by initializing the :class:`.Settings.suppress_missing` context manager.
         """
-        self[name] = Settings()
+        cls = type(self)
+        self[name] = cls()
         return self[name]
 
 
@@ -433,8 +444,9 @@ class Settings(dict):
 
     def __setitem__(self, name, value):
         """Like regular ``__setitem__``, but ignore the case and if the value is a dict, convert it to |Settings|."""
-        if isinstance(value, dict) and not isinstance(value, Settings):
-            value = Settings(value)
+        cls = type(self)
+        if isinstance(value, dict) and type(value) is not cls:
+            value = cls(value)
         dict.__setitem__(self, self.find_case(name), value)
 
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -201,6 +201,23 @@ class Settings(dict):
         return key
 
 
+    def get(self, key, default=None):
+        """Like regular ``get``, but ignore the case."""
+        return dict.get(self, self.find_case(key), default)
+
+
+    def pop(self, key, *args):
+        """Like regular ``pop``, but ignore the case."""
+        # A single positional argument can be supplied `*args`,
+        # functioning as a default return value in case `key` is not present in this instance
+        return dict.pop(self, self.find_case(key), *args)
+
+
+    def popitem(self, key):
+        """Like regular ``popitem``, but ignore the case."""
+        return dict.popitem(self, self.find_case(key))
+
+
 
     def as_dict(self):
         """Return a copy of this instance with all |Settings| replaced by regular Python dictionaries.


### PR DESCRIPTION
This PR makes two enhancements to the `Settings` class:
* It adds support for case-insensitivity to three more methods: `get`, `pop` and `popitem`.
* It adds support for `Settings` subclasses to all remaining methods.