### PR TITLE
Fix checking for molecule identity using "is"

### DIFF
--- a/unit_tests/test_amsjob.py
+++ b/unit_tests/test_amsjob.py
@@ -81,8 +81,8 @@ EndEngine
 
         # When get molecule from job
         # Then job molecule is a deep copy
-        assert not job.molecule == job_input.molecule
-        assert not job.molecule.atoms == job_input.molecule.atoms
+        assert job.molecule is not job_input.molecule
+        assert job.molecule.atoms is not job_input.molecule.atoms
 
     def test_pickle_dumps_and_loads_job_successfully(self, job_input):
         # Given job with molecule and settings
@@ -355,10 +355,10 @@ EndEngine
 
         # When get molecule from job
         # Then job molecule is a deep copy
-        assert not job.molecule == job_input.molecule
+        assert job.molecule is not job_input.molecule
         for name, mol in job.molecule.items():
-            assert not mol == job_input.molecule[name]
-            assert not mol.atoms == job_input.molecule[name].atoms
+            assert mol is not job_input.molecule[name]
+            assert mol.atoms is not job_input.molecule[name].atoms
 
 
 class TestAMSJobWithMultipleChemicalSystems(TestAMSJobWithMultipleMolecules):


### PR DESCRIPTION
This is necessary to make PLAMS tests compatible with UCS's new content-comparing equality operator.

~~RFC: Shouldn't we also similarly adjust the `mol.atoms` comparisons on the immediately following lines? The unit tests work OK even in the current state, but it feels like `is not` would express the spirit of the assertion better (checking if things are two separate copies or just two references to the same object).~~ Done.