### PR TITLE
Fix CP2KResults._get_charges with Empty Lines

### DIFF
--- a/interfaces/thirdparty/cp2k.py
+++ b/interfaces/thirdparty/cp2k.py
@@ -247,10 +247,10 @@ class Cp2kResults(Results):
         spin = []
         for ch in chunk:
             charges.append([float(line.strip().split()[selectCharge])
-                            for line in ch])
+                            for line in ch if line])
             if return_spin:
                 spin.append([float(line.strip().split()[selectSpin])
-                             for line in ch])
+                             for line in ch if line])
         if return_spin:
             if match == 0:
                 return charges, spin


### PR DESCRIPTION
`Cp2kResults.get_hirshfeld_charges(return_spin=True)` fails because there is an empty line in the CP2K output of the version I am using right now. Small fix prevents that from happening.