### PR TITLE
Stop writing rdkit properties to AMS input (not supported by UCS) SO107

### DIFF
--- a/interfaces/adfsuite/ams.py
+++ b/interfaces/adfsuite/ams.py
@@ -2758,7 +2758,7 @@ class AMSJob(SingleJob):
 
         def serialize(sett, prefix=""):
             for key, val in sett.items():
-                if prefix == "" and key.lower() in ["suffix", "ghost", "name", "supercell"]:
+                if prefix == "" and key.lower() in ["suffix", "ghost", "name", "supercell", "rdkit"]:
                     # Special atomic properties that are handled by _atom_symbol() already (handled explicitly below).
                     # Or internal PLAMS properties which are not accepted as valid atom properties in AMS, and so can be pruned out.
                     continue


### PR DESCRIPTION
Tiny change in the AMS interface. The ``rdkit`` atomic properties group is also one that is produced by PLAMS (e.g. by the ``from_smiles`` method), but not used in the AMS driver. Since we won't add this one to the UnifiedChemicalSystem, we should not write it to the input for AMS.