### PR TITLE
Manual sync from SCM-svn to GitHub from 2024.101 to 2024.102

### DIFF
--- a/interfaces/adfsuite/unifac.py
+++ b/interfaces/adfsuite/unifac.py
@@ -16,7 +16,7 @@ try:
     from rdkit.Chem import MolToSmiles, RemoveHs
 
     RDKIT_EX = None
-except ImportError as ex:
+except (ImportError, SystemError) as ex:
     RDKIT_EX = ex
 
 __all__ = ["UnifacJob", "UnifacResults"]

--- a/interfaces/molecule/packmol.py
+++ b/interfaces/molecule/packmol.py
@@ -745,7 +745,7 @@ def packmol_on_slab(
     """
     if len(slab.lattice) != 3:
         raise ValueError("slab in packmol_on_slab must be 3D periodic: slab in xy-plane with vacuum gap along z-axis")
-    if slab.cell_angles() != [90.0, 90.0, 90.0]:
+    if not all(np.isclose(slab.cell_angles(), [90.0, 90.0, 90.0])):
         raise ValueError("slab in packmol_on_slab must be have orthorhombic cell")
 
     liquid = packmol(

--- a/recipes/adfcosmorscompound.py
+++ b/recipes/adfcosmorscompound.py
@@ -1,6 +1,6 @@
 import os
 from collections import OrderedDict
-from typing import List
+from typing import List, Optional
 
 from scm.plams.interfaces.adfsuite.ams import AMSJob
 from scm.plams.interfaces.adfsuite.crs import CRSJob
@@ -117,17 +117,21 @@ class ADFCOSMORSCompoundJob(MultiJob):
 
         MultiJob.__init__(self, children=OrderedDict(), **kwargs)
         self.input_molecule = molecule
-        mol_info["Molar Mass"] = molecule.get_mass()
-        mol_info["Formula"] = molecule.get_formula()    
-        try:
-            rings = molecule.locate_rings()
-            flatten_atoms = [atom for subring in rings for atom in subring]
-            nring = len(set(flatten_atoms))
-            mol_info["Nring"] = int(nring)
-        except:
-            pass           
 
-        self.mol_info = mol_info
+        self.mol_info = dict()
+        self.atomic_ion = False  # should be set when molecule is set if using a custom prerun() method
+        if molecule is not None:
+            self.mol_info["Molar Mass"] = molecule.get_mass()
+            self.mol_info["Formula"] = molecule.get_formula()
+            self.atomic_ion = len(molecule.atoms) == 1
+            try:
+                rings = molecule.locate_rings()
+                flatten_atoms = [atom for subring in rings for atom in subring]
+                nring = len(set(flatten_atoms))
+                self.mol_info["Nring"] = int(nring)
+            except:
+                pass
+
         self.settings = settings or Settings()
 
         self.coskf_name = coskf_name
@@ -139,16 +143,11 @@ class ADFCOSMORSCompoundJob(MultiJob):
         if self.coskf_name is not None and isinstance(self.coskf_name, str) and not self.coskf_name.endswith(".coskf"):
             self.coskf_name += ".coskf"
 
-        self.atomic_ion = len(molecule.atoms) == 1
-
         gas_s = Settings()
-        gas_s += self.adf_settings(solvation=False, settings=self.settings, atomic_ion=self.atomic_ion)
+        gas_s += self.adf_settings(solvation=False, settings=self.settings)
         gas_job = AMSJob(settings=gas_s, name="gas")
 
-        if singlepoint:
-            gas_job.settings.input.ams.Task = "SinglePoint"
-            gas_job.molecule = molecule
-        else:
+        if not singlepoint:
             if preoptimization:
                 preoptimization_s = Settings()
                 preoptimization_s.runscript.nproc = 1
@@ -157,40 +156,56 @@ class ADFCOSMORSCompoundJob(MultiJob):
                 preoptimization_job = AMSJob(settings=preoptimization_s, name="preoptimization", molecule=molecule)
                 self.children["preoptimization"] = preoptimization_job
 
-            gas_job.settings.input.ams.Task = "GeometryOptimization"
+            gas_s = Settings()
+            gas_s.input.ams.Task = "GeometryOptimization"
+            gas_s += self.adf_settings(solvation=False, settings=self.settings)
+            gas_job = AMSJob(settings=gas_s, name="gas")
 
             if preoptimization:
 
                 @add_to_instance(gas_job)
-                def prerun(self):  # noqa F811
+                def prerun(self):
                     self.molecule = self.parent.children["preoptimization"].results.get_main_molecule()
 
             else:
                 gas_job.molecule = molecule
 
-        self.children["gas"] = gas_job
+            self.children["gas"] = gas_job
 
         solv_s = Settings()
         solv_s.input.ams.Task = "SinglePoint"
         solv_job = AMSJob(settings=solv_s, name="solv")
 
-        @add_to_instance(solv_job)
-        def prerun(self):  # noqa F811
-            gas_job.results.wait()
-            self.settings.input.ams.EngineRestart = "../gas/adf.rkf"
-            self.settings.input.ams.LoadSystem.File = "../gas/ams.rkf"
-            self.settings += self.parent.adf_settings(
-                solvation=True,
-                settings=self.parent.settings,
-                elements=list(set(at.symbol for at in self.parent.input_molecule)),
-                atomic_ion=self.parent.atomic_ion,
-            )
+        if singlepoint:
 
-            # self.settings.input.ams.EngineRestart = self.parent.children['gas'].results.rkfpath(file='adf') # this doesn't work with PLAMS restart since the file will refer to the .res directory (so the job is rerun needlessly)
-            # self.settings.input.ams.LoadSystem.File = self.parent.children['gas'].results.rkfpath(file='ams')
-            # cannot copy to gasphase-ams.rkf etc. because that conflicts with PLAMS restarts
-            # shutil.copyfile(gas_job.results.rkfpath(file='ams'), os.path.join(self.path, 'gasphase-ams.rkf'))
-            # shutil.copyfile(gas_job.results.rkfpath(file='adf'), os.path.join(self.path, 'gasphase-adf.rkf'))
+            @add_to_instance(solv_job)
+            def prerun(self):
+                self.molecule = self.parent.input_molecule
+                self.settings += self.parent.adf_settings(
+                    solvation=True,
+                    settings=self.parent.settings,
+                    elements=list(set(at.symbol for at in self.parent.input_molecule)),
+                    atomic_ion=self.parent.atomic_ion
+                )
+
+        else:
+
+            @add_to_instance(solv_job)
+            def prerun(self):
+                gas_job.results.wait()
+                self.settings.input.ams.EngineRestart = "../gas/adf.rkf"
+                self.settings.input.ams.LoadSystem.File = "../gas/ams.rkf"
+                self.settings += self.parent.adf_settings(
+                    solvation=True,
+                    settings=self.parent.settings,
+                    elements=list(set(at.symbol for at in self.parent.input_molecule)),
+                    atomic_ion=self.parent.atomic_ion
+                )
+                # self.settings.input.ams.EngineRestart = self.parent.children['gas'].results.rkfpath(file='adf') # this doesn't work with PLAMS restart since the file will refer to the .res directory (so the job is rerun needlessly)
+                # self.settings.input.ams.LoadSystem.File = self.parent.children['gas'].results.rkfpath(file='ams')
+                # cannot copy to gasphase-ams.rkf etc. because that conflicts with PLAMS restarts
+                # shutil.copyfile(gas_job.results.rkfpath(file='ams'), os.path.join(self.path, 'gasphase-ams.rkf'))
+                # shutil.copyfile(gas_job.results.rkfpath(file='adf'), os.path.join(self.path, 'gasphase-adf.rkf'))
 
         @add_to_instance(solv_job)
         def postrun(self):
@@ -246,7 +261,7 @@ class ADFCOSMORSCompoundJob(MultiJob):
         return radii
 
     @staticmethod
-    def solvation_settings(elements: List[str] = None, atomic_ion=False) -> Settings:
+    def solvation_settings(elements: Optional[List[str]] = None, atomic_ion: bool = False) -> Settings:
         sett = Settings()
 
         radii = {
@@ -373,7 +388,7 @@ class ADFCOSMORSCompoundJob(MultiJob):
         if elements:
             radii = {k: radii[k] for k in sorted(elements)}
 
-        if atomic_ion is True:
+        if atomic_ion:
             charge_method = "method=atom corr"
         else:
             charge_method = "method=Conj corr"
@@ -389,7 +404,9 @@ class ADFCOSMORSCompoundJob(MultiJob):
         return sett
 
     @staticmethod
-    def adf_settings(solvation: bool, settings=None, elements: List[str] = None, atomic_ion=False) -> Settings:
+    def adf_settings(
+        solvation: bool, settings=None, elements: Optional[List[str]] = None, atomic_ion: bool = False
+    ) -> Settings:
         """
         Returns ADF settings with or without solvation
 
@@ -419,5 +436,5 @@ class ADFCOSMORSCompoundJob(MultiJob):
             coskf_file.write("COSMO", k, v)
         for key, value in mol_info.items():
             # print(f"write to coskf {key}: {value}")
-            coskf_file.write("Compound Data", key, value)       
+            coskf_file.write("Compound Data", key, value)
         coskf_file.save()

--- a/recipes/redox.py
+++ b/recipes/redox.py
@@ -367,6 +367,7 @@ class AMSRedoxScreeningJob(AMSRedoxParentJob):
         @add_to_instance(gencoskf_0)
         def prerun(self):  # noqa F811
             self.input_molecule = dftb_go_0.results.get_main_molecule()  # will inherit the charge
+            self.atomic_ion = len(self.input_molecule) == 1
 
         self.children["gencoskf_0"] = gencoskf_0
 
@@ -379,6 +380,7 @@ class AMSRedoxScreeningJob(AMSRedoxParentJob):
             @add_to_instance(gencoskf_ox)
             def prerun(self):  # noqa F811
                 self.input_molecule = dftb_go_ox.results.get_main_molecule()
+                self.atomic_ion = len(self.input_molecule) == 1
 
             self.children["gencoskf_ox"] = gencoskf_ox
 
@@ -391,6 +393,7 @@ class AMSRedoxScreeningJob(AMSRedoxParentJob):
             @add_to_instance(gencoskf_red)
             def prerun(self):  # noqa F811
                 self.input_molecule = dftb_go_red.results.get_main_molecule()
+                self.atomic_ion = len(self.input_molecule) == 1
 
             self.children["gencoskf_red"] = gencoskf_red
 


### PR DESCRIPTION
**Description**
This is a manual sync of commits from subversion `fix2024` branch, from `2024.101`  to `2024.102` (07/06/2024) tags.
This will be merged into the `fix2024` branch here.

**Notes for Reviewer**
The copied files have been checked by comparing the commits to the subversion equivalent, by using:

git diff --shortstat <2024.101> <2024.102>
4 files changed, 64 insertions(+), 44 deletions(-)

Please could the reviewer double check that the commits align with what they would expect from subversion.

**List of contained Commits**
syncing the following commits:
Matti Hellström: fix AMSRedoxScreeningJob SO103 SCMSUITE-9508 
Matti Hellström: catch SystemError in unifac.py to allow users to copy scm into other Python envs SO-- 
Matti Hellström: plams packmol allow small noise in lattice for packmol_on_slab SO--