### PR TITLE
Improve Exception Handling in Pre and Post Run Methods SCMSUITE-10131 SO107

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This changelog is effective from the 2025 releases.
 * Build using `pyproject.toml`, addition of extras groups to install optional dependencies
 * Logging of job summaries to CSV logfile
 * Logging of AMS job error messages to stdout and logfile on job failure
+* Method `get_errormsg` enforced on the `Job` base class, with a default implementation
 
 ### Changed
 * Functions for optional packages (e.g. RDKit, ASE) are available even when these packages are not installed, but will raise an `MissingOptionalPackageError` when called
@@ -33,12 +34,15 @@ This changelog is effective from the 2025 releases.
 * Restructuring of examples and conversion of various examples to notebooks
 * Support for `networkx>=3` and `ase>=3.23`
 * Use standard library logger for `log` function
+* Make `Job` class inherit from `ABC` and mark abstract methods 
+* Exceptions raised in `prerun` and `postrun` will always be caught and populate error message
 
 ### Fixed
 * `Molecule.properties.charge` is a numeric instead of string type when loading molecule from a file
 * `Molecule.delete_all_bonds` removes the reference molecule from the removed bond instances
 * `SingleJob.load` returns the correctly loaded job
 * `AMSJob.check` handles a `NoneType` status, returning `False`
+* `MultiJob.run` locking resolved when errors raised within `prerun` and `postrun` methods
 
 ### Deprecated
 * `plams` launch script is deprecated in favour of simply running with `amspython`

--- a/core/basejob.py
+++ b/core/basejob.py
@@ -83,6 +83,7 @@ class Job(ABC):
         self.default_settings = [config.job]
         self.depend = depend or []
         self._dont_pickle: List[str] = []
+        self._error_msg: Optional[str] = None
         if settings is not None:
             if isinstance(settings, Settings):
                 self.settings = settings.copy()
@@ -186,6 +187,17 @@ class Job(ABC):
     @abstractmethod
     def check(self) -> bool:
         """Check if the execution of this instance was successful."""
+
+    def get_errormsg(self) -> Optional[str]:
+        """Tries to get an error message for a failed job. This method returns ``None`` for successful jobs."""
+        if self.check():
+            return None
+
+        return (
+            self._error_msg
+            if self._error_msg
+            else "Could not determine error message. Please check the output manually."
+        )
 
     @abstractmethod
     def hash(self) -> Optional[str]:

--- a/core/basejob.py
+++ b/core/basejob.py
@@ -4,7 +4,7 @@ import stat
 import threading
 import time
 from os.path import join as opj
-from typing import TYPE_CHECKING, Dict, Generator, Iterable, List, Optional, Union, Callable, Any
+from typing import TYPE_CHECKING, Dict, Generator, Iterable, List, Optional, Union
 from abc import ABC, abstractmethod
 import traceback
 
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 __all__ = ["SingleJob", "MultiJob"]
 
 
-def _fail_on_exception(func: Callable[["Job", Any], Any]) -> Callable[["Job", Any], Any]:
+def _fail_on_exception(func):
     """Decorator to wrap a job method and mark the job as failed on any exception."""
 
     def wrapper(self: "Job", *args, **kwargs):
@@ -39,11 +39,11 @@ def _fail_on_exception(func: Callable[["Job", Any], Any]) -> Callable[["Job", An
         except:
             # Mark job status as failed and the results as complete
             self.status = JobStatus.FAILED
-            self.results.finished.set()
-            self.results.done.set()
+            self.results.finished.set()  # type: ignore
+            self.results.done.set()  # type: ignore
             # Notify any parent multi-job of the failure
-            if self.parent and self in self.parent:
-                self.parent._notify()
+            if self.parent and self in self.parent:  # type: ignore
+                self.parent._notify()  # type: ignore
             # Store the exception message to be accessed from get_errormsg
             self._error_msg = traceback.format_exc()
 

--- a/core/basejob.py
+++ b/core/basejob.py
@@ -36,7 +36,7 @@ def _fail_on_exception(func):
     def wrapper(self: "Job", *args, **kwargs):
         try:
             return func(self, *args, **kwargs)
-        except:
+        except Exception:
             # Mark job status as failed and the results as complete
             self.status = JobStatus.FAILED
             self.results.finished.set()  # type: ignore

--- a/core/basejob.py
+++ b/core/basejob.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Dict, Generator, Iterable, List, Optional, Uni
 from abc import ABC, abstractmethod
 import traceback
 
-from scm.plams.core.enums import JobStatus
+from scm.plams.core.enums import JobStatus, JobStatusType
 from scm.plams.core.errors import FileError, JobError, PlamsError, ResultsError
 from scm.plams.core.functions import config, log
 from scm.plams.core.private import sha256
@@ -124,14 +124,14 @@ class Job(ABC):
     # =======================================================================
 
     @property
-    def status(self) -> JobStatus:
+    def status(self) -> JobStatusType:
         """
         Current status of the job
         """
         return self._status
 
     @status.setter
-    def status(self, value: JobStatus) -> None:
+    def status(self, value: JobStatusType) -> None:
         # This setter should really be private i.e. internally should use self._status
         # But for backwards compatibility it is exposed and set by e.g. the JobManager
         self._status = value

--- a/core/enums.py
+++ b/core/enums.py
@@ -1,3 +1,5 @@
+from typing import Literal, Union
+
 # Import StrEnum for Python >=3.11, otherwise use backwards compatible class
 try:
     from enum import StrEnum  # type: ignore
@@ -13,7 +15,7 @@ except ImportError:
             return str(self.value)
 
 
-__all__ = ["JobStatus"]
+__all__ = ["JobStatus", "JobStatusType"]
 
 
 class JobStatus(StrEnum):
@@ -32,3 +34,21 @@ class JobStatus(StrEnum):
     COPIED = "copied"
     PREVIEW = "preview"
     DELETED = "deleted"
+
+
+JobStatusType = Union[
+    JobStatus,
+    Literal[
+        "created",
+        "started",
+        "registered",
+        "running",
+        "finished",
+        "crashed",
+        "failed",
+        "successful",
+        "copied",
+        "preview",
+        "deleted",
+    ],
+]

--- a/core/formatters.py
+++ b/core/formatters.py
@@ -38,15 +38,8 @@ class JobCSVFormatter(CSVFormatter):
 
             if job.status not in [JobStatus.REGISTERED, JobStatus.RUNNING]:
                 message.update({"job_ok": job.ok()})
-                try:
-                    message.update({"job_check": job.check()})
-                except TypeError:
-                    pass
-                try:
-                    # this one it is not supported by the Job class but on many jobs they have it implemented
-                    message.update({"job_get_errormsg": job.get_errormsg()})
-                except (AttributeError, TypeError):
-                    pass
+                message.update({"job_check": job.check()})
+                message.update({"job_get_errormsg": job.get_errormsg()})
 
         if job.parent:
             message["job_parent_name"] = job.parent.name

--- a/core/jobrunner.py
+++ b/core/jobrunner.py
@@ -140,12 +140,7 @@ class JobRunner(metaclass=_MetaRunner):
             try:
                 # Log any error messages to the standard logger
                 if not job.ok(False) or not job.check():
-                    # get_errormsg is not required by the base job class, but often implemented by convention
-                    err_msg = (
-                        job.get_errormsg()
-                        if hasattr(job, "get_errormsg")
-                        else "Could not determine error message. Please check the output manually."
-                    )
+                    err_msg = job.get_errormsg()
                     err_lines = err_msg.splitlines()
                     max_lines = 30
                     if len(err_lines) > max_lines:

--- a/interfaces/adfsuite/ams.py
+++ b/interfaces/adfsuite/ams.py
@@ -1802,8 +1802,8 @@ class AMSResults(Results):
 
         start_step, end_step, every, _ = self._get_integer_start_end_every_max(start_fs, end_fs, every_fs, None)
         nEntries = self.readrkf("History", "nEntries")
-        coords = np.array(self.get_history_property("Coords")).reshape(nEntries, -1, 3)
-        coords = coords[start_step:end_step:every]
+        history_coords = np.array(self.get_history_property("Coords")).reshape(nEntries, -1, 3)
+        coords = history_coords[start_step:end_step:every]
         nEntries = len(coords)
 
         axis2index = {"x": 0, "y": 1, "z": 2}
@@ -2507,7 +2507,7 @@ class AMSJob(SingleJob):
                 try:
                     log_err_lines = self.results.grep_file("ams.log", "ERROR: ")
                     if log_err_lines:
-                        self._error_msg = log_err_lines[-1].partition("ERROR: ")[2]
+                        self._error_msg: Optional[str] = log_err_lines[-1].partition("ERROR: ")[2]
                         return self._error_msg
                 except FileError:
                     pass

--- a/interfaces/adfsuite/ams.py
+++ b/interfaces/adfsuite/ams.py
@@ -2483,10 +2483,14 @@ class AMSJob(SingleJob):
         if self.check():
             return None
         else:
+            # Check if there is an error captured during the job process, or a previously cached error
+            if self._error_msg:
+                return self._error_msg
+
             default_msg = "Could not determine error message. Please check the output manually."
             msg = None
             try:
-                # Something went wrong. The first place to check is the termination status on the ams.rkf.
+                # If not, the first place to check is the termination status on the ams.rkf.
                 # If the AMS driver stopped with a known error (called StopIt in the Fortran code), the error will be in there.
                 # Status can be:
                 # - NORMAL TERMINATION with errors: find the error from the ams log file
@@ -2503,7 +2507,8 @@ class AMSJob(SingleJob):
                 try:
                     log_err_lines = self.results.grep_file("ams.log", "ERROR: ")
                     if log_err_lines:
-                        return log_err_lines[-1].partition("ERROR: ")[2]
+                        self._error_msg = log_err_lines[-1].partition("ERROR: ")[2]
+                        return self._error_msg
                 except FileError:
                     pass
 
@@ -2517,7 +2522,8 @@ class AMSJob(SingleJob):
                         match=1,
                     )
                     if license_err_lines:
-                        return str.join("\n", license_err_lines)
+                        self._error_msg = str.join("\n", license_err_lines)
+                        return self._error_msg
                 except FileError:
                     pass
 
@@ -2537,7 +2543,11 @@ class AMSJob(SingleJob):
                             break
             except:
                 pass
-            return msg if msg else default_msg
+
+            # Cache error message if called again
+            self._error_msg = msg if msg else default_msg
+
+            return self._error_msg
 
     def hash_input(self) -> str:
         """Calculate the hash of the input file.

--- a/mol/molecule.py
+++ b/mol/molecule.py
@@ -1487,7 +1487,7 @@ class Molecule:
 
         return ret
 
-    def get_complete_molecules_within_threshold(self, atom_indices, threshold: float):
+    def get_complete_molecules_within_threshold(self, atom_indices: List[int], threshold: float):
         """
         Returns a new molecule containing complete submolecules for any molecules
         that are closer than ``threshold`` to any of the atoms in ``atom_indices``.
@@ -1509,7 +1509,7 @@ class Molecule:
         D = distance_array(solvated_coords, solvated_coords)[zero_based_indices]
         less_equal = np.less_equal(D, threshold)
         within_threshold = np.any(less_equal, axis=0)
-        good_indices = [i for i, value in enumerate(within_threshold) if value]
+        good_indices = [i for i, value in enumerate(within_threshold) if value]  # type: ignore
 
         complete_indices: Set[int] = set()
         for indlist in molecule_indices:

--- a/unit_tests/test_amsjob.py
+++ b/unit_tests/test_amsjob.py
@@ -569,6 +569,7 @@ class TestAMSJobRun:
 
         # Invalid license
         job = AMSJob()
+        job._error_msg = None
         results = MagicMock(spec=AMSResults)
         results.readrkf.side_effect = FileError()
         results.grep_file.side_effect = FileError()
@@ -595,6 +596,7 @@ License file: ./license.txt"""
         )
 
         # Invalid input
+        job._error_msg = None
         results.grep_file.side_effect = None
         results.grep_file.return_value = [
             '<Dec05-2024> <12:03:49>  ERROR: Input error: value "foo" found in line 13 for multiple choice key "Task" is not an allowed choice'
@@ -605,9 +607,14 @@ License file: ./license.txt"""
         )
 
         # Error in calculation
+        job._error_msg = None
         results.readrkf.return_value = "NORMAL TERMINATION with errors"
         results.readrkf.side_effect = None
         results.grep_file.return_value = [
             "<Dec05-2024> <13:44:55>  ERROR: Geometry optimization failed! (Did not converge.)"
         ]
         assert job.get_errormsg() == "Geometry optimization failed! (Did not converge.)"
+
+        # Error in prerun
+        job._error_msg = "RuntimeError: something went wrong"
+        assert job.get_errormsg() == "RuntimeError: something went wrong"

--- a/unit_tests/test_molecule.py
+++ b/unit_tests/test_molecule.py
@@ -216,6 +216,15 @@ class TestWater(MoleculeTestBase):
         with pytest.raises(MoleculeError):
             assert mol.guess_atomic_charges() == [1, 1, 0, 0]
 
+    def test_get_complete_molecules_within_threshold(self, mol):
+        m0 = mol.get_complete_molecules_within_threshold([2], 0)
+        m1 = mol.get_complete_molecules_within_threshold([2], 1)
+        m2 = mol.get_complete_molecules_within_threshold([2], 2)
+
+        assert m0.get_formula() == "H"
+        assert m1.get_formula() == "HO"
+        assert m2.get_formula() == "H2O"
+
 
 class TestNiO(MoleculeTestBase):
     """


### PR DESCRIPTION
# Description 

The behaviour of exceptions raised in `prerun` and `postrun` methods of jobs was inconsistent and had issues, for example:

* `SingleJob` with a serial runner would raise the exception in the main thread and so kill the script entirely (not just fail a job)
* With a parallel runner, any exceptions would only get raised on the spawned thread and not be surfaced on the main thread, so there is a discrepancy in behaviour
* A multi-job which had a job which raised an exception in a child job would deadlock. This is because the parent job would never be notified that the job had finished

This PR makes this behaviour consistent, by catching any exception raised in these job steps, marking the job as complete, and storing the error message.

# Changes 

To achieve this, the following changes were made:

* The method `get_errormsg` which was already implemented on the `AMSJob` has been added to the `Job` base class with some basic implementation
* Add the decorator `_fail_on_exception` which handles exceptions for functions, marks the job and complete and notifies the parent multi-job
* Apply this decorator to `_prepare`, `_execute` and `_finalize`
* Store the exception trace in `_error_msg` which can be used by `get_errormsg` 

The following changes were also made:

* Fix some mypy issues that were flagged on the latest version 
* Convert the `Job` to an actual abstract base class instead of just raising exceptions when the methods were called