### PR TITLE
Use standard logger in log function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ This changelog is effective from the 2025 releases.
 * Script `generate_example.sh` to generate documentation pages from notebook examples
 * GitHub workflows for CI and publishing to PyPI
 * Build using `pyproject.toml`, addition of extras groups to install optional dependencies
-* `LogManager` and `Logger` to manage log files and console logging
+* `LogManager` and `TextLogger` to manage log files and console logging
 
 ### Changed
 * Functions for optional packages (e.g. RDKit, ASE) are available even when these packages are not installed, but will raise an `MissingOptionalPackageError` when called

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This changelog is effective from the 2025 releases.
 * Script `generate_example.sh` to generate documentation pages from notebook examples
 * GitHub workflows for CI and publishing to PyPI
 * Build using `pyproject.toml`, addition of extras groups to install optional dependencies
+* `LogManager` and `Logger` to manage log files and console logging
 
 ### Changed
 * Functions for optional packages (e.g. RDKit, ASE) are available even when these packages are not installed, but will raise an `MissingOptionalPackageError` when called
@@ -30,6 +31,7 @@ This changelog is effective from the 2025 releases.
 * Supercell and RDKit properties are no longer serialized to AMS input
 * Restructuring of examples and conversion of various examples to notebooks
 * Support for `networkx>=3` and `ase>=3.23`
+* Use standard library logger for `log` function
 
 ### Fixed
 * `Molecule.properties.charge` is a numeric instead of string type when loading molecule from a file

--- a/__init__.py
+++ b/__init__.py
@@ -36,7 +36,7 @@ from scm.plams.core.settings import (
     SafeRunSettings,
     Settings,
 )
-from scm.plams.core.logging import Logger
+from scm.plams.core.logging import Logger, LoggerManager
 from scm.plams.interfaces.adfsuite.ams import AMSJob, AMSResults
 from scm.plams.interfaces.adfsuite.amsanalysis import AMSAnalysisJob, AMSAnalysisResults, convert_to_unicode
 from scm.plams.interfaces.adfsuite.amsworker import AMSWorker, AMSWorkerError, AMSWorkerPool, AMSWorkerResults
@@ -165,6 +165,7 @@ __all__ = [
     "JobManagerSettings",
     "ConfigSettings",
     "Logger",
+    "LoggerManager",
     "SingleJob",
     "MultiJob",
     "JobStatus",

--- a/__init__.py
+++ b/__init__.py
@@ -36,7 +36,7 @@ from scm.plams.core.settings import (
     SafeRunSettings,
     Settings,
 )
-from scm.plams.core.logging import Logger, LogManager
+from scm.plams.core.logging import get_logger, Logger
 from scm.plams.interfaces.adfsuite.ams import AMSJob, AMSResults
 from scm.plams.interfaces.adfsuite.amsanalysis import AMSAnalysisJob, AMSAnalysisResults, convert_to_unicode
 from scm.plams.interfaces.adfsuite.amsworker import AMSWorker, AMSWorkerError, AMSWorkerPool, AMSWorkerResults
@@ -164,8 +164,8 @@ __all__ = [
     "JobSettings",
     "JobManagerSettings",
     "ConfigSettings",
+    "get_logger",
     "Logger",
-    "LogManager",
     "SingleJob",
     "MultiJob",
     "JobStatus",

--- a/__init__.py
+++ b/__init__.py
@@ -36,6 +36,7 @@ from scm.plams.core.settings import (
     SafeRunSettings,
     Settings,
 )
+from scm.plams.core.logging import Logger
 from scm.plams.interfaces.adfsuite.ams import AMSJob, AMSResults
 from scm.plams.interfaces.adfsuite.amsanalysis import AMSAnalysisJob, AMSAnalysisResults, convert_to_unicode
 from scm.plams.interfaces.adfsuite.amsworker import AMSWorker, AMSWorkerError, AMSWorkerPool, AMSWorkerResults
@@ -163,6 +164,7 @@ __all__ = [
     "JobSettings",
     "JobManagerSettings",
     "ConfigSettings",
+    "Logger",
     "SingleJob",
     "MultiJob",
     "JobStatus",

--- a/__init__.py
+++ b/__init__.py
@@ -36,7 +36,7 @@ from scm.plams.core.settings import (
     SafeRunSettings,
     Settings,
 )
-from scm.plams.core.logging import Logger, LoggerManager
+from scm.plams.core.logging import Logger, LogManager
 from scm.plams.interfaces.adfsuite.ams import AMSJob, AMSResults
 from scm.plams.interfaces.adfsuite.amsanalysis import AMSAnalysisJob, AMSAnalysisResults, convert_to_unicode
 from scm.plams.interfaces.adfsuite.amsworker import AMSWorker, AMSWorkerError, AMSWorkerPool, AMSWorkerResults
@@ -165,7 +165,7 @@ __all__ = [
     "JobManagerSettings",
     "ConfigSettings",
     "Logger",
-    "LoggerManager",
+    "LogManager",
     "SingleJob",
     "MultiJob",
     "JobStatus",

--- a/__init__.py
+++ b/__init__.py
@@ -36,7 +36,7 @@ from scm.plams.core.settings import (
     SafeRunSettings,
     Settings,
 )
-from scm.plams.core.logging import get_logger, Logger
+from scm.plams.core.logging import get_logger, TextLogger
 from scm.plams.interfaces.adfsuite.ams import AMSJob, AMSResults
 from scm.plams.interfaces.adfsuite.amsanalysis import AMSAnalysisJob, AMSAnalysisResults, convert_to_unicode
 from scm.plams.interfaces.adfsuite.amsworker import AMSWorker, AMSWorkerError, AMSWorkerPool, AMSWorkerResults
@@ -165,7 +165,7 @@ __all__ = [
     "JobManagerSettings",
     "ConfigSettings",
     "get_logger",
-    "Logger",
+    "TextLogger",
     "SingleJob",
     "MultiJob",
     "JobStatus",

--- a/core/functions.py
+++ b/core/functions.py
@@ -12,7 +12,7 @@ import atexit
 from importlib.util import find_spec
 import functools
 
-from scm.plams.core.logging import LoggerManager
+from scm.plams.core.logging import LogManager
 from scm.plams.core.errors import FileError, MissingOptionalPackageError
 from scm.plams.core.private import retry
 from scm.plams.core.settings import Settings, ConfigSettings
@@ -42,7 +42,7 @@ __all__ = [
 config = ConfigSettings()
 # ===========================================================================
 
-_logger = LoggerManager.get_logger("plams")
+_logger = LogManager.get_logger("plams")
 
 
 def log(message: str, level: int = 0) -> None:
@@ -51,16 +51,11 @@ def log(message: str, level: int = 0) -> None:
     Logs are printed independently to the text logfile (a file called ``logfile`` in the main working folder) and to the standard output. If *level* is equal or lower than verbosity (defined by ``config.log.file`` or ``config.log.stdout``) the message is printed. Date and/or time can be added based on ``config.log.date`` and ``config.log.time``. All logging activity is thread safe.
     """
     if config.init and "log" in config:
-        _logger.configure_stdout(config.log.stdout)
         logfile = config.default_jobmanager.logfile if config["default_jobmanager"] is not None else None
-        _logger.configure_logfile(logfile, config.log.file)
-        _logger.configure_formatter(config.log.date, config.log.time)
+        _logger.configure(config.log.stdout, config.log.file, logfile, config.log.date, config.log.time)
     else:
         # log() is called before plams.init() was called ...
-        _logger.configure_stdout(3)
-        _logger.configure_logfile(None)
-        _logger.configure_formatter(False, False)
-
+        _logger.configure(3)
     _logger.log(message, level)
 
 

--- a/core/functions.py
+++ b/core/functions.py
@@ -245,6 +245,8 @@ def _finish():
     if not config.init:
         return
 
+    _logger.close()
+
     for thread in threading.enumerate():
         if thread.name == "plamsthread":
             thread.join()

--- a/core/functions.py
+++ b/core/functions.py
@@ -12,7 +12,7 @@ import atexit
 from importlib.util import find_spec
 import functools
 
-from scm.plams.core.logging import LogManager
+from scm.plams.core.logging import get_logger
 from scm.plams.core.errors import FileError, MissingOptionalPackageError
 from scm.plams.core.private import retry
 from scm.plams.core.settings import Settings, ConfigSettings
@@ -42,19 +42,24 @@ __all__ = [
 config = ConfigSettings()
 # ===========================================================================
 
-_logger = LogManager.get_logger("plams")
+_logger = get_logger("plams")
 
 
 def log(message: str, level: int = 0) -> None:
-    """Log *message* with verbosity *level*.
+    """
+    Log a *message* with verbosity *level*.
 
-    Logs are printed independently to the text logfile (a file called ``logfile`` in the main working folder) and to the standard output. If *level* is equal or lower than verbosity (defined by ``config.log.file`` or ``config.log.stdout``) the message is printed. Date and/or time can be added based on ``config.log.date`` and ``config.log.time``. All logging activity is thread safe.
+    Logs are printed independently to the text logfile (a file called ``logfile`` in the main working folder) and to the standard output.
+    If *level* is equal or lower than verbosity (defined by ``config.log.file`` or ``config.log.stdout``) the message is printed.
+    By convention in PLAMS, level should be between 0-7, with 0 indicating no loggin and 7 indicating the most verbose logging.
+    Date and/or time can be added based on ``config.log.date`` and ``config.log.time``.
+    All logging activity is thread safe.
     """
     if config.init and "log" in config:
         logfile = config.default_jobmanager.logfile if config["default_jobmanager"] is not None else None
         _logger.configure(config.log.stdout, config.log.file, logfile, config.log.date, config.log.time)
     else:
-        # log() is called before plams.init() was called ...
+        # By default write to stdout with level 3
         _logger.configure(3)
     _logger.log(message, level)
 

--- a/core/functions.py
+++ b/core/functions.py
@@ -4,7 +4,6 @@ import shutil
 import subprocess
 import sys
 import threading
-import time
 import types
 from os.path import dirname, expandvars, isdir, isfile
 from os.path import join as opj
@@ -13,6 +12,7 @@ import atexit
 from importlib.util import find_spec
 import functools
 
+from scm.plams.core.logging import Logger
 from scm.plams.core.errors import FileError, MissingOptionalPackageError
 from scm.plams.core.private import retry
 from scm.plams.core.settings import Settings, ConfigSettings
@@ -42,8 +42,7 @@ __all__ = [
 config = ConfigSettings()
 # ===========================================================================
 
-_stdlock = threading.Lock()
-_filelock = threading.Lock()
+_logger = Logger("plams")
 
 
 def log(message: str, level: int = 0) -> None:
@@ -52,29 +51,17 @@ def log(message: str, level: int = 0) -> None:
     Logs are printed independently to the text logfile (a file called ``logfile`` in the main working folder) and to the standard output. If *level* is equal or lower than verbosity (defined by ``config.log.file`` or ``config.log.stdout``) the message is printed. Date and/or time can be added based on ``config.log.date`` and ``config.log.time``. All logging activity is thread safe.
     """
     if config.init and "log" in config:
-        if level <= config.log.file or level <= config.log.stdout:
-            message = str(message)
-            prefix = ""
-            if config.log.date:
-                prefix += "%d.%m|"
-            if config.log.time:
-                prefix += "%H:%M:%S"
-            if prefix:
-                prefix = "[" + prefix.rstrip("|") + "] "
-                message = time.strftime(prefix) + message
-            if level <= config.log.stdout:
-                with _stdlock:
-                    print(message)
-            if level <= config.log.file and config["default_jobmanager"] is not None:
-                try:
-                    with _filelock, open(config.default_jobmanager.logfile, "a") as f:
-                        f.write(message + "\n")
-                except FileNotFoundError:
-                    pass
-    elif level <= 3:
+        _logger.configure_stdout(config.log.stdout)
+        logfile = config.default_jobmanager.logfile if config["default_jobmanager"] is not None else None
+        _logger.configure_logfile(logfile, config.log.file)
+        _logger.configure_formatter(config.log.date, config.log.time)
+    else:
         # log() is called before plams.init() was called ...
-        with _stdlock:
-            print(message)
+        _logger.configure_stdout(3)
+        _logger.configure_logfile(None)
+        _logger.configure_formatter(False, False)
+
+    _logger.log(message, level)
 
 
 # ===========================================================================

--- a/core/functions.py
+++ b/core/functions.py
@@ -245,8 +245,6 @@ def _finish():
     if not config.init:
         return
 
-    _logger.close()
-
     for thread in threading.enumerate():
         if thread.name == "plamsthread":
             thread.join()
@@ -257,6 +255,16 @@ def _finish():
         config.default_jobmanager._clean()
 
         if config.erase_workdir is True:
+            from scm.plams.core.logging import LogManager
+
+            # Close all loggers which have files in the directory to be erased
+            workdir = os.path.abspath(config.default_jobmanager.workdir)
+            for logger in LogManager._loggers.values():
+                if logger._file_handler is not None:
+                    logfile = os.path.abspath(logger._file_handler.baseFilename)
+                    if os.path.commonpath([workdir]) == os.path.commonpath([workdir, logfile]):
+                        logger.close()
+
             shutil.rmtree(config.default_jobmanager.workdir)
 
     config.init = False

--- a/core/functions.py
+++ b/core/functions.py
@@ -12,7 +12,7 @@ import atexit
 from importlib.util import find_spec
 import functools
 
-from scm.plams.core.logging import Logger
+from scm.plams.core.logging import LoggerManager
 from scm.plams.core.errors import FileError, MissingOptionalPackageError
 from scm.plams.core.private import retry
 from scm.plams.core.settings import Settings, ConfigSettings
@@ -42,7 +42,7 @@ __all__ = [
 config = ConfigSettings()
 # ===========================================================================
 
-_logger = Logger("plams")
+_logger = LoggerManager.get_logger("plams")
 
 
 def log(message: str, level: int = 0) -> None:

--- a/core/logging.py
+++ b/core/logging.py
@@ -97,6 +97,7 @@ class Logger:
                 self._logger.removeHandler(self._file_handler)
                 self._file_handler.flush()
                 self._file_handler.close()
+                self._file_handler = None
 
             # Add new file handler if required
             if logfile_path is not None and (

--- a/core/logging.py
+++ b/core/logging.py
@@ -1,20 +1,22 @@
 import logging
 import sys
-from typing import Optional, Dict
+from typing import Optional, Dict, Literal, Any
 import threading
+from abc import ABC, abstractmethod
 
 
-from scm.plams.core.errors import FileError
+from scm.plams.core.errors import FileError, PlamsError
 
-__all__ = ["get_logger", "Logger"]
+__all__ = ["get_logger", "TextLogger"]
 
 
-def get_logger(name: str) -> "Logger":
+def get_logger(name: str, fmt: Optional[Literal["txt"]] = None) -> "Logger":
     """
     Get a logger with the specified name.
     If there is an existing logger with the same name this is returned, otherwise a new logger is created.
+    If no format is specified, the logger will be a simple ``TextLogger``.
     """
-    return LogManager.get_logger(name)
+    return LogManager.get_logger(name, fmt)
 
 
 class LogManager:
@@ -29,17 +31,21 @@ class LogManager:
         raise TypeError("LoggerManager cannot be directly instantiated.")
 
     @classmethod
-    def get_logger(cls, name: str) -> "Logger":
+    def get_logger(cls, name: str, fmt: Optional[Literal["txt"]] = None) -> "Logger":
         """
         Get a logger with the specified name.
         If there is an existing logger with the same name this is returned, otherwise a new logger is created.
         """
         if name not in cls._loggers:
-            cls._loggers[name] = Logger(name)
+            if fmt == "txt" or fmt is None:
+                logger = TextLogger(name)
+            else:
+                raise PlamsError(f"Cannot create logger '{name}' with format '{fmt}'")
+            cls._loggers[name] = logger
         return cls._loggers[name]
 
 
-class Logger:
+class Logger(ABC):
     """
     Wrapper around default logger, which handles logging to stdout and a text logfile depending on the options in the
     global logging config.
@@ -51,9 +57,124 @@ class Logger:
         """
         self._logger = logging.Logger(name)
         self._stdout_handler: Optional[logging.StreamHandler] = None
+        self._stdout_formatter: Optional[logging.Formatter] = None
         self._file_handler: Optional[logging.FileHandler] = None
-        self._formatter: Optional[logging.Formatter] = None
+        self._file_formatter: Optional[logging.Formatter] = None
         self._lock = threading.Lock()
+
+    @abstractmethod
+    def configure(
+        self,
+        stdout_level: int = 0,
+        logfile_level: int = 0,
+        logfile_path: Optional[str] = None,
+        *args,
+        **kwargs,
+    ) -> None:
+        """
+        Configure logging to stdout and the logfile, and its formatting.
+
+        For backwards compatibility, the logging level is between 0-7, with 0 indicating no logging and 7 the most verbose logging.
+        Note that this is only a PLAMS logging level, it will be mapped to a level between INFO and WARNING for the
+        standard python logger.
+
+        The logfile path must be unique across all loggers, otherwise a |FileError| is raised. If set to None this will disable file logging.
+        """
+        pass
+
+    def _configure_stdout_handler(self, level: int):
+        """
+        Configure the stdout handler, initializing and adjusting the level if required
+        """
+
+        # Initialise the stdout handler if not already done so
+        if self._stdout_handler is None:
+            self._stdout_handler = logging.StreamHandler(sys.stdout)
+            self._stdout_handler.setFormatter(self._stdout_formatter)
+            self._logger.addHandler(self._stdout_handler)
+
+        # Update the logfile handler level if required
+        if level != 28 - self._stdout_handler.level:
+            self._stdout_handler.setLevel(28 - level)
+
+    def _configure_file_handler(self, level: int, logfile_path: Optional[str]):
+        """
+        Configure the file handler, setting the logfile and adjusting the level if required
+        """
+
+        # Remove and close existing file handler if present and required
+        if self._file_handler is not None and (logfile_path is None or logfile_path != self._file_handler.baseFilename):
+            self._remove_handler(self._file_handler)
+            self._file_handler = None
+
+        # Add new file handler if required
+        if logfile_path is not None and (self._file_handler is None or logfile_path != self._file_handler.baseFilename):
+            # Check logfile is not already in use by another logger
+            # This will cause permission errors on Windows and generally is not a good idea
+            for name, logger in LogManager._loggers.items():
+                if logger._file_handler is not None and logger._file_handler.baseFilename == logfile_path:
+                    raise FileError(f"Logger '{name}' already exists with logfile path '{logfile_path}'")
+
+            self._file_handler = logging.FileHandler(logfile_path)
+            self._file_handler.setFormatter(self._file_formatter)
+            self._logger.addHandler(self._file_handler)
+
+        # Update the logfile handler level if required
+        if self._file_handler is not None:
+            self._file_handler.setLevel(28 - level)
+
+    def _configure_stdout_formatter(self, formatter: logging.Formatter) -> None:
+        """
+        Configure the formatter for the stdout handler
+        """
+        self._stdout_formatter = formatter
+        if self._stdout_handler is not None:
+            self._stdout_handler.setFormatter(self._stdout_formatter)
+
+    def _configure_file_formatter(self, formatter: logging.Formatter) -> None:
+        """
+        Configure the formatter for the file handler
+        """
+        self._file_formatter = formatter
+        if self._file_handler is not None:
+            self._file_handler.setFormatter(self._file_formatter)
+
+    def _remove_handler(self, handler: Optional[logging.Handler]) -> None:
+        """
+        Flush logs, close the handler and remove it from the logger.
+        """
+        if handler is not None:
+            self._logger.removeHandler(handler)
+            try:
+                handler.flush()
+            except ValueError:
+                pass  # Already closed
+            handler.close()
+
+    def close(self) -> None:
+        """
+        Flush logs to stdout and logfile, then close the resources.
+        No further logs will then be written.
+        """
+        with self._lock:
+            self._remove_handler(self._file_handler)
+            self._remove_handler(self._stdout_handler)
+            self._file_handler = None
+            self._stdout_handler = None
+
+    @abstractmethod
+    def log(self, message: Any, level: int) -> None:
+        """
+        Log a message with the given level of verbosity.
+        """
+        pass
+
+
+class TextLogger(Logger):
+    """
+    Wrapper around default logger, which handles simple text logging to stdout and a text logfile depending on the options in the
+    global logging config.
+    """
 
     def configure(
         self,
@@ -80,42 +201,10 @@ class Logger:
         """
         with self._lock:
 
-            # Initialise the stdout handler once
-            if self._stdout_handler is None:
-                self._stdout_handler = logging.StreamHandler(sys.stdout)
-                self._stdout_handler.setFormatter(self._formatter)
-                self._logger.addHandler(self._stdout_handler)
+            self._configure_stdout_handler(stdout_level)
+            self._configure_file_handler(logfile_level, logfile_path)
 
-            # Update the stdout handler level if required
-            if stdout_level != 28 - self._stdout_handler.level:
-                self._stdout_handler.setLevel(28 - stdout_level)
-
-            # Remove and close existing file handler if present and required
-            if self._file_handler is not None and (
-                logfile_path is None or logfile_path != self._file_handler.baseFilename
-            ):
-                self._remove_handler(self._file_handler)
-                self._file_handler = None
-
-            # Add new file handler if required
-            if logfile_path is not None and (
-                self._file_handler is None or logfile_path != self._file_handler.baseFilename
-            ):
-                # Check logfile is not already in use by another logger
-                # This will cause permission errors on Windows and generally is not a good idea
-                for name, logger in LogManager._loggers.items():
-                    if logger._file_handler is not None and logger._file_handler.baseFilename == logfile_path:
-                        raise FileError(f"Logger '{name}' already exists with logfile path '{logfile_path}'")
-
-                self._file_handler = logging.FileHandler(logfile_path)
-                self._file_handler.setFormatter(self._formatter)
-                self._logger.addHandler(self._file_handler)
-
-            # Update the logfile handler level if required
-            if self._file_handler is not None:
-                self._file_handler.setLevel(28 - logfile_level)
-
-            # Configure the formatter if required
+            # Configure formatter if required
             datefmt = None
             if include_date and include_time:
                 datefmt = "[%d.%m|%H:%M:%S]"
@@ -123,34 +212,13 @@ class Logger:
                 datefmt = "[%d.%m]"
             elif include_time:
                 datefmt = "[%H:%M:%S]"
+            fmt = "%(asctime)s %(message)s" if datefmt is not None else None
 
-            if self._formatter is None or datefmt != self._formatter.datefmt:
-                fmt = "%(asctime)s %(message)s" if datefmt is not None else None
-                self._formatter = logging.Formatter(fmt, datefmt=datefmt)
-                if self._stdout_handler is not None:
-                    self._stdout_handler.setFormatter(self._formatter)
-                if self._file_handler is not None:
-                    self._file_handler.setFormatter(self._formatter)
+            if self._stdout_formatter is None or datefmt != self._stdout_formatter.datefmt:
+                self._configure_stdout_formatter(logging.Formatter(fmt, datefmt=datefmt))
 
-    def _remove_handler(self, handler: Optional[logging.Handler]) -> None:
-        """
-        Flush logs, close the handler and remove it from the logger.
-        """
-        if handler is not None:
-            handler.flush()
-            self._logger.removeHandler(handler)
-            handler.close()
-
-    def close(self) -> None:
-        """
-        Flush logs to stdout and logfile, then close the resources.
-        No further logs will then be written.
-        """
-        with self._lock:
-            self._remove_handler(self._file_handler)
-            self._remove_handler(self._stdout_handler)
-            self._file_handler = None
-            self._stdout_handler = None
+            if self._file_formatter is None or datefmt != self._file_formatter.datefmt:
+                self._configure_file_formatter(logging.Formatter(fmt, datefmt=datefmt))
 
     def log(self, message: str, level: int) -> None:
         """

--- a/core/logging.py
+++ b/core/logging.py
@@ -87,7 +87,7 @@ class Logger:
                 self._logger.addHandler(self._stdout_handler)
 
             # Update the stdout handler level if required
-            if stdout_level != self._stdout_handler.level:
+            if stdout_level != 28 - self._stdout_handler.level:
                 self._stdout_handler.setLevel(28 - stdout_level)
 
             # Remove and close existing file handler if present and required

--- a/core/logging.py
+++ b/core/logging.py
@@ -1,0 +1,88 @@
+import logging
+import sys
+from typing import Optional
+
+__all__ = ["Logger"]
+
+
+class Logger:
+    """
+    Wrapper around default logger, which handles logging to stdout and a text logfile depending on the options in the
+    global logging config.
+    """
+
+    def __init__(self, name: str):
+        """
+        Set up logger with given name.
+        """
+        self._logger = logging.Logger(name)
+        self._stdout_handler: Optional[logging.StreamHandler] = None
+        self._file_handler: Optional[logging.FileHandler] = None
+        self._formatter: Optional[logging.Formatter] = None
+
+    def configure_stdout(self, level: int) -> None:
+        """
+        Configure the logging to stdout.
+
+        Note that for backwards compatibility, level is between 0-7, with 0 indicating no logging and 7 the most verbose logging.
+        Note that this is only a PLAMS logging level, it will be mapped to a level between INFO and WARNING for the
+        python logger.
+        """
+        if self._stdout_handler is None:
+            self._stdout_handler = logging.StreamHandler(sys.stdout)
+            self._stdout_handler.setFormatter(self._formatter)
+            self._logger.addHandler(self._stdout_handler)
+
+        if level != self._stdout_handler.level:
+            self._stdout_handler.setLevel(28 - level)
+
+    def configure_logfile(self, path: Optional[str], level: int = 0) -> None:
+        """
+        Configure the logging to a logfile.
+
+        Path is the file path for the logfile. If set to None this will remove file logging.
+
+        For backwards compatibility, level is between 0-7, with 0 indicating no logging and 7 the most verbose logging.
+        Note that this is only a PLAMS logging level, it will be mapped to a level between INFO and WARNING for the
+        python logger.
+        """
+        # Remove and close existing file handler if present and required
+        if self._file_handler is not None and (path is None or path != self._file_handler.baseFilename):
+            self._logger.removeHandler(self._file_handler)
+            self._file_handler.close()
+
+        # Add new file handler if required
+        if path is not None and (self._file_handler is None or path != self._file_handler.baseFilename):
+            self._file_handler = logging.FileHandler(path)
+            self._file_handler.setFormatter(self._formatter)
+            self._logger.addHandler(self._file_handler)
+
+        if self._file_handler is not None:
+            self._file_handler.setLevel(28 - level)
+
+    def configure_formatter(self, include_date: bool, include_time: bool) -> None:
+        """
+        Configure the formatting of the logging both to stdout and to the logfile.
+        Choose whether to begin the logline with a date and/or time stamp.
+        """
+        datefmt = None
+        if include_date and include_time:
+            datefmt = "[%d.%m|%H:%M:%S]"
+        elif include_date:
+            datefmt = "[%d.%m]"
+        elif include_time:
+            datefmt = "[%H:%M:%S]"
+
+        if self._formatter is None or datefmt != self._formatter.datefmt:
+            fmt = "%(asctime)s %(message)s" if datefmt is not None else None
+            self._formatter = logging.Formatter(fmt, datefmt=datefmt)
+            if self._stdout_handler is not None:
+                self._stdout_handler.setFormatter(self._formatter)
+            if self._file_handler is not None:
+                self._file_handler.setFormatter(self._formatter)
+
+    def log(self, message: str, level: int) -> None:
+        """
+        Log a message with the given level of verbosity.
+        """
+        self._logger.log(28 - level, message)

--- a/core/logging.py
+++ b/core/logging.py
@@ -94,9 +94,7 @@ class Logger:
             if self._file_handler is not None and (
                 logfile_path is None or logfile_path != self._file_handler.baseFilename
             ):
-                self._logger.removeHandler(self._file_handler)
-                self._file_handler.flush()
-                self._file_handler.close()
+                self._remove_handler(self._file_handler)
                 self._file_handler = None
 
             # Add new file handler if required
@@ -133,6 +131,26 @@ class Logger:
                     self._stdout_handler.setFormatter(self._formatter)
                 if self._file_handler is not None:
                     self._file_handler.setFormatter(self._formatter)
+
+    def _remove_handler(self, handler: Optional[logging.Handler]) -> None:
+        """
+        Flush logs, close the handler and remove it from the logger.
+        """
+        if handler is not None:
+            handler.flush()
+            self._logger.removeHandler(handler)
+            handler.close()
+
+    def close(self) -> None:
+        """
+        Flush logs to stdout and logfile, then close the resources.
+        No further logs will then be written.
+        """
+        with self._lock:
+            self._remove_handler(self._file_handler)
+            self._remove_handler(self._stdout_handler)
+            self._file_handler = None
+            self._stdout_handler = None
 
     def log(self, message: str, level: int) -> None:
         """

--- a/core/logging.py
+++ b/core/logging.py
@@ -6,7 +6,15 @@ import threading
 
 from scm.plams.core.errors import FileError
 
-__all__ = ["Logger", "LogManager"]
+__all__ = ["get_logger", "Logger"]
+
+
+def get_logger(name: str) -> "Logger":
+    """
+    Get a logger with the specified name.
+    If there is an existing logger with the same name this is returned, otherwise a new logger is created.
+    """
+    return LogManager.get_logger(name)
 
 
 class LogManager:
@@ -24,7 +32,7 @@ class LogManager:
     def get_logger(cls, name: str) -> "Logger":
         """
         Get a logger with the specified name.
-        If there is an existing logger with the same name this is returned, otherwise the logger is created.
+        If there is an existing logger with the same name this is returned, otherwise a new logger is created.
         """
         if name not in cls._loggers:
             cls._loggers[name] = Logger(name)

--- a/core/logging.py
+++ b/core/logging.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 from typing import Optional
+import threading
 
 
 from scm.plams.core.errors import FileError
@@ -44,6 +45,7 @@ class Logger:
         self._stdout_handler: Optional[logging.StreamHandler] = None
         self._file_handler: Optional[logging.FileHandler] = None
         self._formatter: Optional[logging.Formatter] = None
+        self._lock = threading.Lock()
 
     def configure_stdout(self, level: int) -> None:
         """
@@ -53,13 +55,14 @@ class Logger:
         Note that this is only a PLAMS logging level, it will be mapped to a level between INFO and WARNING for the
         python logger.
         """
-        if self._stdout_handler is None:
-            self._stdout_handler = logging.StreamHandler(sys.stdout)
-            self._stdout_handler.setFormatter(self._formatter)
-            self._logger.addHandler(self._stdout_handler)
+        with self._lock:
+            if self._stdout_handler is None:
+                self._stdout_handler = logging.StreamHandler(sys.stdout)
+                self._stdout_handler.setFormatter(self._formatter)
+                self._logger.addHandler(self._stdout_handler)
 
-        if level != self._stdout_handler.level:
-            self._stdout_handler.setLevel(28 - level)
+            if level != self._stdout_handler.level:
+                self._stdout_handler.setLevel(28 - level)
 
     def configure_logfile(self, path: Optional[str], level: int = 0) -> None:
         """
@@ -72,25 +75,27 @@ class Logger:
         Note that this is only a PLAMS logging level, it will be mapped to a level between INFO and WARNING for the
         python logger.
         """
-        # Remove and close existing file handler if present and required
-        if self._file_handler is not None and (path is None or path != self._file_handler.baseFilename):
-            self._logger.removeHandler(self._file_handler)
-            self._file_handler.close()
+        with self._lock:
+            # Remove and close existing file handler if present and required
+            if self._file_handler is not None and (path is None or path != self._file_handler.baseFilename):
+                self._logger.removeHandler(self._file_handler)
+                self._file_handler.flush()
+                self._file_handler.close()
 
-        # Add new file handler if required
-        if path is not None and (self._file_handler is None or path != self._file_handler.baseFilename):
+            # Add new file handler if required
+            if path is not None and (self._file_handler is None or path != self._file_handler.baseFilename):
 
-            # Check logfile is not already in use by another logger
-            for name, logger in LoggerManager._loggers.items():
-                if logger._file_handler is not None and logger._file_handler.baseFilename == path:
-                    raise FileError(f"Logger '{name}' already exists with path '{path}'")
+                # Check logfile is not already in use by another logger
+                for name, logger in LoggerManager._loggers.items():
+                    if logger._file_handler is not None and logger._file_handler.baseFilename == path:
+                        raise FileError(f"Logger '{name}' already exists with path '{path}'")
 
-            self._file_handler = logging.FileHandler(path)
-            self._file_handler.setFormatter(self._formatter)
-            self._logger.addHandler(self._file_handler)
+                self._file_handler = logging.FileHandler(path)
+                self._file_handler.setFormatter(self._formatter)
+                self._logger.addHandler(self._file_handler)
 
-        if self._file_handler is not None:
-            self._file_handler.setLevel(28 - level)
+            if self._file_handler is not None:
+                self._file_handler.setLevel(28 - level)
 
     def configure_formatter(self, include_date: bool, include_time: bool) -> None:
         """
@@ -105,16 +110,21 @@ class Logger:
         elif include_time:
             datefmt = "[%H:%M:%S]"
 
-        if self._formatter is None or datefmt != self._formatter.datefmt:
-            fmt = "%(asctime)s %(message)s" if datefmt is not None else None
-            self._formatter = logging.Formatter(fmt, datefmt=datefmt)
-            if self._stdout_handler is not None:
-                self._stdout_handler.setFormatter(self._formatter)
-            if self._file_handler is not None:
-                self._file_handler.setFormatter(self._formatter)
+        with self._lock:
+            if self._formatter is None or datefmt != self._formatter.datefmt:
+                fmt = "%(asctime)s %(message)s" if datefmt is not None else None
+                self._formatter = logging.Formatter(fmt, datefmt=datefmt)
+                if self._stdout_handler is not None:
+                    self._stdout_handler.setFormatter(self._formatter)
+                if self._file_handler is not None:
+                    self._file_handler.setFormatter(self._formatter)
 
     def log(self, message: str, level: int) -> None:
         """
         Log a message with the given level of verbosity.
         """
-        self._logger.log(28 - level, message)
+        # Shouldn't really have to take a lock here as logging itself is thread-safe
+        # but in the PLAMS log function the logfile can be reconfigured on a per-call basis
+        # which could easily lead to dropped logs if this were multi-threaded.
+        with self._lock:
+            self._logger.log(28 - level, message)

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -30,6 +30,19 @@ def config():
         _finish()
 
 
+@pytest.fixture(autouse=True)
+def logger():
+    """
+    Instead of re-using the same global logger object, patch with a fresh logger instance.
+    """
+    from scm.plams.core.logging import Logger
+
+    logger = Logger("plams")
+
+    with patch("scm.plams.core.functions._logger", logger):
+        yield logger
+
+
 @pytest.fixture
 def xyz_folder():
     """

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -30,19 +30,6 @@ def config():
         _finish()
 
 
-@pytest.fixture(autouse=True)
-def logger():
-    """
-    Instead of re-using the same global logger object, patch with a fresh logger instance.
-    """
-    from scm.plams.core.logging import Logger
-
-    logger = Logger("plams")
-
-    with patch("scm.plams.core.functions._logger", logger):
-        yield logger
-
-
 @pytest.fixture
 def xyz_folder():
     """

--- a/unit_tests/test_amsjob.py
+++ b/unit_tests/test_amsjob.py
@@ -517,43 +517,49 @@ class TestAMSJobRun:
 
     def test_run_with_watch_forwards_ams_logs_to_stdout(self, config):
         # Patch the config and the stdout
+        from scm.plams.core.logging import get_logger
+
         with patch("scm.plams.interfaces.adfsuite.ams.config", config), patch(
             "sys.stdout", new_callable=StringIO
         ) as mock_stdout:
-            config.log.date = False
-            config.log.time = False
+            logger = get_logger("test_run_with_watch_forwards_ams_logs_to_stdout")
+            with patch("scm.plams.core.functions._logger", logger):
+                config.log.date = False
+                config.log.time = False
 
-            # Given a dummy job
-            job = AMSJob()
+                # Given a dummy job
+                job = AMSJob()
 
-            # Which writes logs to logfile periodically on background thread
-            logfile = os.path.join(config.default_jobmanager.workdir, job.name, "ams.log")
+                # Which writes logs to logfile periodically on background thread
+                logfile = os.path.join(config.default_jobmanager.workdir, job.name, "ams.log")
 
-            def write_logs():
-                for i in range(10):
-                    time.sleep(0.01)
-                    try:
-                        with open(logfile, "a") as f:
-                            f.write(f"<Oct21-2024> <09:34:54>  line {i}\n")
-                            f.flush()
-                    except FileNotFoundError:
-                        pass
+                def write_logs():
+                    for i in range(10):
+                        time.sleep(0.01)
+                        try:
+                            with open(logfile, "a") as f:
+                                f.write(f"<Oct21-2024> <09:34:54>  line {i}\n")
+                                f.flush()
+                        except FileNotFoundError:
+                            pass
 
-            background_thread = threading.Thread(target=write_logs)
+                background_thread = threading.Thread(target=write_logs)
 
-            def get_runscript() -> str:
-                background_thread.start()
-                return "sleep 1"
+                def get_runscript() -> str:
+                    background_thread.start()
+                    return "sleep 1"
 
-            job.get_runscript = get_runscript
+                job.get_runscript = get_runscript
 
-            # When run job and watching output
-            job.run(watch=True)
+                # When run job and watching output
+                job.run(watch=True)
 
-            # Then ams logs are also forwarded to the standard output
-            stdout = mock_stdout.getvalue().replace("\r\n", "\n").split("\n")
-            postrun_lines = [l for l in stdout if re.fullmatch("plamsjob: line \d", l)]
-            status_lines = [l for l in stdout if re.fullmatch("JOB plamsjob (STARTED|RUNNING|FINISHED|FAILED)", l)]
+                # Then ams logs are also forwarded to the standard output
+                stdout = mock_stdout.getvalue().replace("\r\n", "\n").split("\n")
+                postrun_lines = [l for l in stdout if re.fullmatch("plamsjob: line \d", l)]
+                status_lines = [l for l in stdout if re.fullmatch("JOB plamsjob (STARTED|RUNNING|FINISHED|FAILED)", l)]
 
-            assert len(postrun_lines) == 10
-            assert len(status_lines) == 4
+                assert len(postrun_lines) == 10
+                assert len(status_lines) == 4
+
+                logger.configure()

--- a/unit_tests/test_amsjob.py
+++ b/unit_tests/test_amsjob.py
@@ -562,4 +562,4 @@ class TestAMSJobRun:
                 assert len(postrun_lines) == 10
                 assert len(status_lines) == 4
 
-                logger.configure()
+                logger.close()

--- a/unit_tests/test_functions.py
+++ b/unit_tests/test_functions.py
@@ -588,9 +588,9 @@ class TestLog:
         """
         Instead of re-using the same global logger object, patch with a fresh logger instance.
         """
-        from scm.plams.core.logging import LoggerManager
+        from scm.plams.core.logging import LogManager
 
-        logger = LoggerManager.get_logger(f"plams-{uuid.uuid4()}")
+        logger = LogManager.get_logger(f"plams-{uuid.uuid4()}")
 
         with patch("scm.plams.core.functions._logger", logger):
             yield logger

--- a/unit_tests/test_functions.py
+++ b/unit_tests/test_functions.py
@@ -605,7 +605,9 @@ log with level 3
 
     def test_log_with_init_writes_message_to_stdout_and_default_jobmanger_file(self, config):
         with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
-            with tempfile.NamedTemporaryFile() as temp_log_file1, tempfile.NamedTemporaryFile() as temp_log_file2:
+            with tempfile.NamedTemporaryFile(
+                dir=".", suffix=".log", mode="r"
+            ) as temp_log_file1, tempfile.NamedTemporaryFile(dir=".", suffix=".log", mode="r") as temp_log_file2:
 
                 # Log to both stdout and file with date and time
                 config.init = True
@@ -648,12 +650,12 @@ log with level 3
                 self.assert_logs(stdout_logs, line_start=9, expected_lines=3, date_expected=True)
 
                 # # File1 has a log for each level up to and including 5
-                file1_logs = temp_log_file1.read().decode()
+                file1_logs = temp_log_file1.read()
                 self.assert_logs(file1_logs, line_end=5, date_expected=True, time_expected=True)
                 self.assert_logs(file1_logs, line_start=5, expected_lines=5)
 
                 # File2 has a log for each level up to and including 4
-                file2_logs = temp_log_file2.read().decode()
+                file2_logs = temp_log_file2.read()
                 self.assert_logs(file2_logs, expected_lines=4, time_expected=True)
 
     def assert_logs(

--- a/unit_tests/test_functions.py
+++ b/unit_tests/test_functions.py
@@ -588,9 +588,9 @@ class TestLog:
         """
         Instead of re-using the same global logger object, patch with a fresh logger instance.
         """
-        from scm.plams.core.logging import LogManager
+        from scm.plams.core.logging import get_logger
 
-        logger = LogManager.get_logger(f"plams-{uuid.uuid4()}")
+        logger = get_logger(f"plams-{uuid.uuid4()}")
 
         with patch("scm.plams.core.functions._logger", logger):
             yield logger

--- a/unit_tests/test_functions.py
+++ b/unit_tests/test_functions.py
@@ -5,6 +5,9 @@ import threading
 import os
 from pathlib import Path
 import inspect
+from io import StringIO
+import tempfile
+import re
 
 from scm.plams.core.functions import (
     _init,
@@ -14,6 +17,7 @@ from scm.plams.core.functions import (
     requires_optional_package,
     add_to_class,
     add_to_instance,
+    log,
 )
 from scm.plams.core.settings import Settings
 from scm.plams.core.errors import MissingOptionalPackageError
@@ -578,3 +582,100 @@ class TestDecorators:
 
         with pytest.raises(MissingOptionalPackageError):
             empty_class.requires_unavailable_package_and_is_added_to_instance()
+
+
+class TestLog:
+
+    def test_log_no_init_writes_message_to_stdout(self, config):
+        with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+            config.init = False
+
+            for i in range(10):
+                log(f"log with level {i}", level=i)
+
+            self.assert_logs(mock_stdout.getvalue(), expected_lines=4)
+            assert (
+                mock_stdout.getvalue()
+                == """log with level 0
+log with level 1
+log with level 2
+log with level 3
+"""
+            )
+
+    def test_log_with_init_writes_message_to_stdout_and_default_jobmanger_file(self, config):
+        with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+            with tempfile.NamedTemporaryFile() as temp_log_file1, tempfile.NamedTemporaryFile() as temp_log_file2:
+
+                # Log to both stdout and file with date and time
+                config.init = True
+                config.default_jobmanager = MagicMock()
+                config.default_jobmanager.logfile = temp_log_file1.name
+                config.log.stdout = 3
+                config.log.file = 5
+                config.log.time = True
+                config.log.date = True
+
+                for i in range(1, 10):
+                    log(f"date and time log with level {i}", level=i)
+
+                # Log to both stdout and file without date and time
+                config.log.time = False
+                config.log.date = False
+                for i in range(1, 10):
+                    log(f"log with level {i}", level=i)
+
+                # Log to stdout and file switching logfile location
+                config.default_jobmanager = MagicMock()
+                config.default_jobmanager.logfile = temp_log_file2.name
+                config.log.file = 4
+                config.log.time = True
+                for i in range(1, 10):
+                    log(f"time log with level {i}", level=i)
+
+                # Log only to stdout
+                config.default_jobmanager = None
+                config.log.date = True
+                config.log.time = False
+                for i in range(1, 10):
+                    log(f"date log with level {i}", level=i)
+
+                # Stdout has a log line for each level up to and including 3
+                stdout_logs = mock_stdout.getvalue()
+                self.assert_logs(stdout_logs, line_end=3, date_expected=True, time_expected=True)
+                self.assert_logs(stdout_logs, line_start=3, line_end=6)
+                self.assert_logs(stdout_logs, line_start=6, line_end=9, time_expected=True)
+                self.assert_logs(stdout_logs, line_start=9, expected_lines=3, date_expected=True)
+
+                # # File1 has a log for each level up to and including 5
+                file1_logs = temp_log_file1.read().decode()
+                self.assert_logs(file1_logs, line_end=5, date_expected=True, time_expected=True)
+                self.assert_logs(file1_logs, line_start=5, expected_lines=5)
+
+                # File2 has a log for each level up to and including 4
+                file2_logs = temp_log_file2.read().decode()
+                self.assert_logs(file2_logs, expected_lines=4, time_expected=True)
+
+    def assert_logs(
+        self, logs, line_start=0, line_end=None, expected_lines=None, date_expected=False, time_expected=False
+    ):
+        # Convert string text to individual lines
+        lines = [l for l in logs.replace("\r\n", "\n").split("\n") if l]
+
+        # Select the required logs section
+        line_end = len(lines) if line_end is None else line_end
+        lines = lines[line_start:line_end]
+        expected_lines = line_end - line_start if expected_lines is None else expected_lines
+        assert len(lines) == expected_lines
+
+        # Check all log lines match the expected pattern
+        if date_expected and time_expected:
+            pattern = "\[\d{2}\.\d{2}\|\d{2}:\d{2}:\d{2}\] date and time log with level \d"
+        elif date_expected:
+            pattern = "\[\d{2}\.\d{2}] date log with level \d"
+        elif time_expected:
+            pattern = "\[\d{2}:\d{2}:\d{2}] time log with level \d"
+        else:
+            pattern = "log with level \d"
+
+        assert all([re.fullmatch(pattern, line) is not None for line in lines])

--- a/unit_tests/test_helpers.py
+++ b/unit_tests/test_helpers.py
@@ -3,6 +3,9 @@ from unittest.mock import patch, mock_open
 import pytest
 import os
 from importlib.util import find_spec
+from pathlib import Path
+import uuid
+from contextlib import contextmanager
 
 from scm.plams.core.settings import (
     SafeRunSettings,
@@ -60,6 +63,20 @@ def get_mock_find_spec(patch_module: str, package_name: str):
         return None if name == package_name else find_spec(name)
 
     return patch(f"{patch_module}.find_spec", side_effect=mock_find_spec)
+
+
+@contextmanager
+def temp_file_path(suffix=".txt"):
+    """
+    Get the path to a temporary file in the current directory, which will be deleted after the context.
+    An alternative to tempfile, as the file is not opened on entry into the context.
+    """
+    temp_path = str(Path(__file__).parent.absolute() / f"{uuid.uuid4()}{suffix}")
+    try:
+        yield str(temp_path)
+    finally:
+        if os.path.exists(temp_path):
+            os.remove(temp_path)
 
 
 def assert_config_as_expected(

--- a/unit_tests/test_logging.py
+++ b/unit_tests/test_logging.py
@@ -1,23 +1,39 @@
 import re
+import uuid
 from unittest.mock import patch
 from io import StringIO
-import tempfile
 
-from scm.plams.core.logging import Logger
+import pytest
+
+from scm.plams.core.errors import FileError
+from scm.plams.core.logging import LoggerManager
+from scm.plams.unit_tests.test_helpers import temp_file_path
+
+
+class TestLoggerManager:
+
+    def test_get_logger_returns_existing_or_creates_new(self):
+        name1 = str(uuid.uuid4())
+        name2 = str(uuid.uuid4())
+        logger1 = LoggerManager.get_logger(name1)
+        logger2 = LoggerManager.get_logger(name2)
+        logger3 = LoggerManager.get_logger(name1)
+
+        assert logger1 == logger3 != logger2
 
 
 class TestLogger:
 
     def test_no_logging_to_stdout_by_default(self):
         with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
-            logger = Logger("test")
+            logger = LoggerManager.get_logger(str(uuid.uuid4()))
             logger.log("hello", 1)
 
             assert mock_stdout.getvalue() == ""
 
     def test_configure_stdout_writes_to_stdout_up_to_and_including_level(self):
         with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
-            logger = Logger("test")
+            logger = LoggerManager.get_logger(str(uuid.uuid4()))
             logger.configure_stdout(3)
             for i in range(10):
                 logger.log(f"log line {i}", i)
@@ -32,59 +48,43 @@ log line 3
             )
 
     def test_configure_logfile_writes_to_file_up_to_and_including_level(self):
-        with tempfile.NamedTemporaryFile(dir=".", suffix=".log") as temp_log_file:
-            logger = Logger("test")
-            logger.configure_logfile(temp_log_file.name, 3)
+        with temp_file_path(suffix=".log") as temp_log_file:
+            logger = LoggerManager.get_logger(str(uuid.uuid4()))
+            logger.configure_logfile(temp_log_file, 3)
             for i in range(10):
                 logger.log(f"log line {i}", i)
 
-            assert (
-                temp_log_file.read().decode()
-                == """log line 0
+            with open(temp_log_file) as tf:
+                assert (
+                    tf.read()
+                    == """log line 0
 log line 1
 log line 2
 log line 3
 """
-            )
-
-    def test_multiple_loggers_write_to_stdout_and_same_file(self):
-        with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
-            with tempfile.NamedTemporaryFile(dir=".", suffix=".log") as temp_log_file:
-                logger1 = Logger("test1")
-                logger2 = Logger("test2")
-                logger1.configure_stdout(2)
-                logger2.configure_stdout(3)
-                logger1.configure_logfile(temp_log_file.name, 2)
-                logger2.configure_logfile(temp_log_file.name, 3)
-
-                for i in range(5):
-                    logger1.log(f"From 1, level {i}", i)
-                    logger2.log(f"From 2, level {i}", i)
-
-                assert (
-                    mock_stdout.getvalue()
-                    == temp_log_file.read().decode()
-                    == """From 1, level 0
-From 2, level 0
-From 1, level 1
-From 2, level 1
-From 1, level 2
-From 2, level 2
-From 2, level 3
-"""
                 )
+            logger.configure_logfile(None)
 
-    def test_multiple_loggers_write_to_stdout_but_different_files(self):
+    def test_multiple_loggers_cannot_write_to_same_file(self):
         with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
-            with tempfile.NamedTemporaryFile(
-                dir=".", suffix=".log", mode="r"
-            ) as temp_log_file1, tempfile.NamedTemporaryFile(dir=".", suffix=".log", mode="r") as temp_log_file2:
-                logger1 = Logger("test1")
-                logger2 = Logger("test2")
+            with temp_file_path(suffix=".log") as temp_log_file:
+                logger1 = LoggerManager.get_logger(str(uuid.uuid4()))
+                logger2 = LoggerManager.get_logger(str(uuid.uuid4()))
                 logger1.configure_stdout(2)
                 logger2.configure_stdout(3)
-                logger1.configure_logfile(temp_log_file1.name, 1)
-                logger2.configure_logfile(temp_log_file2.name, 2)
+                logger1.configure_logfile(temp_log_file, 2)
+                with pytest.raises(FileError):
+                    logger2.configure_logfile(temp_log_file, 3)
+
+    def test_multiple_loggers_can_write_to_stdout_but_different_files(self):
+        with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+            with temp_file_path(suffix=".log") as temp_log_file1, temp_file_path(suffix=".log") as temp_log_file2:
+                logger1 = LoggerManager.get_logger(str(uuid.uuid4()))
+                logger2 = LoggerManager.get_logger(str(uuid.uuid4()))
+                logger1.configure_stdout(2)
+                logger2.configure_stdout(3)
+                logger1.configure_logfile(temp_log_file1, 1)
+                logger2.configure_logfile(temp_log_file2, 2)
 
                 for i in range(5):
                     logger1.log(f"From 1, level {i}", i)
@@ -102,31 +102,34 @@ From 2, level 3
 """
                 )
 
-                assert (
-                    temp_log_file1.read()
-                    == """From 1, level 0
+                with open(temp_log_file1) as tf1:
+                    assert (
+                        tf1.read()
+                        == """From 1, level 0
 From 1, level 1
 """
-                )
-                assert (
-                    temp_log_file2.read()
-                    == """From 2, level 0
+                    )
+
+                with open(temp_log_file2) as tf2:
+                    assert (
+                        tf2.read()
+                        == """From 2, level 0
 From 2, level 1
 From 2, level 2
 """
-                )
+                    )
+            logger1.configure_logfile(None)
+            logger2.configure_logfile(None)
 
     def test_same_logger_can_switch_write_files(self):
-        with tempfile.NamedTemporaryFile(dir=".", suffix=".log") as temp_log_file1, tempfile.NamedTemporaryFile(
-            dir=".", suffix=".log"
-        ) as temp_log_file2:
-            logger = Logger("test")
-            logger.configure_logfile(temp_log_file1.name, 2)
+        with temp_file_path(suffix=".log") as temp_log_file1, temp_file_path(suffix=".log") as temp_log_file2:
+            logger = LoggerManager.get_logger(str(uuid.uuid4()))
+            logger.configure_logfile(temp_log_file1, 2)
 
             for i in range(5):
                 logger.log(f"To 1, level {i}", i)
 
-            logger.configure_logfile(temp_log_file2.name, 1)
+            logger.configure_logfile(temp_log_file2, 1)
 
             for i in range(5):
                 logger.log(f"To 2, level {i}", i)
@@ -136,33 +139,38 @@ From 2, level 2
             for i in range(5):
                 logger.log(f"To None, level {i}", i)
 
-            logger.configure_logfile(temp_log_file1.name, 2)
+            logger.configure_logfile(temp_log_file1, 2)
             for i in range(5):
                 logger.log(f"To 1 again, level {i}", i)
 
-            assert (
-                temp_log_file1.read().decode()
-                == """To 1, level 0
+            with open(temp_log_file1) as tf1:
+                assert (
+                    tf1.read()
+                    == """To 1, level 0
 To 1, level 1
 To 1, level 2
 To 1 again, level 0
 To 1 again, level 1
 To 1 again, level 2
 """
-            )
-            assert (
-                temp_log_file2.read().decode()
-                == """To 2, level 0
+                )
+
+            with open(temp_log_file2) as tf2:
+
+                assert (
+                    tf2.read()
+                    == """To 2, level 0
 To 2, level 1
 """
-            )
+                )
+            logger.configure_logfile(None)
 
     def test_configure_formatter_prefixes_date_and_or_time_for_stdout_and_file(self):
         with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
-            with tempfile.NamedTemporaryFile(dir=".", suffix=".log") as temp_log_file:
-                logger = Logger("test")
+            with temp_file_path(suffix=".log") as temp_log_file:
+                logger = LoggerManager.get_logger(str(uuid.uuid4()))
                 logger.configure_stdout(4)
-                logger.configure_logfile(temp_log_file.name, 4)
+                logger.configure_logfile(temp_log_file, 4)
 
                 dts = [[tf1, tf2] for tf1 in [True, False] for tf2 in [True, False]]
                 for date, time in dts:
@@ -172,43 +180,47 @@ To 2, level 1
 
                 logger.configure_formatter(True, False)
 
-                for i, (l1, l2) in enumerate(
-                    zip(
-                        [l for l in mock_stdout.getvalue().replace("\r\n", "\n").split("\n") if l],
-                        [l for l in temp_log_file.read().decode().replace("\r\n", "\n").split("\n") if l],
-                    )
-                ):
-                    date, time = dts[i // 2]
-                    pattern = f"d={date}, t={time}, level={i % 2 + 3}"
-                    if date and time:
-                        pattern = "\[\d{2}\.\d{2}\|\d{2}:\d{2}:\d{2}\] " + pattern
-                    elif date:
-                        pattern = "\[\d{2}\.\d{2}\] " + pattern
-                    elif time:
-                        pattern = "\[\d{2}:\d{2}:\d{2}\] " + pattern
-                    assert re.fullmatch(pattern, l1) is not None and re.fullmatch(pattern, l2) is not None
+                with open(temp_log_file) as tf:
+                    for i, (l1, l2) in enumerate(
+                        zip(
+                            [l for l in mock_stdout.getvalue().replace("\r\n", "\n").split("\n") if l],
+                            [l for l in tf.read().replace("\r\n", "\n").split("\n") if l],
+                        )
+                    ):
+                        date, time = dts[i // 2]
+                        pattern = f"d={date}, t={time}, level={i % 2 + 3}"
+                        if date and time:
+                            pattern = "\[\d{2}\.\d{2}\|\d{2}:\d{2}:\d{2}\] " + pattern
+                        elif date:
+                            pattern = "\[\d{2}\.\d{2}\] " + pattern
+                        elif time:
+                            pattern = "\[\d{2}:\d{2}:\d{2}\] " + pattern
+                        assert re.fullmatch(pattern, l1) is not None and re.fullmatch(pattern, l2) is not None
+
+                logger.configure_logfile(None)
 
     def test_configure_order_invariant(self):
         with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
-            with tempfile.NamedTemporaryFile(dir=".", suffix=".log") as temp_log_file1, tempfile.NamedTemporaryFile(
-                dir=".", suffix=".log"
-            ) as temp_log_file2:
-                logger = Logger("test")
+            with temp_file_path(suffix=".log") as temp_log_file1, temp_file_path(suffix=".log") as temp_log_file2:
+                logger = LoggerManager.get_logger(str(uuid.uuid4()))
 
                 logger.configure_stdout(10)
                 logger.configure_formatter(True, True)
-                logger.configure_logfile(temp_log_file2.name)
+                logger.configure_logfile(temp_log_file2)
                 logger.configure_formatter(True, False)
                 logger.configure_logfile(None, 10)
                 logger.configure_stdout(2)
                 logger.configure_formatter(False, False)
-                logger.configure_logfile(temp_log_file1.name, 2)
+                logger.configure_logfile(temp_log_file1, 2)
 
                 logger.log("A log line", 1)
 
-                assert (
-                    mock_stdout.getvalue()
-                    == temp_log_file1.read().decode()
-                    == """A log line
+                with open(temp_log_file1) as tf1:
+                    assert (
+                        mock_stdout.getvalue()
+                        == tf1.read()
+                        == """A log line
 """
-                )
+                    )
+
+                logger.configure_logfile(None)

--- a/unit_tests/test_logging.py
+++ b/unit_tests/test_logging.py
@@ -33,7 +33,7 @@ class TestLogger:
 
             assert mock_stdout.getvalue() == ""
 
-    def test_configure_stdout_writes_to_stdout_up_to_and_including_level(self):
+    def test_configure_writes_to_stdout_up_to_and_including_level(self):
         with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
             logger = LogManager.get_logger(str(uuid.uuid4()))
             logger.configure(3)
@@ -49,7 +49,7 @@ log line 3
 """
             )
 
-    def test_configure_logfile_writes_to_file_up_to_and_including_level(self):
+    def test_configure_writes_to_logfile_up_to_and_including_level(self):
         with temp_file_path(suffix=".log") as temp_log_file:
             logger = LogManager.get_logger(str(uuid.uuid4()))
             logger.configure(logfile_path=temp_log_file, logfile_level=3)
@@ -77,7 +77,7 @@ log line 3
             logger1.configure()  # close logfile
             logger2.configure()  # close logfile
 
-    def test_multiple_loggers_can_write_to_stdout_but_different_files(self):
+    def test_multiple_loggers_can_write_to_stdout_and_different_files(self):
         with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
             with temp_file_path(suffix=".log") as temp_log_file1, temp_file_path(suffix=".log") as temp_log_file2:
                 logger1 = LogManager.get_logger(str(uuid.uuid4()))
@@ -164,7 +164,7 @@ To 2, level 1
                 )
             logger.configure()  # close logfile
 
-    def test_configure_formatter_prefixes_date_and_or_time_for_stdout_and_file(self):
+    def test_configure_prefixes_date_and_or_time_for_stdout_and_file(self):
         with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
             with temp_file_path(suffix=".log") as temp_log_file:
                 logger = LogManager.get_logger(str(uuid.uuid4()))

--- a/unit_tests/test_logging.py
+++ b/unit_tests/test_logging.py
@@ -7,7 +7,7 @@ import pytest
 import time
 import random
 
-from scm.plams.core.errors import FileError
+from scm.plams.core.errors import FileError, PlamsError
 from scm.plams.core.logging import get_logger
 from scm.plams.unit_tests.test_helpers import temp_file_path
 
@@ -22,6 +22,10 @@ class TestGetLogger:
         logger3 = get_logger(name1)
 
         assert logger1 == logger3 != logger2
+
+    def test_get_logger_errors_with_unsupported_format(self):
+        with pytest.raises(PlamsError):
+            get_logger("foo", "bar")
 
 
 class TestLogger:

--- a/unit_tests/test_logging.py
+++ b/unit_tests/test_logging.py
@@ -1,0 +1,174 @@
+import re
+from unittest.mock import patch
+from io import StringIO
+import tempfile
+
+from scm.plams.core.logging import Logger
+
+
+class TestLogger:
+
+    def test_no_logging_to_stdout_by_default(self):
+        with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+            logger = Logger("test")
+            logger.log("hello", 1)
+
+            assert mock_stdout.getvalue() == ""
+
+    def test_configure_stdout_writes_to_stdout_up_to_and_including_level(self):
+        with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+            logger = Logger("test")
+            logger.configure_stdout(3)
+            for i in range(10):
+                logger.log(f"log line {i}", i)
+
+            assert (
+                mock_stdout.getvalue()
+                == """log line 0
+log line 1
+log line 2
+log line 3
+"""
+            )
+
+    def test_configure_logfile_writes_to_file_up_to_and_including_level(self):
+        with tempfile.NamedTemporaryFile() as temp_log_file:
+            logger = Logger("test")
+            logger.configure_logfile(temp_log_file.name, 3)
+            for i in range(10):
+                logger.log(f"log line {i}", i)
+
+            assert (
+                temp_log_file.read().decode()
+                == """log line 0
+log line 1
+log line 2
+log line 3
+"""
+            )
+
+    def test_multiple_loggers_write_to_stdout_but_different_files(self):
+        with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+            with tempfile.NamedTemporaryFile() as temp_log_file1, tempfile.NamedTemporaryFile() as temp_log_file2:
+                logger1 = Logger("test1")
+                logger2 = Logger("test2")
+                logger1.configure_stdout(2)
+                logger2.configure_stdout(3)
+                logger1.configure_logfile(temp_log_file1.name, 1)
+                logger2.configure_logfile(temp_log_file2.name, 2)
+
+                for i in range(5):
+                    logger1.log(f"From 1, level {i}", i)
+                    logger2.log(f"From 2, level {i}", i)
+
+                assert (
+                    mock_stdout.getvalue()
+                    == """From 1, level 0
+From 2, level 0
+From 1, level 1
+From 2, level 1
+From 1, level 2
+From 2, level 2
+From 2, level 3
+"""
+                )
+
+                assert (
+                    temp_log_file1.read().decode()
+                    == """From 1, level 0
+From 1, level 1
+"""
+                )
+                assert (
+                    temp_log_file2.read().decode()
+                    == """From 2, level 0
+From 2, level 1
+From 2, level 2
+"""
+                )
+
+    def test_same_logger_can_switch_write_files(self):
+        with tempfile.NamedTemporaryFile() as temp_log_file1, tempfile.NamedTemporaryFile() as temp_log_file2:
+            logger = Logger("test")
+            logger.configure_logfile(temp_log_file1.name, 2)
+
+            for i in range(5):
+                logger.log(f"To 1, level {i}", i)
+
+            logger.configure_logfile(temp_log_file2.name, 1)
+
+            for i in range(5):
+                logger.log(f"To 2, level {i}", i)
+
+            logger.configure_logfile(None, 1)
+
+            for i in range(5):
+                logger.log(f"To None, level {i}", i)
+
+            assert (
+                temp_log_file1.read().decode()
+                == """To 1, level 0
+To 1, level 1
+To 1, level 2
+"""
+            )
+            assert (
+                temp_log_file2.read().decode()
+                == """To 2, level 0
+To 2, level 1
+"""
+            )
+
+    def test_configure_formatter_prefixes_date_and_or_time_for_stdout_and_file(self):
+        with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+            with tempfile.NamedTemporaryFile() as temp_log_file:
+                logger = Logger("test")
+                logger.configure_stdout(4)
+                logger.configure_logfile(temp_log_file.name, 4)
+
+                dts = [[tf1, tf2] for tf1 in [True, False] for tf2 in [True, False]]
+                for date, time in dts:
+                    logger.configure_formatter(date, time)
+                    for i in range(3, 8):
+                        logger.log(f"d={date}, t={time}, level={i}", i)
+
+                logger.configure_formatter(True, False)
+
+                for i, (l1, l2) in enumerate(
+                    zip(
+                        [l for l in mock_stdout.getvalue().replace("\r\n", "\n").split("\n") if l],
+                        [l for l in temp_log_file.read().decode().replace("\r\n", "\n").split("\n") if l],
+                    )
+                ):
+                    date, time = dts[i // 2]
+                    pattern = f"d={date}, t={time}, level={i % 2 + 3}"
+                    if date and time:
+                        pattern = "\[\d{2}\.\d{2}\|\d{2}:\d{2}:\d{2}\] " + pattern
+                    elif date:
+                        pattern = "\[\d{2}\.\d{2}\] " + pattern
+                    elif time:
+                        pattern = "\[\d{2}:\d{2}:\d{2}\] " + pattern
+                    assert re.fullmatch(pattern, l1) is not None and re.fullmatch(pattern, l2) is not None
+
+    def test_configure_order_invariant(self):
+        with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+            with tempfile.NamedTemporaryFile() as temp_log_file1, tempfile.NamedTemporaryFile() as temp_log_file2:
+                logger = Logger("test")
+
+                logger.configure_stdout(10)
+                logger.configure_formatter(True, True)
+                logger.configure_logfile(temp_log_file2.name)
+                logger.configure_formatter(True, False)
+                logger.configure_logfile(None, 10)
+                logger.configure_stdout(2)
+                logger.configure_formatter(False, False)
+                logger.configure_logfile(temp_log_file1.name, 2)
+
+                logger.log("A log line", 1)
+
+                assert (
+                    mock_stdout.getvalue()
+                    == temp_log_file1.read().decode()
+                    == """A log line
+"""
+                )


### PR DESCRIPTION
# Description

We are currently considering how to improve the PLAMS logging for a better user experience. 

This includes having logging of job summaries etc. as in https://github.com/SCM-NV/PLAMS/pull/156

As a first step though, a refactor of the existing `log` method in PLAMS. This currently had it's own logging implementation to write to stdout and a file, including handling the thread safety etc.

This change maintains the current behaviour exactly, but instead uses the standard python logger and formatter etc. This is more a best-practice change at the moment, but also provides a pattern for adding other logger types.

## Implementation

A wrapper class `Logger` has been added to `scm.plams.core.logging`. It is a thin wrapper over the standard library logger, which has an interface optimised for the current usage in PLAMS. It has a `configure` method and a `log` method which are both used by the general `log` function.

Note that the configure methods are called very frequently (every time log is called), but they only update the handlers if there is an actual change to the config. This is required as the current behaviour is to log to the global config default job manger, which can be changed dynamically in the script. So this can't be a one-time-setup type of configuration.

Instead of instantiating the `Logger` directly, a `LogManager` static class has also been added. This allows the loggers to be accessed by name and makes sure they are singletons. This is exposed to the user via a `get_logger` helper method.

## Example

An example usage is as follows:

<img width="1120" alt="Screenshot 2024-10-18 at 10 02 46" src="https://github.com/user-attachments/assets/434afb01-f19b-4202-845e-f7e015eeaf1a">

## Testing

Logging tests were added for `log` function, which passed before and after this change. 

Specific tests have also been added for the `Logger` class.

In addition, the scripting tests for PLAMS were run, which should flag any issues as the diffs would be incorrect

## Future Extensions

It would now be possible to add a `get_csv_logger` method which could return a csv logger based on a similar pattern to the current logger. There could also be an (abstract) base class for the different logger types.
