### PR TITLE
Change `init` from a function into a context manager

### DIFF
--- a/core/functions.py
+++ b/core/functions.py
@@ -62,8 +62,6 @@ class init(contextlib.AbstractContextManager):
       This function **must** be called before any other PLAMS command can be executed. Trying to do anything without it results in a crash. See also |master-script|.
     """
 
-    __slots__ = ("otherJM",)
-
     def __init__(self, path=None, folder=None, config_settings: Dict = None, quiet=False, otherJM=None, use_existing_folder=False):
         self.otherJM = otherJM
 
@@ -105,19 +103,11 @@ class init(contextlib.AbstractContextManager):
 
     def __enter__(self):
         """Enter the context manager; return |init|."""
-        return self
+        return None
 
     def __exit__(self, exc_type, exc_value, traceback):
         """Exit the context manager; call |finish|."""
         finish(self.otherJM)
-
-    def __repr__(self):
-        """Return :func:`repr(self) <repr>`."""
-        return f"<plams.init: {config.init}>"
-
-    def __bool__(self):
-        """Return :class:`bool(self) <bool>`."""
-        return config.init
 
 
 def _init_slurm():

--- a/doc/source/components/functions.rst
+++ b/doc/source/components/functions.rst
@@ -7,7 +7,7 @@ Public functions
 
 This chapter gathers information about public functions that can be used in PLAMS scripts.
 
-.. autofunction:: init
+.. autoclass:: init
 .. autofunction:: finish
 .. autofunction:: load
 .. autofunction:: load_all

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -208,7 +208,7 @@ autodoc_member_order = 'bysource'
 autodoc_typehints = 'none'
 
 rst_epilog = """
-.. |init| replace:: :func:`~scm.plams.core.functions.init`
+.. |init| replace:: :class:`~scm.plams.core.functions.init`
 .. |log| replace:: :func:`~scm.plams.core.functions.log`
 .. |load| replace:: :func:`~scm.plams.core.functions.load`
 .. |load_all| replace:: :func:`~scm.plams.core.functions.load_all`


### PR DESCRIPTION
This PR changes `plams.init` from a function into a context manager.

In addition to calling it as a normal function, as could be done previously, `plams.init` can now be used on conjunction with the `with` statement. In the latter case `plams.finish` will be automatically called upon exiting the context manager.

Examples
---------
``` python
>>> from scm.plams import Molecule, Settings, AMSJob, init, finish

>>> mol: Molecule = ...
>>> settings: Settings = ...

>>> with init():
...     job1 = AMSJob(molecule=mol, settings=settings)
...     result1 = job1.run()

# Equivalently:
>>> init()
>>> job2 = AMSJob(molecule=mol, settings=settings)
>>> result2 = job2.run()
>>> finish()

```