### PR TITLE
Fixed non-standard use of comparison operators

### DIFF
--- a/core/functions.py
+++ b/core/functions.py
@@ -39,7 +39,7 @@ def init(path=None, folder=None, config_settings:Dict=None):
       This function **must** be called before any other PLAMS command can be executed. Trying to do anything without it results in a crash. See also |master-script|.
     """
 
-    if config.init == True:
+    if config.init:
         return
 
     if 'PLAMSDEFAULTS' in os.environ and isfile(expandvars('$PLAMSDEFAULTS')):
@@ -83,7 +83,7 @@ def finish(otherJM=None):
 
     If you used some other job managers than just the default one, they need to be passed as *otherJM* list.
     """
-    if config.init == False:
+    if not config.init:
         return
 
     for thread in threading.enumerate():

--- a/core/results.py
+++ b/core/results.py
@@ -274,7 +274,7 @@ class Results(metaclass=_MetaResults):
         """
         current_match = 0
         ret = []
-        switch = (begin == None)
+        switch = (begin is None)
 
         append = lambda x: ret.append(x.rstrip('\n')) if (match in [0,current_match]) else None
 

--- a/doc/source/cookbook/numhess.rst
+++ b/doc/source/cookbook/numhess.rst
@@ -33,3 +33,4 @@ An example usage::
                    gradient = lambda x: x.get_gradients().reshape(-1))
     r = j.run(jobrunner=JobRunner(parallel=True, maxjobs=8))
     print(r.get_hessian(mass_weighted=True))
+

--- a/examples/ExcitationsWorkflow.py
+++ b/examples/ExcitationsWorkflow.py
@@ -22,7 +22,7 @@ def has_good_excitations(results, min_energy, max_energy, oscillator_str_thresho
        in the energy range [min_energy, max_energy]. Unit for min_energy and max energy: eV. """
     exci_energies, oscillator_str = results.get_excitations()
     for e,o in zip(exci_energies, oscillator_str):
-        if e > min_energy and e < max_energy and o > oscillator_str_threshold:
+        if min_energy < e < max_energy and o > oscillator_str_threshold:
             return True
     return False
 

--- a/interfaces/adfsuite/ams.py
+++ b/interfaces/adfsuite/ams.py
@@ -583,8 +583,8 @@ class AMSResults(Results):
             def __str__(self):
                 if self.isTS:
                     lines  = [f"State {self.id}: transition state @ {self.energy} Hartree (found {self.count} times, results on {self.engfile})"]
-                    if self.reactantsID != None: lines += [f"|- Reactants: {self.reactants}"]
-                    if self.productsID  != None: lines += [f"+- Products:  {self.products}"]
+                    if self.reactantsID is not None: lines += [f"|- Reactants: {self.reactants}"]
+                    if self.productsID is not None: lines += [f"+- Products:  {self.products}"]
                 else:
                     lines  = [f"State {self.id}: local minimum @ {self.energy} Hartree (found {self.count} times, results on {self.engfile})"]
                 return "\n".join(lines)

--- a/interfaces/adfsuite/crs.py
+++ b/interfaces/adfsuite/crs.py
@@ -88,7 +88,7 @@ class CRSResults(SCMResults):
         r"""Read the section of the .crskf file and return a list of the properties that were calculated.  The section argument can be supplied to look at previously-calculated results.  If no section name is supplied, the function defaults to using the most recent property that was calculated.
 
         """
-        if section == None:
+        if section is None:
             section = self.section
         try:
             return self._kf.get_skeleton()[section]
@@ -99,7 +99,7 @@ class CRSResults(SCMResults):
         r"""Read the section from the most recent calculation type and return the result as a dictionary.
 
         """
-        if section == None:
+        if section is None:
             section = self.section
 
         output = getattr(self, '_prop_dict', False)

--- a/interfaces/molecule/rdkit.py
+++ b/interfaces/molecule/rdkit.py
@@ -143,7 +143,7 @@ def to_rdmol(plams_mol, sanitize=True, properties=True, assignChirality=False):
 
     # Mapping of PLAMS bond orders to RDKit bond types:
     def plams_to_rd_bonds(bo):
-        if bo > 1.4 and bo < 1.6:
+        if 1.4 < bo < 1.6:
             return 12 # bond type for aromatic bond
         else:
             return int(bo)

--- a/interfaces/thirdparty/cp2k.py
+++ b/interfaces/thirdparty/cp2k.py
@@ -210,7 +210,7 @@ class Cp2kResults(Results):
             return 0
         elif isinstance(idx, slice):
             raise TypeError("Passing a slice here is not supported!")
-        elif idx >= 0 and idx < nTotal:
+        elif 0 <= idx < nTotal:
             return idx + 1
         elif idx < -nTotal or idx >= nTotal:
             raise ResultsError("Trying to select a non-existing index.")
@@ -476,7 +476,7 @@ class Cp2kJob(SingleJob):
                 for el in value:
                     ret += parse(key, el, indent)
 
-            elif value is '' or value is True:
+            elif value == '' or value is True:
                 ret += '{}{}\n'.format(indent, key)
             else:
                 ret += '{}{}  {}\n'.format(indent, key, str(value))
@@ -486,7 +486,7 @@ class Cp2kJob(SingleJob):
 
         if self.molecule:
             use_molecule = ('ignore_molecule' not in self.settings) or (
-                self.settings.ignore_molecule == False)
+                self.settings.ignore_molecule is False)
             if use_molecule:
                 self._parsemol()
 

--- a/interfaces/thirdparty/crystal.py
+++ b/interfaces/thirdparty/crystal.py
@@ -109,15 +109,15 @@ class CrystalJob(SingleJob):
                 ret += '{}\n'.format(value.upper())
 
             elif isinstance(value, list):
-                if not key is '':
+                if key != '':
                     ret += '{}\n'.format(key)
                 for el in value:
                     ret += '{}\n'.format(str(el).upper())
 
-            elif key is '':
+            elif key == '':
                 ret += '{}\n'.format(str(value).upper())
 
-            elif value is '' or value is True:
+            elif value == '' or value is True:
                 ret += '{}\n'.format(key)
 
             elif value is False:

--- a/mol/molecule.py
+++ b/mol/molecule.py
@@ -622,7 +622,7 @@ class Molecule:
             at._metalbondcounter = len([x for x in at.bonds if x.other_end(at).is_metallic])
             at._electronegativebondcounter = len([x for x in at.bonds if x.other_end(at).is_electronegative])
             if at._electronegativebondcounter >= 3 or \
-                    (at._electronegativebondcounter >= 2 and at._metalbondcounter <= 2) or \
+                    (at._electronegativebondcounter >= 2 >= at._metalbondcounter) or \
                     (at._electronegativebondcounter >= 1 and at._metalbondcounter <= 0):
                 bonds_to_delete = [b for b in at.bonds if b.other_end(at).is_metallic or b.other_end(at).atnum == 1]
                 for b in bonds_to_delete:

--- a/mol/pdbtools.py
+++ b/mol/pdbtools.py
@@ -193,7 +193,7 @@ class PDBHandler:
             self.add_record(newmodel)
             self.add_record(endmdl)
 
-        if self.records['MODEL '] != []: #there were 1+ models present before
+        if self.records['MODEL ']: #there were 1+ models present before
             newmodel = PDBRecord('MODEL     %4i' % (1+len(self.records['MODEL '])))
             newmodel.model = model
             if newmodel.model[-1].name != 'ENDMDL':

--- a/recipes/vibration.py
+++ b/recipes/vibration.py
@@ -60,7 +60,7 @@ class VibrationsJob(MultiJob):
         self.vibClass = aseVib
 
         self.get_grad = getattr(self.jobType._result_type, get_gradients)
-        if reorder != None:
+        if reorder is not None:
             self.reorder = getattr(self.jobType._result_type, reorder)
         else:
             self.reorder = lambda x: x

--- a/trajectories/rkffile.py
+++ b/trajectories/rkffile.py
@@ -462,7 +462,7 @@ class RKFTrajectoryFile (TrajectoryFile) :
                 """
                 Store the data from the MDHistory section
                 """
-                if self.mddata == None : self.mddata = {}
+                if self.mddata is None: self.mddata = {}
                 section = 'MDHistory'
 
                 # First get the block info
@@ -496,7 +496,7 @@ class RKFTrajectoryFile (TrajectoryFile) :
                 """
                 Store the extra data from the History section
                 """
-                if self.historydata == None : self.historydata = {}
+                if self.historydata is None: self.historydata = {}
                 section = 'History'
 
                 # Look for the items


### PR DESCRIPTION
This fixes #107 .

I've run a linter to catch non-standard uses of comparison operators.
Changes that have been made:

* Comparisons to True, False and None have all been changed to use the `is`
operator
* Comparisons to string literals have all been changed to use the `==`
oeprator
* Comparison to the empty list has been replaced with simply if my_list:
(which saves instantiating an empty list each time).
* Range comparisons (e.g. `if a < b and a > c`) have been changed to the
more standard `if c < a < b`.

I also caught one error in the numhess.rst which just required the
addition of a blank line to complete a code block so I've included it
here.