### PR TITLE
Add job status logging to job logger csv SCMSUITE-10132 SO107

### DIFF
--- a/core/basejob.py
+++ b/core/basejob.py
@@ -2,9 +2,10 @@ import copy
 import os
 import stat
 import threading
+import datetime
 import time
 from os.path import join as opj
-from typing import TYPE_CHECKING, Dict, Generator, Iterable, List, Optional, Union
+from typing import TYPE_CHECKING, Dict, Generator, Iterable, List, Optional, Union, Tuple
 from abc import ABC, abstractmethod
 import traceback
 
@@ -94,6 +95,7 @@ class Job(ABC):
     ):
         if os.path.sep in name:
             raise PlamsError("Job name cannot contain {}".format(os.path.sep))
+        self._status_log: List[Tuple[datetime.datetime, str]] = []
         self.status = JobStatus.CREATED
         self.results = self.__class__._result_type(self)
         self.name = name
@@ -135,6 +137,15 @@ class Job(ABC):
         # This setter should really be private i.e. internally should use self._status
         # But for backwards compatibility it is exposed and set by e.g. the JobManager
         self._status = value
+        self._status_log.append((datetime.datetime.now(), str(value)))
+
+    @property
+    def status_log(self) -> List[Tuple[datetime.datetime, str]]:
+        """
+        Log of the status changes of the job, in chronological order.
+        Each entry in the list consists of a timestamp and the set status.
+        """
+        return self._status_log
 
     def run(
         self, jobrunner: Optional["JobRunner"] = None, jobmanager: Optional["JobManager"] = None, **kwargs

--- a/core/formatters.py
+++ b/core/formatters.py
@@ -29,6 +29,7 @@ class JobCSVFormatter(CSVFormatter):
             "job_ok": "",
             "job_check": "",
             "job_get_errormsg": "",
+            "job_timeline": str.join(" -> ", [f"{dt.strftime('%Y-%m-%d %H:%M:%S')} {s}" for dt, s in job.status_log]),
             "job_parent_name": "",
             "job_parent_path": "",
         }


### PR DESCRIPTION
# Description

Add a job status tracker to the base plams job, which stores the status and the timestamp at which it was changed.

Add a field to the job logging csv, which shows the timeline of these status changes. This can be useful for analysing how long jobs take and when they start running etc. which can be useful for job analysis.

An example would be:
```
2024-12-12 10:43:48 created -> 2024-12-12 10:43:48 started -> 2024-12-12 10:43:48 registered -> 2024-12-12 10:43:48 running -> 2024-12-12 10:43:51 finished -> 2024-12-12 10:43:51 successful
```