### PR TITLE
Add error messaging logging for ams jobs SO107 SCMSUITE-8725

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *,cover
+unit_tests/result_images/*
 
 # Translations
 *.mo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This changelog is effective from the 2025 releases.
 * GitHub workflows for CI and publishing to PyPI
 * Build using `pyproject.toml`, addition of extras groups to install optional dependencies
 * Logging of job summaries to CSV logfile
+* Logging of AMS job error messages to stdout and logfile on job failure
 
 ### Changed
 * Functions for optional packages (e.g. RDKit, ASE) are available even when these packages are not installed, but will raise an `MissingOptionalPackageError` when called

--- a/core/formatters.py
+++ b/core/formatters.py
@@ -25,12 +25,12 @@ class JobCSVFormatter(CSVFormatter):
             "job_base_name": re.sub(r"\.\d+$", "", job.name),
             "job_name": job.name,
             "job_status": job.status,
-            "job_parent_name": "",
-            "job_parent_path": "",
             "job_path": "",
             "job_ok": "",
             "job_check": "",
             "job_get_errormsg": "",
+            "job_parent_name": "",
+            "job_parent_path": "",
         }
 
         if job.status not in [JobStatus.CREATED, JobStatus.STARTED]:

--- a/core/functions.py
+++ b/core/functions.py
@@ -43,7 +43,6 @@ config = ConfigSettings()
 # ===========================================================================
 
 _logger = get_logger("plams")
-_logger.configure(3)
 
 
 def log(message: str, level: int = 0) -> None:
@@ -56,11 +55,13 @@ def log(message: str, level: int = 0) -> None:
     Date and/or time can be added based on ``config.log.date`` and ``config.log.time``.
     All logging activity is thread safe.
     """
-    if config.init and config["default_jobmanager"] is not None:
-        logger = config.default_jobmanager.logger
+    if config.init and "log" in config:
+        logfile = config.default_jobmanager.logfile if config["default_jobmanager"] is not None else None
+        _logger.configure(config.log.stdout, config.log.file, logfile, config.log.date, config.log.time)
     else:
-        logger = _logger
-    logger.log(message, level)
+        # By default write to stdout with level 3
+        _logger.configure(3)
+    _logger.log(message, level)
 
 
 # ===========================================================================

--- a/core/functions.py
+++ b/core/functions.py
@@ -43,6 +43,7 @@ config = ConfigSettings()
 # ===========================================================================
 
 _logger = get_logger("plams")
+_logger.configure(3)
 
 
 def log(message: str, level: int = 0) -> None:
@@ -55,13 +56,11 @@ def log(message: str, level: int = 0) -> None:
     Date and/or time can be added based on ``config.log.date`` and ``config.log.time``.
     All logging activity is thread safe.
     """
-    if config.init and "log" in config:
-        logfile = config.default_jobmanager.logfile if config["default_jobmanager"] is not None else None
-        _logger.configure(config.log.stdout, config.log.file, logfile, config.log.date, config.log.time)
+    if config.init and config["default_jobmanager"] is not None:
+        logger = config.default_jobmanager.logger
     else:
-        # By default write to stdout with level 3
-        _logger.configure(3)
-    _logger.log(message, level)
+        logger = _logger
+    logger.log(message, level)
 
 
 # ===========================================================================

--- a/core/functions.py
+++ b/core/functions.py
@@ -300,6 +300,7 @@ def finish(otherJM: Optional[Iterable["JobManager"]] = None):
 
 # Register call to _finish on workflow end
 atexit.register(_finish)
+atexit.register(_logger.close)
 
 
 # ===========================================================================

--- a/core/jobmanager.py
+++ b/core/jobmanager.py
@@ -11,6 +11,7 @@ from scm.plams.core.errors import FileError, PlamsError
 from scm.plams.core.functions import config, get_logger, log
 from scm.plams.core.logging import Logger
 from scm.plams.core.formatters import JobCSVFormatter
+from scm.plams.core.settings import LogSettings
 
 if TYPE_CHECKING:
     from scm.plams.core.basejob import Job
@@ -52,6 +53,7 @@ class JobManager:
         path: Optional[str] = None,
         folder: Optional[str] = None,
         use_existing_folder: bool = False,
+        logger: Optional[Logger] = None,
         job_logger: Optional[Logger] = None,
     ):
 
@@ -83,14 +85,28 @@ class JobManager:
                 n += 1
 
         self.workdir = opj(self.path, self.foldername)
-        self.logfile = os.environ["SCM_LOGFILE"] if ("SCM_LOGFILE" in os.environ) else opj(self.workdir, "logfile")
         self.input = opj(self.workdir, "input")
 
         if not (use_existing_folder and os.path.exists(self.workdir)):
             os.mkdir(self.workdir)
 
+        if logger is None:
+            self.logfile = os.environ["SCM_LOGFILE"] if ("SCM_LOGFILE" in os.environ) else opj(self.workdir, "logfile")
+            logger = get_logger(os.path.basename(self.workdir), fmt="txt")
+            log_settings = config.log if "log" in config else LogSettings()
+            logger.configure(
+                log_settings.stdout,
+                log_settings.file,
+                self.logfile,
+                log_settings.date,
+                log_settings.time
+            )
+        else:
+            self.logfile = logger.logfile
+        self.logger = logger
+
         if job_logger is None:
-            job_logger = get_logger(os.path.basename(self.workdir), fmt="csv")
+            job_logger = get_logger(f"{os.path.basename(self.workdir)}_job", fmt="csv")
             job_logger.configure(
                 logfile_level=7,
                 logfile_path=opj(self.workdir, "job_logfile.csv"),
@@ -225,6 +241,7 @@ class JobManager:
                     if not os.listdir(fullname):
                         os.rmdir(fullname)
 
+        self.logger.close()
         self.job_logger.close()
 
         log("Job manager cleaned", 7)

--- a/core/jobrunner.py
+++ b/core/jobrunner.py
@@ -141,7 +141,11 @@ class JobRunner(metaclass=_MetaRunner):
                 # Log any error messages to the standard logger
                 if not job.check():
                     # get_errormsg is not required by the base job class, but often implemented by convention
-                    err_msg = job.get_errormsg() if hasattr(job, "get_errormsg") else "Could not determine error message. Please check the output manually."
+                    err_msg = (
+                        job.get_errormsg()
+                        if hasattr(job, "get_errormsg")
+                        else "Could not determine error message. Please check the output manually."
+                    )
                     err_lines = err_msg.splitlines()
                     max_lines = 20
                     if len(err_lines) > max_lines:

--- a/core/jobrunner.py
+++ b/core/jobrunner.py
@@ -139,7 +139,7 @@ class JobRunner(metaclass=_MetaRunner):
             # Log job summaries
             try:
                 # Log any error messages to the standard logger
-                if not job.check():
+                if not job.ok(False) or not job.check():
                     # get_errormsg is not required by the base job class, but often implemented by convention
                     err_msg = (
                         job.get_errormsg()

--- a/core/jobrunner.py
+++ b/core/jobrunner.py
@@ -136,7 +136,21 @@ class JobRunner(metaclass=_MetaRunner):
                 job._execute(self)
                 job._finalize()
         finally:
+            # Log job summaries
             try:
+                # Log any error messages to the standard logger
+                if not job.check():
+                    # get_errormsg is not required by the base job class, but often implemented by convention
+                    err_msg = job.get_errormsg() if hasattr(job, "get_errormsg") else "Could not determine error message. Please check the output manually."
+                    err_lines = err_msg.splitlines()
+                    max_lines = 20
+                    if len(err_lines) > max_lines:
+                        err_lines = err_lines[:max_lines]
+                        err_lines.append("... (see output for full error)")
+                    err_msg = str.join("\n", [f"\t{l}" for l in err_lines])
+                    log(f"""Error message for job {job.name} was:\n{err_msg}""", 3)
+
+                # Log job summary to the csv logger
                 jobmanager.job_logger.log(job, level=3)
             except:  # logging should never throw, but best to make sure
                 pass

--- a/core/jobrunner.py
+++ b/core/jobrunner.py
@@ -147,7 +147,7 @@ class JobRunner(metaclass=_MetaRunner):
                         else "Could not determine error message. Please check the output manually."
                     )
                     err_lines = err_msg.splitlines()
-                    max_lines = 20
+                    max_lines = 30
                     if len(err_lines) > max_lines:
                         err_lines = err_lines[:max_lines]
                         err_lines.append("... (see output for full error)")

--- a/core/logging.py
+++ b/core/logging.py
@@ -303,7 +303,7 @@ class CSVFormatter(logging.Formatter):
         if self.include_level:
             log_record["level"] = 28 - record.levelno
         if self.log_time:
-            log_record["asctime"] = self.formatTime(record, self.datefmt)
+            log_record["logged_at"] = self.formatTime(record, self.datefmt)
 
         if isinstance(record.msg, dict):
             log_record.update(record.msg)

--- a/interfaces/adfsuite/ams.py
+++ b/interfaces/adfsuite/ams.py
@@ -2522,7 +2522,7 @@ class AMSJob(SingleJob):
                         with open(self.results["$JN.err"]) as err:
                             msg = err.read().strip()
 
-                elif termination_status == "IN PROGRESS" and "$JN.err" in self.results:
+                elif "$JN.err" in self.results:
                     # If the status is still "IN PROGRESS", that probably means AMS was shut down hard from the outside.
                     # E.g. it got SIGKILL from the scheduler for exceeding some resource limit.
                     # In this case useful information may be found on stderr.
@@ -2530,7 +2530,10 @@ class AMSJob(SingleJob):
                         errlines = err.read().splitlines()
                     for el in reversed(errlines):
                         if el != "" and not el.isspace():
-                            msg = "Killed while IN PROGRESS: " + el
+                            msg = (
+                                f"Termination status: {termination_status}. Message: {el} . "
+                                f"Check the files in {self.path} for more details."
+                            )
                             break
             except:
                 pass

--- a/interfaces/adfsuite/ams.py
+++ b/interfaces/adfsuite/ams.py
@@ -2488,41 +2488,41 @@ class AMSJob(SingleJob):
             try:
                 # Something went wrong. The first place to check is the termination status on the ams.rkf.
                 # If the AMS driver stopped with a known error (called StopIt in the Fortran code), the error will be in there.
-                # Note AMS can crash before even creating an rkf, at which point the log and stderr files are available.
+                # Status can be:
+                # - NORMAL TERMINATION with errors: find the error from the ams log file
+                # - IN PROGRESS: probably means AMS was shut down hard from the outside
+                #                e.g. it got SIGKILL from the scheduler for exceeding some resource limit
+                #                find the last error from the stderr
+                # Note AMS can crash before even creating an rkf, then can just check the output and error files.
                 try:
                     termination_status = self.results.readrkf("General", "termination status")
                 except FileError:
                     termination_status = None
 
-                if termination_status == "NORMAL TERMINATION with errors" or termination_status is None:
-                    # First look for the last error in the logfile
-                    try:
-                        log_err_lines = self.results.grep_file("ams.log", "ERROR: ")
-                        if log_err_lines:
-                            return log_err_lines[-1].partition("ERROR: ")[2]
-                    except FileError:
-                        pass
+                # First look for the last error in the logfile
+                try:
+                    log_err_lines = self.results.grep_file("ams.log", "ERROR: ")
+                    if log_err_lines:
+                        return log_err_lines[-1].partition("ERROR: ")[2]
+                except FileError:
+                    pass
 
-                    # Then for a licensing issue, check the output logs directly
-                    try:
-                        license_err_lines = self.results.get_output_chunk(
-                            begin="LICENSE INVALID",
-                            end="License file",
-                            inc_begin=True,
-                            inc_end=True,
-                            match=1,
-                        )
-                        if license_err_lines:
-                            return str.join("\n", license_err_lines)
-                    except FileError:
-                        pass
+                # Then for a licensing issue, check the output logs directly
+                try:
+                    license_err_lines = self.results.get_output_chunk(
+                        begin="LICENSE INVALID",
+                        end="License file",
+                        inc_begin=True,
+                        inc_end=True,
+                        match=1,
+                    )
+                    if license_err_lines:
+                        return str.join("\n", license_err_lines)
+                except FileError:
+                    pass
 
-                    # For any other issue fall back to the error file directly
-                    if "$JN.err" in self.results:
-                        with open(self.results["$JN.err"]) as err:
-                            msg = err.read().strip()
-
-                elif "$JN.err" in self.results:
+                # For any other issue fall back to the error file directly
+                if "$JN.err" in self.results:
                     # If the status is still "IN PROGRESS", that probably means AMS was shut down hard from the outside.
                     # E.g. it got SIGKILL from the scheduler for exceeding some resource limit.
                     # In this case useful information may be found on stderr.

--- a/unit_tests/test_amsjob.py
+++ b/unit_tests/test_amsjob.py
@@ -570,7 +570,7 @@ class TestAMSJobRun:
         # Invalid license
         job = AMSJob()
         results = MagicMock(spec=AMSResults)
-        results.readrkf.return_value = None
+        results.readrkf.side_effect = FileError()
         results.grep_file.side_effect = FileError()
         results.get_output_chunk.return_value = [
             "LICENSE INVALID",
@@ -606,6 +606,7 @@ License file: ./license.txt"""
 
         # Error in calculation
         results.readrkf.return_value = "NORMAL TERMINATION with errors"
+        results.readrkf.side_effect = None
         results.grep_file.return_value = [
             "<Dec05-2024> <13:44:55>  ERROR: Geometry optimization failed! (Did not converge.)"
         ]

--- a/unit_tests/test_basejob.py
+++ b/unit_tests/test_basejob.py
@@ -301,7 +301,7 @@ sleep 0.0 && sed 's/input/output/g' plamsjob.in
         with open(job_manager.job_logger.logfile) as f:
             assert (
                 f.readline()
-                == """asctime,job_base_name,job_name,job_status,job_parent_name,job_parent_path,job_path,job_ok,job_check,job_get_errormsg
+                == """logged_at,job_base_name,job_name,job_status,job_path,job_ok,job_check,job_get_errormsg,job_parent_name,job_parent_path
 """
             )
 

--- a/unit_tests/test_basejob.py
+++ b/unit_tests/test_basejob.py
@@ -340,7 +340,7 @@ sleep 0.0 && sed 's/input/output/g' plamsjob.in
                     re.DOTALL,
                 )
                 assert re.match(
-                    f".*Error message for job {job2.name} was:.* 3: x: (command ){{0,1}}not found.* 22: x: (command ){{0,1}}not found.*(see output for full error)",
+                    f".*Error message for job {job2.name} was:.* 3: x: (command ){{0,1}}not found.* 32: x: (command ){{0,1}}not found.*(see output for full error)",
                     stdout,
                     re.DOTALL,
                 )

--- a/unit_tests/test_basejob.py
+++ b/unit_tests/test_basejob.py
@@ -333,16 +333,14 @@ sleep 0.0 && sed 's/input/output/g' plamsjob.in
                 job1.run()
                 job2.run()
 
-                assert (
-                    f"""Error message for job {job1.name} was:
-	./{job1.name}.run: line 3: not_a_cmd: command not found"""
-                    in mock_stdout.getvalue()
+                stdout = mock_stdout.getvalue()
+                assert re.match(
+                    f".*Error message for job {job1.name} was:.* 3: not_a_cmd: (command ){{0,1}}not found",
+                    stdout,
+                    re.DOTALL,
                 )
-
-            assert (
-                f"""
-	./{job2.name}.run: line 21: x: command not found
-	./{job2.name}.run: line 22: x: command not found
-	... (see output for full error)"""
-                in mock_stdout.getvalue()
-            )
+                assert re.match(
+                    f".*Error message for job {job2.name} was:.* 3: x: (command ){{0,1}}not found.* 22: x: (command ){{0,1}}not found.*(see output for full error)",
+                    stdout,
+                    re.DOTALL,
+                )


### PR DESCRIPTION
# Description

Log any results of `AMSJob.get_errormsg` to the default logger at the end of the job.
This makes it clear in the std output what may have gone wrong e.g.

```
[05.12|13:56:39] Error message for job water_optimization was:
	 LICENSE INVALID
	 ---------------
	
	 Your license does not include module AMS version 2024.206 on this machine.
	
	 Module AMS
	 Version 2024.206
	 Machine: XXXXX
	
	 License file: ./license.txt
```

Add a small tweak to `get_errormsg` to handle license issues, and small unit test.

Note that this limits any error logs to 20 lines (arbitrary choice).

Also make the message 
```
WARNING: Trying to obtain results of crashed or failed job crashing_job
```
slightly less spammy by ignoring it when called from `ok`, `check` or `get_errormsg`