### PR TITLE
Add manual trigger to AMSJobLogTailHandler SCMSUITE-10077 SO107

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ natsort==8.1.0
 ase==3.22.1
 rdkit==2024.03.1
 networkx==2.8.8
+watchdog==2.1.8


### PR DESCRIPTION
# Description 

There is a nightly test which regularly fails on MacOS when under load.

The option of forwarding of the AMS job logs to the stdout / plams log file seems to be dropping a number of the final log messages, causing the test to fail. 

The origin of the failure actually seems to be a delay in the event handler receiving the file modified signal. This is an issue as the observer is stopped immediately after the ams results are available, and so the final logs are not forwarded. In testing, if a sleep is added the logs eventually come through. 

However, a direct tail command through python show the logs have already been written. So, it appears it is actually the signal which is not firing.

This change then adds a manual trigger of the file after the results are available, to do a final processing of the log file.

A small unit test has been added to test the watch behaviour in general, although it does not pick up on this edge case.