### PR TITLE
Fix contains method in KFFile SCMSUITE-8670 SO107

### DIFF
--- a/tools/kftools.py
+++ b/tools/kftools.py
@@ -492,7 +492,7 @@ class KFFile:
             try:
                 self.read(*arg)
                 return True
-            except (KeyError, AttributeError):
+            except (KeyError, AttributeError, FileError):
                 return False
         raise TypeError("'in <KFFile>' requires string of a pair of strings as left operand")
 

--- a/unit_tests/test_kftools.py
+++ b/unit_tests/test_kftools.py
@@ -192,6 +192,36 @@ class TestKFFile:
         with pytest.raises(ValueError):
             file.write("Test", "ListInvalidTypes", [{}, {}])
 
+    def test_contains(self, water_optimization_rkf):
+        happy_file = KFFile(water_optimization_rkf, autosave=False)
+        unhappy_file = KFFile("not-a-file", autosave=False)
+
+        # Section present
+        assert "Molecule" in happy_file
+        assert "General" in happy_file
+        # Section and variable present
+        assert ("Molecule", "nAtoms") in happy_file
+        assert ("General", "CPUTime") in happy_file
+        # Section not present
+        assert "Foo" not in happy_file
+        assert ("Foo", "Bar") not in happy_file
+        # Variable not present
+        assert ("Molecule", "Bar") not in happy_file
+        # No file present
+        assert "Molecule" not in unhappy_file
+        assert "General" not in unhappy_file
+        assert ("Molecule", "nAtoms") not in unhappy_file
+        assert ("General", "CPUTime") not in unhappy_file
+        assert "Foo" not in unhappy_file
+        assert ("Foo", "Bar") not in unhappy_file
+        assert ("Molecule", "Bar") not in unhappy_file
+
+        with pytest.raises(TypeError):
+            ("a", "b", "c") in happy_file
+
+        with pytest.raises(TypeError):
+            ("a", "b", "c") in unhappy_file
+
 
 class TestKFHistory:
     """


### PR DESCRIPTION
# Description

Fix bug introduced in https://github.com/SCM-NV/PLAMS/commit/2dd56736842efe3f8de2c6c9bf44b8b0058aedfa which was flagged by the nightly tests.

The `KFFile.read` method was made safer by raising a `FileError` when the given file did not exist (instead of an `AttributeError`). However, the `__contains__` method was anticipating these and catching such an error. 

Therefore add the `FileError` to the list of handled exceptions. I am leaving the AttributeError in case it is surfaced by another code path.  Unit test added. Integration tests now look to pass.