### PR TITLE
Speed up unit conversions

### DIFF
--- a/tools/units.py
+++ b/tools/units.py
@@ -145,18 +145,26 @@ class Units:
     dicts['stress'] = stress
 
 
+    # Precompute a dict mapping lowercased unit names to quantityName:conversionFactor pairs
+    quantities_for_unit = {}
+    for quantity in dicts:
+        for unit, factor in dicts[quantity].items():
+            unit = unit.lower()
+            if unit not in quantities_for_unit:
+                quantities_for_unit[unit] = {}
+            quantities_for_unit[unit][quantity] = factor
+
+
     def __init__(self):
         raise UnitsError('Instances of Units cannot be created')
 
 
     @classmethod
     def find_unit(cls, unit):
-        ret = {}
-        for quantity in cls.dicts:
-            for k in cls.dicts[quantity]:
-                if k.lower() == unit.lower():
-                    ret[quantity] = k
-        return ret
+        try:
+            return cls.quantities_for_unit[unit.lower()]
+        except KeyError:
+            return {}
 
 
     @classmethod
@@ -167,8 +175,7 @@ class Units:
         common = set(inps.keys()) & set(outs.keys())
         if len(common) > 0:
             quantity = common.pop()
-            d = cls.dicts[quantity]
-            return d[outs[quantity]]/d[inps[quantity]]
+            return outs[quantity]/inps[quantity]
         else:
             if len(inps) == 0 and len(outs) == 0:
                 raise UnitsError("Unsupported units: '{}' and '{}'".format(inp, out))

--- a/tools/units.py
+++ b/tools/units.py
@@ -198,7 +198,7 @@ class Units:
 
         *value* can be a single number or a container (list, tuple, numpy.array etc.). In the latter case a container of the same type and length is returned. Conversion happens recursively, so this method can be used to convert, for example, a list of lists of numbers, or any other hierarchical container structure. Conversion is applied on all levels, to all values that are numbers (also numpy number types). All other values (strings, bools etc.) remain unchanged.
         """
-        if value is None or isinstance(value, (bool, str)):
+        if value is None or isinstance(value, (bool, str)) or inp == out:
             return value
         if isinstance(value, collections.abc.Iterable):
             t = type(value)

--- a/tools/units.py
+++ b/tools/units.py
@@ -161,17 +161,22 @@ class Units:
 
     @classmethod
     def find_unit(cls, unit):
-        try:
-            return cls.quantities_for_unit[unit.lower()]
-        except KeyError:
-            return {}
+        ret = {}
+        u = unit.lower()
+        quantities = cls.quantities_for_unit.get(u, {})
+        for quantity in quantities:
+            for k in cls.dicts[quantity]:
+                if k.lower() == u:
+                    ret[quantity] = k
+                    break
+        return ret
 
 
     @classmethod
     def conversion_ratio(cls, inp, out):
         """Return conversion ratio from unit *inp* to *out*."""
-        inps = cls.find_unit(inp)
-        outs = cls.find_unit(out)
+        inps = cls.quantities_for_unit.get(inp.lower(), {})
+        outs = cls.quantities_for_unit.get(out.lower(), {})
         common = set(inps.keys()) & set(outs.keys())
         if len(common) > 0:
             quantity = common.pop()


### PR DESCRIPTION
Unit conversions have become a major bottleneck recently as new units are added. These two simple patches bring the time to create 10000 Atoms() with coordinates in a.u. down from 6 seconds to 300 ms. Everything seems to be working exactly the same way as before (including error messages for mismatched units), with the exception of conversions from "someInvalidUnit" to "someInvalidUnit", which used to fail but now silently succeed. I hope that's not a big issue.