### PR TITLE
Add unit tests for SingleJob and Results classes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,6 @@
 from scm.plams.version import __version__
 from scm.plams.core.basejob import MultiJob, SingleJob
+from scm.plams.core.enums import JobStatus
 from scm.plams.core.errors import (
     FileError,
     JobError,
@@ -196,6 +197,7 @@ __all__ = [
     "ConfigSettings",
     "SingleJob",
     "MultiJob",
+    "JobStatus",
     "PlamsError",
     "FileError",
     "ResultsError",

--- a/core/basejob.py
+++ b/core/basejob.py
@@ -454,7 +454,7 @@ class SingleJob(Job):
         return self._filenames[t].replace("$JN", self.name)
 
     @classmethod
-    def load(cls, path, jobmanager: "JobManager" = None, strict: bool = True) -> None:
+    def load(cls, path, jobmanager: "JobManager" = None, strict: bool = True) -> "SingleJob":
         """
         Loads a Job instance from `path`, where path can either be a
         directory with a `*.dill` file, or the full path to the `*.dill` file.
@@ -492,8 +492,10 @@ class SingleJob(Job):
 
         if strict and job.__class__ != cls:
             raise ValueError(
-                f"The loaded job is an instance of '{job.__class__.__name__}', wheras this method expects it to be a '{cls.__name__}'. Use `strict=False` to ignore this."
+                f"The loaded job is an instance of '{job.__class__.__name__}', whereas this method expects it to be a '{cls.__name__}'. Use `strict=False` to ignore this."
             )
+
+        return job
 
     @classmethod
     def load_external(

--- a/core/basejob.py
+++ b/core/basejob.py
@@ -4,7 +4,7 @@ import stat
 import threading
 import time
 from os.path import join as opj
-from typing import Optional
+from typing import Optional, List, Generator, TYPE_CHECKING
 
 from scm.plams.core.errors import FileError, JobError, PlamsError, ResultsError
 from scm.plams.core.functions import config, log
@@ -12,6 +12,7 @@ from scm.plams.core.private import sha256
 from scm.plams.core.results import Results
 from scm.plams.core.settings import Settings
 from scm.plams.mol.molecule import Molecule
+from scm.plams.core.enums import JobStatus
 
 try:
     from scm.pisa.block import DriverBlock
@@ -19,6 +20,10 @@ try:
     _has_scm_pisa = True
 except ImportError:
     _has_scm_pisa = False
+
+if TYPE_CHECKING:
+    from scm.plams.core.jobrunner import JobRunner
+    from scm.plams.core.jobmanager import JobManager
 
 __all__ = ["SingleJob", "MultiJob"]
 
@@ -62,10 +67,12 @@ class Job:
 
     _result_type = Results
 
-    def __init__(self, name="plamsjob", settings=None, depend=None):
+    def __init__(
+        self, name: str = "plamsjob", settings: Optional[Settings] = None, depend: Optional[List["Job"]] = None
+    ):
         if os.path.sep in name:
             raise PlamsError("Job name cannot contain {}".format(os.path.sep))
-        self.status = "created"
+        self.status = JobStatus.CREATED
         self.results = self.__class__._result_type(self)
         self.name = name
         self.path = None
@@ -93,7 +100,22 @@ class Job:
 
     # =======================================================================
 
-    def run(self, jobrunner=None, jobmanager=None, **kwargs):
+    @property
+    def status(self) -> JobStatus:
+        """
+        Current status of the job
+        """
+        return self._status
+
+    @status.setter
+    def status(self, value: JobStatus) -> None:
+        # This setter should really be private i.e. internally should use self._status
+        # But for backwards compatibility it is exposed and set by e.g. the JobManager
+        self._status = value
+
+    def run(
+        self, jobrunner: Optional["JobRunner"] = None, jobmanager: Optional["JobManager"] = None, **kwargs
+    ) -> Results:
         """Run the job using *jobmanager* and *jobrunner* (or defaults, if ``None``). Other keyword arguments (*\*\*kwargs*) are stored in ``run`` branch of job's settings. Returned value is the |Results| instance associated with this job.
 
         .. warning::
@@ -104,10 +126,10 @@ class Job:
 
             This method does not do too much by itself. After some initial preparation it passes control to the job runner, which decides if a new thread should be started for this job. The role of the job runner is to execute three methods that make the full job life cycle: :meth:`~Job._prepare`, :meth:`~Job._execute` and :meth:`~Job._finalize`. During :meth:`~Job._execute` the job runner is called once again to execute the runscript (only in case of |SingleJob|).
         """
-        if self.status != "created":
+        if self.status != JobStatus.CREATED:
             raise JobError("Trying to run previously started job {}".format(self.name))
 
-        self.status = "started"
+        self.status = JobStatus.STARTED
         self._log_status(1)
 
         self.settings.run.soft_update(Settings(kwargs))
@@ -126,7 +148,7 @@ class Job:
         jobrunner._run_job(self, jobmanager)
         return self.results
 
-    def pickle(self, filename=None):
+    def pickle(self, filename: Optional[str] = None) -> None:
         """Pickle this instance and save to a file indicated by *filename*. If ``None``, save to ``[jobname].dill`` in the job folder."""
         try:
             import dill as pickle
@@ -140,13 +162,13 @@ class Job:
             except:
                 log("Pickling of {} failed".format(self.name), 1)
 
-    def ok(self, strict=True):
+    def ok(self, strict: bool = True) -> bool:
         """Check if the execution of this instance was successful. If needed, wait for the job to finish and then check if the status is *successful* (or *copied*).
 
         If this method is called before job's |run| method, a warning is logged and the returned value is ``False``. The most likely cause of such a behavior is simply forgetting about |run| call. However, in complicated workflows executed in parallel, it can sometimes naturally happen that one thread is ahead of others and calls :meth:`~Job.ok` before some other thread has a chance to call |run|. If you're experiencing that kind of problems, please consider using ``strict=False`` to skip the |run| check.  But keep in mind that skipping that check will deadlock the current thread if |run| never gets called.
 
         """
-        if strict and self.status == "created":  # first thing run() does is changing the status to 'started'
+        if strict and self.status == JobStatus.CREATED:  # first thing run() does is changing the status to 'started'
             log(
                 "Job {} WARNING: ok() method was called before run(). Returned value is False. Please check the documentation".format(
                     self.name
@@ -155,23 +177,23 @@ class Job:
             )
             return False
         self.results.wait()
-        return self.status in ["successful", "copied"]
+        return self.status in [JobStatus.SUCCESSFUL, JobStatus.COPIED]
 
-    def check(self):
+    def check(self) -> bool:
         """Check if the execution of this instance was successful. Abstract method meant for internal use."""
         raise PlamsError("Trying to run an abstract method Job.check()")
 
-    def hash(self):
+    def hash(self) -> Optional[str]:
         """Calculate the hash of this instance. Abstract method meant for internal use."""
         raise PlamsError("Trying to run an abstract method Job.hash()")
 
-    def prerun(self):  # noqa F811
+    def prerun(self) -> None:  # noqa F811
         """Actions to take before the actual job execution.
 
         This method is initially empty, it can be defined in subclasses or directly added to either the whole class or a single instance using |binding_decorators|.
         """
 
-    def postrun(self):
+    def postrun(self) -> None:
         """Actions to take just after the actual job execution.
 
         This method is initially empty, it can be defined in subclasses or directly added to either the whole class or a single instance using |binding_decorators|.
@@ -179,7 +201,7 @@ class Job:
 
     # =======================================================================
 
-    def _prepare(self, jobmanager):
+    def _prepare(self, jobmanager: "JobManager") -> None:
         """Prepare the job for execution. This method collects steps 1-7 from :ref:`job-life-cycle`. Should not be overridden. Returned value indicates if job execution should continue (|RPM| did not find this job as previously run)."""
 
         log("Starting {}._prepare()".format(self.name), 7)
@@ -203,7 +225,7 @@ class Job:
         if prev is not None:
             try:
                 prev.results._copy_to(self.results)
-                self.status = "copied"
+                self.status = JobStatus.COPIED
             except ResultsError as re:
                 log("Copying results of {} failed because of the following error: {}".format(prev.name, str(re)), 1)
                 self.status = prev.status
@@ -214,7 +236,7 @@ class Job:
             if self.parent and self in self.parent:
                 self.parent._notify()
         else:
-            self.status = "running"
+            self.status = JobStatus.RUNNING
             log("Starting {}._get_ready()".format(self.name), 7)
             self._get_ready()
             log("{}._get_ready() finished".format(self.name), 7)
@@ -223,15 +245,15 @@ class Job:
         self._log_status(3)
         return prev is None
 
-    def _get_ready(self):
+    def _get_ready(self) -> None:
         """Get ready for :meth:`~Job._execute`. This is the last step before :meth:`~Job._execute` is called. Abstract method."""
         raise PlamsError("Trying to run an abstract method Job._get_ready()")
 
-    def _execute(self, jobrunner):
+    def _execute(self, jobrunner: "JobRunner") -> None:
         """Execute the job. Abstract method."""
         raise PlamsError("Trying to run an abstract method Job._execute()")
 
-    def _finalize(self):
+    def _finalize(self) -> None:
         """Gather the results of the job execution and organize them. This method collects steps 9-12 from :ref:`job-life-cycle`. Should not be overridden."""
         log("Starting {}._finalize()".format(self.name), 7)
 
@@ -239,8 +261,8 @@ class Job:
             log("Collecting results of {}".format(self.name), 7)
             self.results.collect()
             self.results.finished.set()
-            if self.status != "crashed":
-                self.status = "finished"
+            if self.status != JobStatus.CRASHED:
+                self.status = JobStatus.FINISHED
                 self._log_status(3)
                 if self.check():
                     log("{}.check() success. Cleaning results with keep = {}".format(self.name, self.settings.keep), 7)
@@ -248,15 +270,15 @@ class Job:
                     log("Starting {}.postrun()".format(self.name), 5)
                     self.postrun()
                     log("{}.postrun() finished".format(self.name), 5)
-                    self.status = "successful"
+                    self.status = JobStatus.SUCCESSFUL
                     log("Pickling {}".format(self.name), 7)
                     if self.settings.pickle:
                         self.pickle()
                 else:
                     log("{}.check() failed".format(self.name), 7)
-                    self.status = "failed"
+                    self.status = JobStatus.FAILED
         else:
-            self.status = "preview"
+            self.status = JobStatus.PREVIEW
             self.results.finished.set()
         self.results.done.set()
 
@@ -274,11 +296,11 @@ class Job:
         remove = ["jobmanager", "parent", "default_settings", "_lock"] + self._dont_pickle
         return {k: v for k, v in self.__dict__.items() if k not in remove}
 
-    def _log_status(self, level):
+    def _log_status(self, level: int) -> None:
         """Log the status of this instance on a chosen log *level*. The message is uppercased to clearly stand out among other log entries."""
         log("JOB {} {}".format(self._full_name(), self.status.upper()), level)
 
-    def _full_name(self):
+    def _full_name(self) -> str:
         if self.parent:
             return "/".join([self.parent._full_name(), self.name])
         return self.name
@@ -308,14 +330,14 @@ class SingleJob(Job):
         Job.__init__(self, **kwargs)
         self.molecule = molecule.copy() if isinstance(molecule, Molecule) else molecule
 
-    def get_input(self):
+    def get_input(self) -> str:
         """Generate the input file. Abstract method.
 
         This method should return a single string with the full content of the input file. It should process information stored in the ``input`` branch of job settings and in the ``molecule`` attribute.
         """
         raise PlamsError("Trying to run an abstract method SingleJob._get_input()")
 
-    def get_runscript(self):
+    def get_runscript(self) -> str:
         """Generate the runscript. Abstract method.
 
         This method should return a single string with the runscript contents. It can process information stored in ``runscript`` branch of job  settings. In general the full runscript has the following form::
@@ -332,15 +354,15 @@ class SingleJob(Job):
         """
         raise PlamsError("Trying to run an abstract method SingleJob._get_runscript()")
 
-    def hash_input(self):
+    def hash_input(self) -> str:
         """Calculate SHA256 hash of the input file."""
         return sha256(self.get_input())
 
-    def hash_runscript(self):
+    def hash_runscript(self) -> str:
         """Calculate SHA256 hash of the runscript."""
         return sha256(self.full_runscript())
 
-    def hash(self):
+    def hash(self) -> Optional[str]:
         """Calculate unique hash of this instance.
 
         The behavior of this method is adjusted by the value of ``hashing`` key in |JobManager| settings. If no |JobManager| is yet associated with this job, default setting from ``config.jobmanager.hashing`` is used.
@@ -370,7 +392,7 @@ class SingleJob(Job):
         else:
             raise PlamsError("Unsupported hashing method: {}".format(mode))
 
-    def check(self):
+    def check(self) -> bool:
         """Check if the calculation was successful.
 
         This method can be overridden in concrete subclasses of |SingleJob|. It should return a boolean value. The definition here serves as a default, to prevent crashing if a subclass does not define its own :meth:`~scm.plams.core.basejob.SingleJob.check`. It always returns ``True``.
@@ -382,7 +404,7 @@ class SingleJob(Job):
         """
         return True
 
-    def full_runscript(self):
+    def full_runscript(self) -> str:
         """Generate the full runscript, including shebang line and contents of ``pre`` and ``post``, if any. In practice this method is just a simple wrapper around |get_runscript|."""
         ret = self.settings.runscript.shebang + "\n\n"
         if "pre" in self.settings.runscript:
@@ -392,7 +414,7 @@ class SingleJob(Job):
             ret += self.settings.runscript.post + "\n\n"
         return ret
 
-    def _get_ready(self):
+    def _get_ready(self) -> None:
         """Create input and runscript files in the job folder. Methods |get_input| and :meth:`full_runscript` are used for that purpose. Filenames correspond to entries in the `_filenames` attribute"""
         inpfile = opj(self.path, self._filename("inp"))
         runfile = opj(self.path, self._filename("run"))
@@ -405,7 +427,7 @@ class SingleJob(Job):
 
         os.chmod(runfile, os.stat(runfile).st_mode | stat.S_IEXEC)
 
-    def _execute(self, jobrunner):
+    def _execute(self, jobrunner) -> None:
         """Execute previously created runscript using *jobrunner*.
 
         The method :meth:`~scm.plams.core.jobrunner.JobRunner.call` of *jobrunner* is used. Working directory is ``self.path``. ``self.settings.run`` is passed as ``runflags`` argument.
@@ -424,15 +446,15 @@ class SingleJob(Job):
             )
             if retcode != 0:
                 log("WARNING: Job {} finished with nonzero return code".format(self.name), 3)
-                self.status = "crashed"
+                self.status = JobStatus.CRASHED
         log("{}._execute() finished".format(self.name), 7)
 
-    def _filename(self, t):
+    def _filename(self, t) -> str:
         """Return filename for file of type *t*. *t* can be any key from ``_filenames`` dictionary. ``$JN`` is replaced with job name in the returned string."""
         return self._filenames[t].replace("$JN", self.name)
 
     @classmethod
-    def load(cls, path, jobmanager=None, strict=True):
+    def load(cls, path, jobmanager: "JobManager" = None, strict: bool = True) -> None:
         """
         Loads a Job instance from `path`, where path can either be a
         directory with a `*.dill` file, or the full path to the `*.dill` file.
@@ -474,7 +496,14 @@ class SingleJob(Job):
             )
 
     @classmethod
-    def load_external(cls, path, settings=None, molecule=None, finalize=False, jobname=None):
+    def load_external(
+        cls,
+        path: str,
+        settings: Optional[Settings] = None,
+        molecule: Optional[Molecule] = None,
+        finalize: bool = False,
+        jobname: str = None,
+    ) -> "SingleJob":
         """Load an external job from *path*.
 
         In this context an "external job" is an execution of some external binary that was not managed by PLAMS, and hence does not have a ``.dill`` file. It can also be used in situations where the execution was started with PLAMS, but the Python process was terminated before the execution finished, resulting in steps 9-12 of :ref:`job-life-cycle` not happening.
@@ -505,7 +534,7 @@ class SingleJob(Job):
 
         job = cls(name=jobname)
         job.path = path
-        job.status = "copied"
+        job._status = JobStatus.COPIED
         job.results.collect()
 
         job._filenames = {}
@@ -561,7 +590,7 @@ class MultiJob(Job):
         self._active_children = 0
         self._lock = threading.Lock()
 
-    def new_children(self):
+    def new_children(self) -> None:
         """Generate new children jobs.
 
         This method is useful when some of children jobs are not known beforehand and need to be generated based on other children jobs, like for example in any kind of self-consistent procedure.
@@ -572,15 +601,15 @@ class MultiJob(Job):
         """
         return None
 
-    def hash(self):
+    def hash(self) -> Optional[str]:
         """Hashing for multijobs is disabled by default. Returns ``None``."""
         return None
 
-    def check(self):
+    def check(self) -> bool:
         """Check if the execution of this instance was successful, by calling :meth:`Job.ok` of all the children jobs."""
         return all([child.ok() for child in self])
 
-    def other_jobs(self):
+    def other_jobs(self) -> Generator[Job, None, None]:
         """Iterate through other jobs that belong to this |MultiJob|, but are not in ``children``.
 
         Sometimes |prerun| or |postrun| methods create and run some small jobs that don't end up in ``children`` collection, but are still considered a part of a |MultiJob| instance (their ``parent`` atribute points to the |MultiJob| and their working folder is inside MultiJob's working folder). This method provides an iterator that goes through all such jobs.
@@ -593,7 +622,7 @@ class MultiJob(Job):
             ):
                 yield attr
 
-    def remove_child(self, job):
+    def remove_child(self, job: Job) -> None:
         """Remove *job* from children."""
 
         rm = None
@@ -604,7 +633,7 @@ class MultiJob(Job):
         if rm is not None:
             del self.children[rm]
 
-    def _get_ready(self):
+    def _get_ready(self) -> None:
         """Get ready for :meth:`~MultiJob._execute`. Count children jobs and set their ``parent`` attribute."""
         self._active_children = len(self.children)
         for child in self:
@@ -616,7 +645,7 @@ class MultiJob(Job):
             return iter(self.children.values())
         return iter(self.children)
 
-    def _notify(self):
+    def _notify(self) -> None:
         """Notify this job that one of its children has finished.
 
         Decrement ``_active_children`` by one. Use ``_lock`` to ensure thread safety.
@@ -624,7 +653,7 @@ class MultiJob(Job):
         with self._lock:
             self._active_children -= 1
 
-    def _execute(self, jobrunner):
+    def _execute(self, jobrunner: "JobRunner") -> None:
         """Run all children from ``children``. Then use :meth:`~MultiJob.new_children` and run all jobs produced by it. Repeat this procedure until :meth:`~MultiJob.new_children` returns an empty list. Wait for all started jobs to finish."""
         log("Starting {}._execute()".format(self.name), 7)
         jr = self.childrunner or jobrunner

--- a/core/enums.py
+++ b/core/enums.py
@@ -1,0 +1,34 @@
+# Import StrEnum for Python >=3.11, otherwise use
+try:
+    from enum import StrEnum
+except ImportError:
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        """
+        Enum where all members are strings and so can be used for string comparison.
+        """
+
+        def __str__(self):
+            return self.value
+
+
+__all__ = ["JobStatus"]
+
+
+class JobStatus(StrEnum):
+    """
+    Status of PLAMS job.
+    """
+
+    CREATED = "created"
+    STARTED = "started"
+    REGISTERED = "registered"
+    RUNNING = "running"
+    FINISHED = "finished"
+    CRASHED = "crashed"
+    FAILED = "failed"
+    SUCCESSFUL = "successful"
+    COPIED = "copied"
+    PREVIEW = "preview"
+    DELETED = "deleted"

--- a/core/enums.py
+++ b/core/enums.py
@@ -1,4 +1,4 @@
-# Import StrEnum for Python >=3.11, otherwise use
+# Import StrEnum for Python >=3.11, otherwise use backwards compatible class
 try:
     from enum import StrEnum
 except ImportError:

--- a/core/functions.py
+++ b/core/functions.py
@@ -14,9 +14,11 @@ import atexit
 from scm.plams.core.errors import FileError
 from scm.plams.core.private import retry
 from scm.plams.core.settings import Settings, ConfigSettings
+from scm.plams.core.enums import JobStatus
 
 if TYPE_CHECKING:
     from scm.plams.core.jobmanager import JobManager
+    from scm.plams.core.basejob import Job
 
 __all__ = [
     "init",
@@ -339,10 +341,10 @@ def load_all(path, jobmanager=None):
 
 
 @retry()
-def delete_job(job):
+def delete_job(job: "Job"):
     """Remove *job* from its corresponding |JobManager| and delete the job folder from the disk. Mark *job* as 'deleted'."""
 
-    if job.status != "created":
+    if job.status != JobStatus.CREATED:
         job.results.wait()
 
     # In case job.jobmanager is None, run() method was not called yet, so no JobManager knows about this job and no folder exists.
@@ -352,7 +354,7 @@ def delete_job(job):
     if job.parent is not None:
         job.parent.remove_child(job)
 
-    job.status = "deleted"
+    job.status = JobStatus.DELETED
     job._log_status(5)
 
 

--- a/core/jobmanager.py
+++ b/core/jobmanager.py
@@ -3,10 +3,15 @@ import re
 import shutil
 import threading
 from os.path import join as opj
+from typing import TYPE_CHECKING
 
 from scm.plams.core.basejob import MultiJob
 from scm.plams.core.errors import FileError, PlamsError
 from scm.plams.core.functions import config, log
+from scm.plams.core.enums import JobStatus
+
+if TYPE_CHECKING:
+    from scm.plams.core.basejob import Job
 
 __all__ = ["JobManager"]
 
@@ -135,7 +140,7 @@ class JobManager:
                     self.remove_job(otherjob)
             shutil.rmtree(job.path)
 
-    def _register(self, job):
+    def _register(self, job: "Job"):
         """Register the *job*. Register job's name (rename if needed) and create the job folder.
 
         If a job with the same name was already registered, *job* is renamed by appending consecutive integers. The number of digits in the appended number is defined by the ``counter_len`` value in ``settings``.
@@ -168,7 +173,7 @@ class JobManager:
             os.mkdir(job.path)
 
             self.jobs.append(job)
-            job.status = "registered"
+            job.status = JobStatus.REGISTERED
             log("Job {} registered".format(job.name), 7)
 
     def _check_hash(self, job):

--- a/core/results.py
+++ b/core/results.py
@@ -53,7 +53,7 @@ def _privileged_access():
 def _restrict(func):
     """Decorator that wraps methods of |Results| instances.
 
-    Whenever decorated method is called, the status of associated job is checked. Depending of its value access to the method is granted, refused or the calling thread is forced to wait for the right :ref:`event<event-objects>` to be set.
+    Whenever decorated method is called, the status of associated job is checked. Depending on its value access to the method is granted, refused or the calling thread is forced to wait for the right :ref:`event<event-objects>` to be set.
     """
 
     @functools.wraps(func)
@@ -357,14 +357,14 @@ class Results(ApplyRestrict):
     def recreate_molecule(self):
         """Recreate the input molecule for the corresponding job based on files present in the job folder. This method is used by |load_external|.
 
-        The definiton here serves as a deafult fall-back template preventing |load_external| from crashing when a particular |Results| subclass does not define it's own :meth:`recreate_molecule`.
+        The definiton here serves as a default fall-back template preventing |load_external| from crashing when a particular |Results| subclass does not define it's own :meth:`recreate_molecule`.
         """
         return None
 
     def recreate_settings(self):
         """Recreate the input |Settings| instance for the corresponding job based on files present in the job folder. This method is used by |load_external|.
 
-        The definiton here serves as a deafult fall-back template preventing |load_external| from crashing when a particular |Results| subclass does not define it's own :meth:`recreate_settings`.
+        The definiton here serves as a default fall-back template preventing |load_external| from crashing when a particular |Results| subclass does not define it's own :meth:`recreate_settings`.
         """
         return None
 

--- a/recipes/md/nvespawner.py
+++ b/recipes/md/nvespawner.py
@@ -3,6 +3,8 @@ from collections import OrderedDict
 from scm.plams.core.basejob import MultiJob
 from scm.plams.core.results import Results
 from scm.plams.core.settings import Settings
+from scm.plams.core.enums import JobStatus
+
 import numpy as np
 from scm.plams.recipes.md.amsmdjob import AMSNVEJob
 
@@ -81,7 +83,7 @@ class AMSNVESpawnerJob(MultiJob):
         """
 
         # use previously run previous_job
-        assert self.previous_job.status != "created", "You can only pass in a finished AMSJob"
+        assert self.previous_job.status != JobStatus.CREATED, "You can only pass in a finished AMSJob"
         try:
             self.previous_job.results.readrkf("MDHistory", "Velocities(1)")
         except KeyError:

--- a/recipes/md/trajectoryanalysis.py
+++ b/recipes/md/trajectoryanalysis.py
@@ -6,6 +6,7 @@ from scm.plams.core.basejob import MultiJob
 from scm.plams.core.results import Results
 from scm.plams.interfaces.adfsuite.amsanalysis import AMSAnalysisJob, AMSAnalysisResults
 from scm.plams.tools.units import Units
+from scm.plams.core.enums import JobStatus
 
 __all__ = ["AMSRDFJob", "AMSMSDJob", "AMSMSDResults", "AMSVACFJob", "AMSVACFResults"]
 
@@ -36,7 +37,7 @@ class AMSConvenientAnalysisJob(AMSAnalysisJob):
     def _parent_prerun(self, section):
 
         # use previously run previous_job
-        assert self.previous_job.status != "created", "You can only pass in a finished AMSJob"
+        assert self.previous_job.status != JobStatus.CREATED, "You can only pass in a finished AMSJob"
 
         self.settings.input.TrajectoryInfo.Trajectory.KFFileName = self.previous_job.results.rkfpath()
         if self.atom_indices and self._parent_write_atoms:

--- a/recipes/pestools/optimizer.py
+++ b/recipes/pestools/optimizer.py
@@ -11,6 +11,7 @@ from scm.plams.core.jobrunner import JobRunner
 from scm.plams.core.settings import Settings
 from scm.plams.interfaces.adfsuite.ams import AMSJob
 from scm.plams.interfaces.adfsuite.amsworker import AMSWorkerPool
+from scm.plams.core.enums import JobStatus
 
 __all__ = ["Optimizer"]
 
@@ -323,7 +324,7 @@ class Optimizer:
             except FileError:
                 pass
             # If the geometry was copied from another directory, then it is not new so we do not need it.
-            if r.job.status == "failed" or not os.path.isfile(os.path.join(r.job.path, "ams.rkf")):
+            if r.job.status == JobStatus.FAILED or not os.path.isfile(os.path.join(r.job.path, "ams.rkf")):
                 optimized_geometries.append(None)
                 energies.append(None)
                 continue
@@ -357,7 +358,7 @@ class Optimizer:
                 energy = r.get_energy()  # * Units.conversion_ratio('Hartree','kcal/mol')
             except FileError:
                 pass
-            if r.job.status == "failed" or not os.path.isfile(os.path.join(r.job.path, "ams.rkf")):
+            if r.job.status == JobStatus.FAILED or not os.path.isfile(os.path.join(r.job.path, "ams.rkf")):
                 energies.append(None)
                 continue
             energy = r.get_energy()  # * Units.conversion_ratio('Hartree','kcal/mol')
@@ -377,7 +378,12 @@ def progress_monitor(results, num_jobs, event, t):
             return
         try:
             num_done = len(
-                [True for r in results if r.job.status not in ["created", "started", "registered", "running"]]
+                [
+                    True
+                    for r in results
+                    if r.job.status
+                    not in [JobStatus.CREATED, JobStatus.STARTED, JobStatus.REGISTERED, JobStatus.RUNNING]
+                ]
             )
         except RuntimeError:
             pass

--- a/unit_tests/test_basejob.py
+++ b/unit_tests/test_basejob.py
@@ -186,7 +186,7 @@ sleep 0.0 && sed 's/input/output/g' plamsjob.in
 
         results[1].wait()
         assert job2.status == JobStatus.SUCCESSFUL
-        assert job2.calls[0][1] > job1.calls[2][1]
+        assert job2.calls[0][1] >= job1.calls[2][1]
 
     def test_run_multiple_prerun_dependent_jobs_in_serial(self):
         # Given parallel job runner
@@ -212,7 +212,7 @@ sleep 0.0 && sed 's/input/output/g' plamsjob.in
 
         results[1].wait()
         assert job2.status == JobStatus.SUCCESSFUL
-        assert job2.calls[1][1] > job1.calls[2][1]
+        assert job2.calls[1][1] >= job1.calls[2][1]
 
     def test_ok_waits_on_results_and_checks_status(self):
         # Given job and a copy

--- a/unit_tests/test_basejob.py
+++ b/unit_tests/test_basejob.py
@@ -1,0 +1,258 @@
+import pytest
+import uuid
+from unittest.mock import patch
+from datetime import datetime
+
+from scm.plams.core.settings import Settings
+from scm.plams.core.basejob import SingleJob
+from scm.plams.core.errors import PlamsError, FileError
+from scm.plams.core.jobrunner import JobRunner
+from scm.plams.core.functions import add_to_instance
+from scm.plams.core.enums import JobStatus
+
+
+class DummySingleJob(SingleJob):
+    """
+    Single Job for testing.
+    By default, creates an input file with a unique id of the form: 'Dummy input <id>'.
+    When the job is run, creates an output file with the contents: 'Dummy output <id>'.
+    There is also an option to add an arbitrary wait period before the job runs to simulate a longer-running calculation.
+    """
+
+    def __init__(self, inp=None, cmd=None, wait=0.0, **kwargs):
+        super().__init__(**kwargs)
+        self.calls = []
+        self.id = uuid.uuid4()  # Ensure input unique
+        self.input = f"Dummy input {self.id}" if inp is None else inp
+        self.command = "sed 's/input/output/g'" if cmd is None else cmd
+        self.wait = wait
+
+    def prerun(self):
+        self.calls.append((self.prerun.__name__, datetime.now()))
+
+    def postrun(self):
+        self.calls.append((self.postrun.__name__, datetime.now()))
+
+    def get_input(self):
+        return self.input
+
+    def get_runscript(self):
+        self.calls.append((self.get_runscript.__name__, datetime.now()))
+        return f"sleep {self.wait} && {self.command} {self._filename('inp')}"
+
+    def check(self):
+        x = self.results.read_file(self._filename("err"))
+        return x == ""
+
+
+class TestSingleJob:
+    """
+    Test suite for the Single Job.
+    Not truly independent as relies upon the job runner/manager and results components.
+    But this suite focuses on testing the methods on the job class itself.
+    """
+
+    def test_full_runscript_applies_pre_and_post_runscript_settings(self):
+        # Given runscript settings
+        s = Settings()
+        s.runscript.shebang = "#!/bin/sh"
+        s.runscript.pre = "# Add pre line"
+        s.runscript.post = "\n# Add post line"
+
+        # When get the runscript from the job
+        job = DummySingleJob(settings=s)
+        runscript = job.full_runscript()
+
+        # Then the script is composed as expected
+        assert (
+            runscript
+            == """#!/bin/sh
+
+# Add pre line
+
+sleep 0.0 && sed 's/input/output/g' plamsjob.in
+# Add post line
+
+""".replace(
+                "\r\n", "\n"
+            )
+        )
+
+    def test_run_wrapped_in_pre_and_postrun(self):
+        # When run a job
+        job = DummySingleJob()
+        job.run()
+
+        # Then makes calls to pre- and post-run
+        assert [c for c, _ in job.calls] == ["prerun", "get_runscript", "postrun"]
+
+    def test_run_writes_output_file_on_success(self):
+        # When run a successful job
+        job = DummySingleJob()
+        results = job.run()
+
+        # Then job check passes and output file written
+        assert job.check()
+        assert results.read_file("$JN.in") == f"Dummy input {job.id}"
+        assert results.read_file("$JN.out") == f"Dummy output {job.id}"
+        assert results.read_file("$JN.err") == ""
+
+    def test_run_writes_error_file_on_failure(self):
+        # When run an erroring job
+        job = DummySingleJob(cmd="not_a_cmd")
+        results = job.run()
+
+        # Then job check fails and error file written
+        assert not job.check()
+        assert results.read_file("$JN.in") == f"Dummy input {job.id}"
+        assert results.read_file("$JN.out") == ""
+        assert results.read_file("$JN.err") != ""
+
+    @pytest.mark.parametrize(
+        "mode,expected",
+        [
+            [None, {(1, 1): None, (1, 2): None, (1, 3): None, (2, 2): None, (2, 3): None, (3, 3): None}],
+            ["input", {(1, 1): True, (1, 2): False, (1, 3): True, (2, 2): True, (2, 3): False, (3, 3): True}],
+            ["runscript", {(1, 1): True, (1, 2): True, (1, 3): False, (2, 2): True, (2, 3): False, (3, 3): True}],
+            [
+                "input+runscript",
+                {(1, 1): True, (1, 2): False, (1, 3): False, (2, 2): True, (2, 3): False, (3, 3): True},
+            ],
+            ["not_a_mode", None],
+        ],
+        ids=["no_hashing", "input_hashing", "runscript_hashing", "both_hashing", "invalid_hashing"],
+    )
+    def test_hash_respects_mode(self, mode, expected, config):
+        # Given jobs with different inputs and/or runscripts
+        with patch("scm.plams.core.basejob.config", config):
+            config.jobmanager.hashing = mode
+            s = Settings()
+            s.runscript.shebang = "#!/bin/sh"
+            job1 = DummySingleJob(settings=s)
+            job2 = DummySingleJob(inp=job1.input.replace("input", "inputx"), settings=s)
+            job3 = DummySingleJob(inp=job1.input, cmd="echo 'foo' && sed 's/input/output/g'", settings=s)
+            jobs = [job1, job2, job3]
+
+            # When call hash with different modes
+            # Then hashes match as expected
+            if expected is None:
+                with pytest.raises(PlamsError):
+                    job1.hash()
+            else:
+                hashes = [
+                    (i + 1, j + 1, job_i.hash(), job_j.hash())
+                    for i, job_i in enumerate(jobs)
+                    for j, job_j in enumerate(jobs)
+                    if j >= i
+                ]
+                matches = {(i, j): None if h_i is None and h_j is None else h_i == h_j for i, j, h_i, h_j in hashes}
+                assert matches == expected
+
+    def test_run_multiple_independent_jobs_in_parallel(self):
+        # Given parallel job runner
+        runner = JobRunner(parallel=True, maxjobs=2)
+
+        # When set up two jobs with no dependencies
+        job1 = DummySingleJob(wait=0.2)
+        job2 = DummySingleJob(wait=0.01)
+        results = [job1.run(runner), job2.run(runner)]
+
+        # Then both run in parallel
+        # Shorter job finishes first even though started second
+        # Pre-run call of second job is made before post-run call of first job
+        results[1].wait()
+        assert job2.status == JobStatus.SUCCESSFUL
+        assert job1.status == JobStatus.RUNNING
+
+        results[0].wait()
+        assert job1.status == JobStatus.SUCCESSFUL
+        assert job2.calls[0][1] < job1.calls[2][1]
+
+    def test_run_multiple_dependent_jobs_in_serial(self):
+        # Given parallel job runner
+        runner = JobRunner(parallel=True, maxjobs=2)
+
+        # When set up two jobs with dependency
+        job1 = DummySingleJob(wait=0.2)
+        job2 = DummySingleJob(wait=0.01, depend=[job1])
+        results = [job1.run(runner), job2.run(runner)]
+
+        # Then run in serial
+        # Second job finishes second even though shorter
+        # Pre-run call of second job is made after post-run call of first job
+        results[0].wait()
+        assert job1.status == JobStatus.SUCCESSFUL
+        assert job2.status in [JobStatus.REGISTERED, JobStatus.STARTED, JobStatus.RUNNING]
+
+        results[1].wait()
+        assert job2.status == JobStatus.SUCCESSFUL
+        assert job2.calls[0][1] > job1.calls[2][1]
+
+    def test_run_multiple_prerun_dependent_jobs_in_serial(self):
+        # Given parallel job runner
+        runner = JobRunner(parallel=True, maxjobs=2)
+
+        # When set up two jobs with dependency via prerun
+        job1 = DummySingleJob(wait=0.2)
+        job2 = DummySingleJob(wait=0.01)
+
+        @add_to_instance(job2)
+        def prerun(s):
+            s.calls.append((s.prerun.__name__, datetime.now()))
+            job1.results.wait()
+
+        results = [job1.run(runner), job2.run(runner)]
+
+        # Then run in serial
+        # Second job finishes second even though shorter
+        # Get runscript call of second job is made after post-run call of first job
+        results[0].wait()
+        assert job1.status == JobStatus.SUCCESSFUL
+        assert job2.status in [JobStatus.REGISTERED, JobStatus.STARTED, JobStatus.RUNNING]
+
+        results[1].wait()
+        assert job2.status == JobStatus.SUCCESSFUL
+        assert job2.calls[1][1] > job1.calls[2][1]
+
+    def test_ok_waits_on_results_and_checks_status(self):
+        # Given job and a copy
+        job1 = DummySingleJob(wait=0.1)
+        job2 = DummySingleJob(inp=job1.input)
+        job3 = DummySingleJob(cmd="not_a_cmd")
+
+        # Then not ok before being started
+        assert not job1.ok()
+
+        # When call run and check ok
+        job1.run()
+        job2.run()
+        job3.run()
+
+        # Then waits for job to finish and checks status
+        assert job1.ok()
+        assert job1.status == JobStatus.SUCCESSFUL
+        assert job2.ok()
+        assert job2.status == JobStatus.COPIED
+        assert not job3.ok()
+        assert job3.status == JobStatus.CRASHED
+
+    def test_load_non_existent_job_errors(self):
+        # Given path that does not point to a job
+        # When call load, then gives error
+        with pytest.raises(FileError):
+            DummySingleJob.load("not_a_path")
+
+    def test_load_previously_run_job_succeeds(self):
+        # Given successful previously run job
+        job1 = DummySingleJob()
+        job1.run()
+
+        # When call load
+        job2 = DummySingleJob.load(job1.path)
+
+        # Then job loaded successfully
+        assert job1.name == job2.name
+        assert job1.id == job2.id
+        assert job1.path == job2.path
+        assert job1.settings == job2.settings
+        assert job1._filenames == job2._filenames

--- a/unit_tests/test_basejob.py
+++ b/unit_tests/test_basejob.py
@@ -23,7 +23,7 @@ class DummySingleJob(SingleJob):
         super().__init__(**kwargs)
         self.calls = []
         self.id = uuid.uuid4()  # Ensure input unique
-        self.input = f"Dummy input {self.id}" if inp is None else inp
+        self.input = f"Dummy input {self.id}" if inp is None else inp.replace("%ID%", str(self.id))
         self.command = "sed 's/input/output/g'" if cmd is None else cmd
         self.wait = wait
 

--- a/unit_tests/test_enums.py
+++ b/unit_tests/test_enums.py
@@ -1,0 +1,22 @@
+import pytest
+
+from scm.plams.core.enums import JobStatus
+
+
+class TestStrEnum:
+    """
+    Check compatibility between Python 3.11 StrEnum and backwards compatible custom version
+    """
+
+    @pytest.mark.parametrize("value,expected", [("foo", None), ("created", JobStatus.CREATED), ("cREated", None)])
+    def test_ctor(self, value, expected):
+        if expected is None:
+            with pytest.raises(ValueError):
+                JobStatus(value)
+        else:
+            assert JobStatus(value) == expected
+
+    def test_str_operations(self):
+        assert JobStatus.CREATED == "created"
+        assert JobStatus.CREATED != "CREATED"
+        assert f"status={JobStatus.CREATED}" == "status=created"

--- a/unit_tests/test_results.py
+++ b/unit_tests/test_results.py
@@ -1,0 +1,130 @@
+import pytest
+
+from scm.plams.unit_tests.test_basejob import DummySingleJob
+from scm.plams.core.errors import ResultsError
+
+
+class TestResults:
+    """
+    Test suite for the Results class.
+    Not truly independent as relies upon the job runner/manager and results components.
+    But this suite focuses on testing the methods on the results class itself.
+    """
+
+    @pytest.fixture(scope="class")
+    def dummy_job(self):
+        """
+        Simple dummy single job.
+        """
+        job = DummySingleJob(name="test_results", inp="# Start\nDummy input %ID%\n# End")
+        job.run()
+        return job
+
+    def test_files_after_run_as_expected(self, dummy_job):
+        # Given results, when get files, then all files (except .dill) are available on the results class
+        assert set(dummy_job.results.files) == {
+            "test_results.out",
+            "test_results.in",
+            "test_results.err",
+            "test_results.run",
+        }
+
+    def test_get_item_returns_file_path(self, dummy_job):
+        # Given results, when get item with file name, then returns full file path
+        assert dummy_job.results["test_results.in"] == f"{dummy_job.path}/test_results.in"
+        assert dummy_job.results["$JN.out"] == f"{dummy_job.path}/test_results.out"
+
+    def test_rename_updates_files(self):
+        # Given results
+        job = DummySingleJob(name="test_results_rename")
+        results = job.run()
+
+        # When rename files
+        results.rename("test_results_rename.in", "new_test_results_rename.in")
+        results.rename("$JN.out", "new_$JN.out")
+
+        # Then name change applied
+        assert set(results.files) == {
+            "test_results_rename.run",
+            "test_results_rename.err",
+            "new_test_results_rename.in",
+            "new_test_results_rename.out",
+        }
+
+    @pytest.mark.parametrize(
+        "pattern,options,expected_match",
+        [
+            ("output", "", True),
+            ("input", "", False),
+            ("#", "-v", True),
+        ],
+    )
+    def test_grep_file_as_expected(self, dummy_job, pattern, options, expected_match):
+        # Given results, when grep output file, then get expected line matches
+        grep_file = dummy_job.results.grep_file("$JN.out", pattern, options)
+        grep_output = dummy_job.results.grep_output(pattern, options)
+
+        if expected_match:
+            assert grep_file == grep_output == [f"Dummy output {dummy_job.id}"]
+        else:
+            assert grep_file == grep_output == []
+
+    def test_read_file_as_expected(self, dummy_job):
+        # Given results, when read output file, then get expected content
+        assert (
+            dummy_job.results.read_file("$JN.out").replace("\r\n", "\n")
+            == f"# Start\nDummy output {dummy_job.id}\n# End"
+        )
+        with pytest.raises(ResultsError):
+            dummy_job.results.read_file("$JN.foo")
+
+    def test_regex_file_as_expected(self, dummy_job):
+        # Given results, when regex output file, then get expected matches
+        assert dummy_job.results.regex_file(
+            "$JN.out", "[0-9a-f]{8}-[a-f0-9]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}"
+        ) == [str(dummy_job.id)]
+        assert dummy_job.results.regex_file("$JN.out", "u[a-z]{1}") == ["um", "ut", "ut"]
+
+    def test_awk_file_as_expected(self, dummy_job):
+        # Given results, when awk output file, then get expected content
+        assert dummy_job.results.awk_file("$JN.out", script="{print $3}") == ["", str(dummy_job.id), ""]
+        assert dummy_job.results.awk_output(script="{print $3}") == ["", str(dummy_job.id), ""]
+
+    def test_get_file_chunk_as_expected(self, dummy_job):
+        # Given results, when get file chunk, then file chunk as expected
+        assert dummy_job.results.get_file_chunk("$JN.out") == [
+            "# Start",
+            f"Dummy output {dummy_job.id}",
+            "# End",
+        ]
+        assert dummy_job.results.get_file_chunk("$JN.out", begin="# Start") == [
+            f"Dummy output {dummy_job.id}",
+            "# End",
+        ]
+        assert dummy_job.results.get_file_chunk("$JN.out", end="# End") == ["# Start", f"Dummy output {dummy_job.id}"]
+        assert dummy_job.results.get_file_chunk(
+            "$JN.out",
+            begin="# Start",
+            end="# End",
+            inc_begin=True,
+            inc_end=True,
+            process=lambda s: s.upper() if "#" in s else s,
+        ) == ["# START", f"Dummy output {dummy_job.id}", "# END"]
+
+        assert dummy_job.results.get_output_chunk() == [
+            "# Start",
+            f"Dummy output {dummy_job.id}",
+            "# End",
+        ]
+        assert dummy_job.results.get_output_chunk(begin="# Start") == [
+            f"Dummy output {dummy_job.id}",
+            "# End",
+        ]
+        assert dummy_job.results.get_output_chunk(end="# End") == ["# Start", f"Dummy output {dummy_job.id}"]
+        assert dummy_job.results.get_output_chunk(
+            begin="# Start",
+            end="# End",
+            inc_begin=True,
+            inc_end=True,
+            process=lambda s: s.upper() if "#" in s else s,
+        ) == ["# START", f"Dummy output {dummy_job.id}", "# END"]

--- a/unit_tests/test_results.py
+++ b/unit_tests/test_results.py
@@ -1,4 +1,5 @@
 import pytest
+from pathlib import Path
 
 from scm.plams.unit_tests.test_basejob import DummySingleJob
 from scm.plams.core.errors import ResultsError
@@ -31,8 +32,8 @@ class TestResults:
 
     def test_get_item_returns_file_path(self, dummy_job):
         # Given results, when get item with file name, then returns full file path
-        assert dummy_job.results["test_results.in"] == f"{dummy_job.path}/test_results.in"
-        assert dummy_job.results["$JN.out"] == f"{dummy_job.path}/test_results.out"
+        assert dummy_job.results["test_results.in"] == str(Path(dummy_job.path) / "test_results.in")
+        assert dummy_job.results["$JN.out"] == str(Path(dummy_job.path) / "test_results.out")
 
     def test_rename_updates_files(self):
         # Given results


### PR DESCRIPTION
# Description

Add tests for the `SingleJob` and `Results` classes. In addition include small refactoring.

## Refactorings

There are small refactorings here. Add a `StrEnum` called `JobStatus` to explicitly define the different job status types. This is now used throughout the code. Note this is backwards compatible as string comparisons should all still work as previously.

In addition add type hints to the Job and Result classes

## Bugfix

One small bug fix flagged by tests - `Job.load` did not actually return the loaded job, now it does.

## Tests

Otherwise add tests for the `SingleJob` and `Results` classes. To facilitate this, add a `DummySingleJob` which runs a simple shell command, possibly with a wait. This allows testing of the job file generation and dependencies.