### PR TITLE
Stop writing supercell properties to AMS input SCMSUITE-10074 SO107

### DIFF
--- a/interfaces/adfsuite/ams.py
+++ b/interfaces/adfsuite/ams.py
@@ -2763,9 +2763,9 @@ class AMSJob(SingleJob):
 
         def serialize(sett, prefix=""):
             for key, val in sett.items():
-                if prefix == "" and key.lower() in ["suffix", "ghost", "name"]:
-                    # Special atomic properties that are handled by _atom_symbol() already.
-                    # Suffix handled explicitly below ...
+                if prefix == "" and key.lower() in ["suffix", "ghost", "name", "supercell"]:
+                    # Special atomic properties that are handled by _atom_symbol() already (handled explicitly below).
+                    # Or internal PLAMS properties which are not accepted as valid atom properties in AMS, and so can be pruned out.
                     continue
                 if isinstance(val, Settings):
                     # Recursively serialize nested Settings object

--- a/unit_tests/test_amsjob.py
+++ b/unit_tests/test_amsjob.py
@@ -425,6 +425,95 @@ EndEngine
         pytest.skip("Cannot pickle ChemicalSystem")
 
 
+class TestAMSJobWithChainOfMolecules(TestAMSJob):
+    """
+    Test suite for AMSJob with a chain of water molecules.
+    """
+
+    @staticmethod
+    def get_input_molecule():
+        """
+        Get instance of the Molecule class passed to the AMSJob
+        """
+        mol = TestAMSJob.get_input_molecule()
+        mol.lattice = [[3, 0, 0]]
+        return mol.supercell(4)
+
+    @staticmethod
+    def get_input_settings():
+        """
+        Instance of the Settings class passed to the AMSJob
+        """
+        settings = Settings()
+        settings.input.Mopac.SCF.ConvergenceThreshold = 1.0e-8
+        settings.input.Mopac.model = "pm6"
+        settings.input.AMS.Task = "SinglePoint"
+        settings.input.AMS.Properties.Gradients = "Yes"
+        settings.input.AMS.NumericalDifferentiation.Parallel.nCoresPerGroup = 1
+        settings.input.AMS.NumericalDifferentiation.NuclearStepSize = 0.0001
+        settings.input.AMS.EngineDebugging.IgnoreGradientsRequest = "No"
+        settings.input.AMS.System.ElectrostaticEmbedding.ElectricField = "0.0 0.0 0.0"
+        settings.input.AMS.Task = "SinglePoint"
+        settings.input.AMS.Properties.Gradients = "Yes"
+        settings.input.AMS.NumericalDifferentiation.Parallel.nCoresPerGroup = 1
+        settings.input.AMS.NumericalDifferentiation.NuclearStepSize = 0.0001
+        return settings
+
+    @staticmethod
+    def get_expected_input():
+        """
+        Get expected input file
+        """
+        return """EngineDebugging
+  IgnoreGradientsRequest No
+End
+
+NumericalDifferentiation
+  NuclearStepSize 0.0001
+  Parallel
+    nCoresPerGroup 1
+  End
+End
+
+Properties
+  Gradients Yes
+End
+
+System
+  Atoms
+              O       0.0000000000       0.0000000000       0.0000000000
+              H       1.0000000000       0.0000000000       0.0000000000
+              H       0.0000000000       1.0000000000       0.0000000000
+              O       3.0000000000       0.0000000000       0.0000000000
+              H       4.0000000000       0.0000000000       0.0000000000
+              H       3.0000000000       1.0000000000       0.0000000000
+              O       6.0000000000       0.0000000000       0.0000000000
+              H       7.0000000000       0.0000000000       0.0000000000
+              H       6.0000000000       1.0000000000       0.0000000000
+              O       9.0000000000       0.0000000000       0.0000000000
+              H      10.0000000000       0.0000000000       0.0000000000
+              H       9.0000000000       1.0000000000       0.0000000000
+  End
+  ElectrostaticEmbedding
+    ElectricField 0.0 0.0 0.0
+  End
+  Lattice
+        12.0000000000     0.0000000000     0.0000000000
+  End
+End
+
+Task SinglePoint
+
+Engine Mopac
+  SCF
+    ConvergenceThreshold 1e-08
+  End
+  model pm6
+EndEngine
+
+"""
+
+
 class TestAMSJobRun:
 
     def test_run_with_watch_forwards_ams_logs_to_stdout(self, config):


### PR DESCRIPTION
# Description

The UCS is strict about which atomic properties it allows for molecule input. Currently in PLAMS, when `supercell` is called, additional `supercell` properties are added onto each atom. These are not used within PLAMS anywhere, but are serialised when creating the input file. With UCS this will cause annoyance as the input will no longer be valid.

This change therefore ignores this specific keyword when serialising the molecule. 

A unit test has been added to test the serialisation of a molecule created via supercell. In addition, the plams scripting tests have been run as well as the electric fields example. All pass as expected.