### PR TITLE
BUG: Do not restrict static-/classmethods in `Results`

### DIFF
--- a/core/results.py
+++ b/core/results.py
@@ -1,4 +1,5 @@
 import copy
+import types
 import functools
 import glob
 import inspect
@@ -122,7 +123,13 @@ class _MetaResults(type):
     _dont_restrict = ['refresh', 'collect', '_clean', 'get_errormsg', 'collect_rkfs']
     def __new__(meta, name, bases, dct):
         for attr in dct:
-            if not (attr.endswith('__') and attr.startswith('__')) and not type(dct[attr]) is type and callable(dct[attr]) and (attr not in _MetaResults._dont_restrict):
+            # Explcitly check for `types.FunctionType` instances instead of `__call__` as to
+            # exclude static-/classmethods (which define `__call__` in python >= 3.10)
+            if (
+                not (attr.endswith('__') and attr.startswith('__'))
+                and isinstance(dct[attr], types.FunctionType)
+                and attr not in _MetaResults._dont_restrict
+            ):
                 dct[attr] = _restrict(dct[attr])
         return type.__new__(meta, name, bases, dct)
 


### PR DESCRIPTION
Python 3.10 newly add the `__call__` method to class- and staticmethods (xref [bpo-43682](https://bugs.python.org/issue43682)), which has had some unforeseen consequences for the `Result._replace_job_name` static method (_i.e._ raising whenever a job is renamed). 

The metaclass of `Result` wraps most of the its methods in a decorator that handles a few tasks such as ensuring thread-safety, writing to the logger, checking result statuses, _etc._. Importantly, the decorators' signature assumes that it is a _normal_ method that is being wrapped. Enter python 3.10: staticmethods are now also callables and hence `Result._replace_job_name` is now also all of a sudden being wrapped:

``` python
  File "/scistor/tc/kdf400/CAT/CAT/jobs.py", line 378, in job_geometry_opt
    results = job.run()
  File "/scistor/tc/kdf400/.conda/envs/CAT/lib/python3.10/site-packages/scm/plams/core/basejob.py", line 115, in run
    jobrunner._run_job(self, jobmanager)
  File "/scistor/tc/kdf400/.conda/envs/CAT/lib/python3.10/site-packages/scm/plams/core/jobrunner.py", line 28, in wrapper
    func(self, *args, **kwargs)
  File "/scistor/tc/kdf400/.conda/envs/CAT/lib/python3.10/site-packages/scm/plams/core/jobrunner.py", line 112, in _run_job
    if job._prepare(jobmanager):
  File "/scistor/tc/kdf400/.conda/envs/CAT/lib/python3.10/site-packages/scm/plams/core/basejob.py", line 194, in _prepare
    prev.results._copy_to(self.results)
  File "/scistor/tc/kdf400/.conda/envs/CAT/lib/python3.10/site-packages/scm/plams/core/results.py", line 65, in guardian
    return func(self, *args, **kwargs)
  File "/scistor/tc/kdf400/.conda/envs/CAT/lib/python3.10/site-packages/scm/plams/core/results.py", line 374, in _copy_to
    newname = Results._replace_job_name(name, self.job.name, newresults.job.name)
  File "/scistor/tc/kdf400/.conda/envs/CAT/lib/python3.10/site-packages/scm/plams/core/results.py", line 61, in guardian
    if not self.job:
AttributeError: 'str' object has no attribute 'job'
```