### PR TITLE
Density reb

### DIFF
--- a/interfaces/adfsuite/ams.py
+++ b/interfaces/adfsuite/ams.py
@@ -1732,6 +1732,7 @@ class AMSResults(Results):
         nEntries = self.readrkf("History", "nEntries")
         coords = np.array(self.get_history_property("Coords")).reshape(nEntries, -1, 3)
         coords = coords[start_step:end_step:every]
+        nEntries = len(coords)
 
         axis2index = {"x": 0, "y": 1, "z": 2}
         index = axis2index[axis]

--- a/trajectories/rkffile.py
+++ b/trajectories/rkffile.py
@@ -380,8 +380,9 @@ class RKFTrajectoryFile(TrajectoryFile):
         """
         Extracts a PLAMS molecule object from the RKF file
         """
-        section_dict = self.file_object.read_section("InputMolecule")
-        if len(section_dict) == 0:
+        if "InputMolecule" in self.file_object:
+            section_dict = self.file_object.read_section("InputMolecule")
+        else:
             section_dict = self.file_object.read_section("Molecule")
         plamsmol = Molecule._mol_from_rkf_section(section_dict)
         return plamsmol


### PR DESCRIPTION
Just made two very small changes (unrelated). Mostly testing out this new PLAMS commit procedure.
1. Fixed a bug in AMSResults.get_density_along_axis, which normalized on all frames, instead of the number of frames specified by the user.
2. Fixed a tiny bug in RKFTrajectoryFile.get_plamsmol, where the Molecule section should only be read if the InputMolecules section is not present in the RKF file.