### PR TITLE
Improve Input File Generation For UCS and PISA SCMSUITE-10150 SO107

### DIFF
--- a/interfaces/adfsuite/ams.py
+++ b/interfaces/adfsuite/ams.py
@@ -2576,14 +2576,14 @@ class AMSJob(SingleJob):
         Special values can be indicated with *special* argument, which should be a dictionary having types of objects as keys and functions translating these types to strings as values.
         """
 
-        def unspec(value):
+        def unspec(value) -> str:
             """Check if *value* is one of a special types and convert it to string if it is."""
             for spec_type in special:
                 if isinstance(value, spec_type):
                     return special[spec_type](value)
             return value
 
-        def serialize(key, value, indent, end="End"):
+        def serialize(key: str, value, indent: int, end: str = "End") -> str:
             """Given a *key* and its corresponding *value* from the |Settings| instance produce a snippet of the input file representing this pair.
 
             If the value is a nested |Settings| instance, use recursive calls to build the snippet for the entire block. Indent the result with *indent* spaces.
@@ -2653,7 +2653,9 @@ class AMSJob(SingleJob):
                 ret += " " * indent + key + " " + str(unspec(value)) + "\n"
             return ret
 
-        def merge_system_blocks(input_settings):
+        def merge_system_blocks(
+            input_settings: Settings, systems: Dict[str, Union[Molecule, "ChemicalSystem"]]
+        ) -> Dict[str, str]:
             """
             Given a settings.input Settings object, combine the system blocks with any systems explicitly specified
             via the input molecule. These can either be PLAMS Molecules or Chemical Systems, but in both cases
@@ -2662,7 +2664,7 @@ class AMSJob(SingleJob):
             ams_key = input_settings.find_case("ams")
             system_key = input_settings[ams_key].find_case("system")
 
-            input_systems_settings = {}
+            input_systems_settings: Dict[str, Settings] = {}
             for item in input_settings[ams_key]:
                 if item == system_key:
                     input_system_settings = input_settings[ams_key][item]
@@ -2673,7 +2675,7 @@ class AMSJob(SingleJob):
 
             systems_settings = {n: self._serialize_single_molecule(n, m) for n, m in systems.items()}
 
-            merged_systems = {}
+            merged_systems: Dict[str, str] = {}
             for name in set(input_systems_settings.keys()).union(set(systems_settings.keys())):
                 input_system_settings = input_systems_settings.get(name, Settings())
                 system_settings = systems_settings.get(name, Settings())
@@ -2683,6 +2685,7 @@ class AMSJob(SingleJob):
 
             return merged_systems
 
+        systems: Dict[str, Union[Molecule, "ChemicalSystem"]]
         if isinstance(self.molecule, Molecule) or (_has_scm_chemsys and isinstance(self.molecule, ChemicalSystem)):
             systems = {"": self.molecule}
         elif isinstance(self.molecule, dict):
@@ -2699,15 +2702,15 @@ class AMSJob(SingleJob):
             #   self.settings.input is an input class that knows how to serialize itself to text input.
 
             # Generate initial input text
-            input_settings = self.settings.input
-            txtinp = input_settings.get_input_string()
-            has_input_systems = hasattr(input_settings, "System") and input_settings.System.value_changed
+            input_class: DriverBlock = self.settings.input
+            txtinp = input_class.get_input_string()
+            has_input_systems = hasattr(input_class, "System") and input_class.System.value_changed
 
             # Add/update any systems using the input molecules
             if not has_input_systems:
                 # if there are no system blocks in the input settings there is an optimisation whereby any
                 # chemical systems can be serialised straight to text
-                system_blocks = {}
+                system_blocks: Dict[str, str] = {}
                 for name, system in systems.items():
                     if _has_scm_chemsys and isinstance(system, ChemicalSystem):
                         system_input = str(system)
@@ -2721,9 +2724,9 @@ class AMSJob(SingleJob):
             elif systems:
                 # otherwise have to go first via serialisation to settings, merge, then serialise to text
                 # to avoid duplication replace the original text system block with the updated text
-                sys_text = str(input_settings.System)
+                sys_text = str(input_class.System)
                 sys_text_updated = ""
-                system_blocks = merge_system_blocks(input_settings.to_settings())
+                system_blocks = merge_system_blocks(input_class.to_settings(), systems)
                 for system_block in system_blocks.values():
                     sys_text_updated += "\n" + system_block
                 txtinp = txtinp.replace(sys_text, sys_text_updated)
@@ -2732,7 +2735,7 @@ class AMSJob(SingleJob):
             # Open-source PLAMS way of writing input files:
             #    self.settings.input is a Settings object that we need to serialize to text input.
 
-            input_settings = self.settings.input.copy()
+            input_settings: Settings = self.settings.input.copy()
 
             ams = input_settings.find_case("ams")
             syst = input_settings[ams].find_case("system")
@@ -2763,7 +2766,7 @@ class AMSJob(SingleJob):
                     system_blocks[name] = system_input
             else:
                 # otherwise have to go first via serialisation to settings, merge, then serialise to text
-                system_blocks = merge_system_blocks(input_settings)
+                system_blocks = merge_system_blocks(input_settings, systems)
 
             for system_block in system_blocks.values():
                 txtinp += system_block
@@ -2776,13 +2779,14 @@ class AMSJob(SingleJob):
         return txtinp
 
     def _serialize_single_molecule(self, name: str, mol: Union[Molecule, "ChemicalSystem"]) -> Settings:
-        def serialize_unichemsys_to_settings(mol):
+
+        def serialize_unichemsys_to_settings(mol: "ChemicalSystem") -> Settings:
             from scm.plams.interfaces.adfsuite.inputparser import InputParserFacade
 
             sett = InputParserFacade().to_settings(AMSJob._command, str(mol))
             return sett.ams.system[0]
 
-        def serialize_molecule_to_settings(mol: Molecule, name: Optional[str] = None):
+        def serialize_molecule_to_settings(mol: Molecule, name: Optional[str] = None) -> Settings:
             sett = Settings()
 
             if len(mol.lattice) in [1, 2] and mol.align_lattice():
@@ -2838,7 +2842,7 @@ class AMSJob(SingleJob):
 
         return sett
 
-    def _serialize_molecule(self):
+    def _serialize_molecule(self) -> List[Settings]:
         """Return a list of |Settings| instances containing the information about one or more |Molecule| instances stored in the ``molecule`` attribute.
 
         Molecular charge is taken from ``molecule.properties.charge``, if present. Additional, atom-specific information to be put in ``atoms`` block after XYZ coordinates can be supplied with ``atom.properties.suffix``.
@@ -2847,7 +2851,7 @@ class AMSJob(SingleJob):
         """
 
         if self.molecule is None:
-            return Settings()
+            return []
 
         if isinstance(self.molecule, Molecule) or (_has_scm_chemsys and isinstance(self.molecule, ChemicalSystem)):
             moldict = {"": self.molecule}

--- a/interfaces/adfsuite/ams.py
+++ b/interfaces/adfsuite/ams.py
@@ -2662,17 +2662,10 @@ class AMSJob(SingleJob):
             systems = self._serialize_molecule()
             for system in systems:
                 system_input = serialize("System", system, 0)
-                # merge existing system block with one serialized from the molecule
                 if hasattr(self.settings.input, "System") and self.settings.input.System.value_changed:
-                    if system["_h"]:
-                        split_line = f"System {system['_h']}\n"
-                    else:
-                        split_line = "System\n"
-                    start, end = txtinp.split(split_line)
-                    # strip duplicate 'End' from molecule system block
-                    system_input = "".join(system_input.splitlines(keepends=True)[:-1])
-                    # insert system input in proper place
-                    txtinp = start + system_input + end
+                    raise PlamsError(
+                        f"Cannot set system block in settings and provide molecule(s). Please remove either 'settings.input.{self.settings.input.name}.System' or the input molecule(s)."
+                    )
                 else:
                     txtinp += "\n" + system_input
 

--- a/interfaces/adfsuite/ams.py
+++ b/interfaces/adfsuite/ams.py
@@ -2717,7 +2717,7 @@ class AMSJob(SingleJob):
                         if name:
                             system_input = system_input.replace("System", f"System {name}", 1)
                     else:
-                        system_settings = self._serialize_single_molecule(name, system)
+                        system_settings = AMSJob._serialize_single_molecule(name, system)
                         system_input = serialize("System", system_settings, 0)
                     system_blocks[name] = system_input
                     txtinp += "\n" + system_input
@@ -2761,7 +2761,7 @@ class AMSJob(SingleJob):
                         if name:
                             system_input = system_input.replace("System", f"System {name}", 1)
                     else:
-                        system_settings = self._serialize_single_molecule(name, system)
+                        system_settings = AMSJob._serialize_single_molecule(name, system)
                         system_input = serialize("System", system_settings, 0)
                     system_blocks[name] = system_input
             else:
@@ -2778,7 +2778,8 @@ class AMSJob(SingleJob):
 
         return txtinp
 
-    def _serialize_single_molecule(self, name: str, mol: Union[Molecule, "ChemicalSystem"]) -> Settings:
+    @staticmethod
+    def _serialize_single_molecule(name: str, mol: Union[Molecule, "ChemicalSystem"]) -> Settings:
 
         def serialize_unichemsys_to_settings(mol: "ChemicalSystem") -> Settings:
             from scm.plams.interfaces.adfsuite.inputparser import InputParserFacade
@@ -2791,14 +2792,13 @@ class AMSJob(SingleJob):
 
             if len(mol.lattice) in [1, 2] and mol.align_lattice():
                 log(
-                    "The lattice of {} Molecule supplied for job {} did not follow the convention required by AMS. I rotated the whole system for you. You're welcome".format(
-                        name if name else "main", self._full_name()
-                    ),
+                    "The lattice of {} Molecule supplied did not follow the convention required by AMS. "
+                    "I rotated the whole system for you. You're welcome".format(name if name else "main"),
                     3,
                 )
 
             sett.Atoms._1 = [
-                atom.str(symbol=self._atom_symbol(atom), space=18, decimal=10, suffix=self._atom_suffix(atom))
+                atom.str(symbol=AMSJob._atom_symbol(atom), space=18, decimal=10, suffix=AMSJob._atom_suffix(atom))
                 for atom in mol
             ]
 
@@ -2862,7 +2862,7 @@ class AMSJob(SingleJob):
                 f"Incorrect 'molecule' attribute of job {self._full_name()}. 'molecule' should be a Molecule, a UnifiedChemicalSystem, a dictionary or None, and not {type(self.molecule).__name__}"
             )
 
-        ret = [self._serialize_single_molecule(name, molecule) for name, molecule in moldict.items()]
+        ret = [AMSJob._serialize_single_molecule(name, molecule) for name, molecule in moldict.items()]
 
         return ret
 

--- a/unit_tests/test_amsjob.py
+++ b/unit_tests/test_amsjob.py
@@ -10,7 +10,6 @@ import threading
 
 from scm.plams.interfaces.adfsuite.ams import AMSJob, AMSResults
 from scm.plams.core.settings import Settings
-from scm.plams.core.errors import PlamsError
 from scm.plams.mol.molecule import Atom, Molecule
 from scm.plams.unit_tests.test_helpers import skip_if_no_scm_pisa, skip_if_no_scm_libbase
 
@@ -56,9 +55,12 @@ class TestAMSJob:
         """
         Get expected input file
         """
-        return """Properties
+        return """\
+Properties
   NormalModes Yes
 End
+
+Task GeometryOptimization
 
 System
   Atoms
@@ -67,8 +69,6 @@ System
               H       0.0000000000       1.0000000000       0.0000000000
   End
 End
-
-Task GeometryOptimization
 
 Engine DFTB
   Model GFN1-xTB
@@ -84,7 +84,12 @@ EndEngine
         # Then job molecule is a deep copy
         if job_input.molecule is not None:
             assert job.molecule is not job_input.molecule
-            assert job.molecule.atoms is not job_input.molecule.atoms
+            if isinstance(job_input.molecule, dict):
+                for name, mol in job.molecule.items():
+                    assert mol is not job_input.molecule[name]
+                    assert mol.atoms is not job_input.molecule[name].atoms
+            else:
+                assert job.molecule.atoms is not job_input.molecule.atoms
         else:
             assert job.molecule is None
 
@@ -214,7 +219,8 @@ class TestAMSJobWithPisa(TestAMSJob):
         """
         Get expected input file
         """
-        return """Properties
+        return """\
+Properties
   NormalModes True
 End
 Task GeometryOptimization
@@ -230,6 +236,66 @@ System
               H       0.0000000000       1.0000000000       0.0000000000
   End
 End
+"""
+
+
+class TestAMSJobWithPisaOnly(TestAMSJob):
+    """
+    Test suite for AMSJob using PISA for settings and molecule input.
+    Sets up a geometry optimization of water.
+    """
+
+    @staticmethod
+    def get_input_molecule():
+        """
+        Get instance of the Molecule class passed to the AMSJob
+        """
+        return None
+
+    @staticmethod
+    def get_input_settings():
+        """
+        Instance of the Settings class passed to the AMSJob
+        """
+        skip_if_no_scm_pisa()
+        from scm.input_classes.drivers import AMS
+        from scm.input_classes.engines import DFTB
+
+        settings = Settings()
+        driver = AMS()
+        driver.Task = "GeometryOptimization"
+        driver.Properties.NormalModes = "True"
+        driver.Engine = DFTB()
+        driver.Engine.Model = "GFN1-xTB"
+        driver.System.Atoms = [
+            "O       0.0000000000       0.0000000000       0.0000000000",
+            "H       1.0000000000       0.0000000000       0.0000000000",
+            "H       0.0000000000       1.0000000000       0.0000000000",
+        ]
+        settings.input = driver
+        return settings
+
+    @staticmethod
+    def get_expected_input():
+        """
+        Get expected input file
+        """
+        return """\
+Properties
+  NormalModes True
+End
+System
+  Atoms
+    O       0.0000000000       0.0000000000       0.0000000000
+    H       1.0000000000       0.0000000000       0.0000000000
+    H       0.0000000000       1.0000000000       0.0000000000
+  End
+End
+Task GeometryOptimization
+
+Engine DFTB
+  Model GFN1-xTB
+EndEngine
 """
 
 
@@ -257,25 +323,69 @@ class TestAMSJobWithChemicalSystem(TestAMSJob):
         """
         Get expected input file
         """
-        return """Properties
+        return """\
+Properties
   NormalModes Yes
 End
 
-System
-  Atoms
-     O    0.0000000000000000  0.0000000000000000  0.0000000000000000
-     H    1.0000000000000000  0.0000000000000000  0.0000000000000000
-     H    0.0000000000000000  1.0000000000000000  0.0000000000000000
-  End
-End
-
 Task GeometryOptimization
+
+System
+   Atoms
+      O    0.0000000000000000  0.0000000000000000  0.0000000000000000
+      H    1.0000000000000000  0.0000000000000000  0.0000000000000000
+      H    0.0000000000000000  1.0000000000000000  0.0000000000000000
+   End
+End
 
 Engine DFTB
   Model GFN1-xTB
 EndEngine
 
 """
+
+
+class TestAMSJobWithChemicalSystemAndPisa(TestAMSJobWithPisa):
+    """
+    Test suite for AMSJob using ChemicalSystem for molecule input and PISA for settings input
+    """
+
+    @staticmethod
+    def get_input_molecule():
+        """
+        Instance of the Molecule class passed to the AMSJob
+        """
+        skip_if_no_scm_libbase()
+        from scm.libbase import UnifiedChemicalSystem as ChemicalSystem
+
+        molecule = ChemicalSystem()
+        molecule.add_atom("O", coords=[0, 0, 0])
+        molecule.add_atom("H", coords=[1, 0, 0])
+        molecule.add_atom("H", coords=[0, 1, 0])
+        return molecule
+
+    @staticmethod
+    def get_expected_input():
+        """
+        Get expected input file
+        """
+        return """\
+Properties
+  NormalModes True
+End
+Task GeometryOptimization
+
+Engine DFTB
+  Model GFN1-xTB
+EndEngine
+
+System
+   Atoms
+      O    0.0000000000000000  0.0000000000000000  0.0000000000000000
+      H    1.0000000000000000  0.0000000000000000  0.0000000000000000
+      H    0.0000000000000000  1.0000000000000000  0.0000000000000000
+   End
+End"""
 
 
 class TestAMSJobWithMultipleMolecules(TestAMSJob):
@@ -320,10 +430,13 @@ class TestAMSJobWithMultipleMolecules(TestAMSJob):
         """
         Get expected input file
         """
-        return """NEB
+        return """\
+NEB
   Images 9
   Iterations 100
 End
+
+Task NEB
 
 System
   Atoms
@@ -340,8 +453,6 @@ System final
   End
 End
 
-Task NEB
-
 Engine DFTB
   DispersionCorrection D3-BJ
   Model DFTB3
@@ -350,21 +461,10 @@ EndEngine
 
 """
 
-    def test_init_deep_copies_molecule(self, job_input):
-        # Given job with molecule
-        job = AMSJob(molecule=job_input.molecule)
-
-        # When get molecule from job
-        # Then job molecule is a deep copy
-        assert job.molecule is not job_input.molecule
-        for name, mol in job.molecule.items():
-            assert mol is not job_input.molecule[name]
-            assert mol.atoms is not job_input.molecule[name].atoms
-
 
 class TestAMSJobWithMultipleMoleculesAndPisa(TestAMSJobWithMultipleMolecules):
     """
-    Test suite for AMSJob using multiple molecules and PISA.
+    Test suite for AMSJob using multiple molecules and PISA for settings input.
     Sets up a NEB calculation for the isomerisation of HCN.
     """
 
@@ -374,7 +474,6 @@ class TestAMSJobWithMultipleMoleculesAndPisa(TestAMSJobWithMultipleMolecules):
         Instance of the Settings class passed to the AMSJob
         """
         skip_if_no_scm_pisa()
-
         from scm.input_classes.drivers import AMS
         from scm.input_classes.engines import DFTB
 
@@ -395,7 +494,8 @@ class TestAMSJobWithMultipleMoleculesAndPisa(TestAMSJobWithMultipleMolecules):
         """
         Get expected input file
         """
-        return """NEB
+        return """\
+NEB
   Images 9
   Iterations 100
 End
@@ -425,9 +525,88 @@ End
 """
 
 
+class TestAMSJobWithMultipleMoleculesAndPisaOnly(TestAMSJobWithMultipleMolecules):
+    """
+    Test suite for AMSJob using multiple molecules and PISA for settings and molecule input.
+    Sets up a NEB calculation for the isomerisation of HCN.
+    """
+
+    @staticmethod
+    def get_input_molecule():
+        """
+        Get instance of the Molecule class passed to the AMSJob
+        """
+        return None
+
+    @staticmethod
+    def get_input_settings():
+        """
+        Instance of the Settings class passed to the AMSJob
+        """
+        skip_if_no_scm_pisa()
+        from scm.input_classes.drivers import AMS
+        from scm.input_classes.engines import DFTB
+
+        settings = Settings()
+        driver = AMS()
+        driver.Task = "NEB"
+        driver.NEB.Images = 9
+        driver.NEB.Iterations = 100
+        driver.Engine = DFTB()
+        driver.Engine.Model = "DFTB3"
+        driver.Engine.ResourcesDir = "DFTB.org/3ob-3-1"
+        driver.Engine.DispersionCorrection = "D3-BJ"
+        driver.System[0].Atoms = [
+            "C       0.0000000000       0.0000000000       0.0000000000",
+            "N       1.1800000000       0.0000000000       0.0000000000",
+            "H       2.1960000000       0.0000000000       0.0000000000",
+        ]
+        driver.System[1].header = "final"
+        driver.System[1].Atoms = [
+            "C       0.0000000000       0.0000000000       0.0000000000",
+            "N       1.1630000000       0.0000000000       0.0000000000",
+            "H      -1.0780000000       0.0000000000       0.0000000000",
+        ]
+        settings.input = driver
+        return settings
+
+    @staticmethod
+    def get_expected_input():
+        """
+        Get expected input file
+        """
+        return """\
+NEB
+  Images 9
+  Iterations 100
+End
+System
+  Atoms
+    C       0.0000000000       0.0000000000       0.0000000000
+    N       1.1800000000       0.0000000000       0.0000000000
+    H       2.1960000000       0.0000000000       0.0000000000
+  End
+End
+System final
+  Atoms
+    C       0.0000000000       0.0000000000       0.0000000000
+    N       1.1630000000       0.0000000000       0.0000000000
+    H      -1.0780000000       0.0000000000       0.0000000000
+  End
+End
+Task NEB
+
+Engine DFTB
+  DispersionCorrection D3-BJ
+  Model DFTB3
+  ResourcesDir DFTB.org/3ob-3-1
+EndEngine
+"""
+
+
 class TestAMSJobWithMultipleChemicalSystems(TestAMSJobWithMultipleMolecules):
     """
-    Test suite for AMSJob using multiple Chemical Systems.
+    Test suite for AMSJob using multiple Chemical Systems for molecule input.
     Sets up a NEB calculation for the isomerisation of HCN.
     """
 
@@ -454,27 +633,28 @@ class TestAMSJobWithMultipleChemicalSystems(TestAMSJobWithMultipleMolecules):
         """
         Get expected input file
         """
-        return """NEB
+        return """\
+NEB
   Images 9
   Iterations 100
 End
 
+Task NEB
+
 System
-  Atoms
-     C    0.0000000000000000  0.0000000000000000  0.0000000000000000
-     N    1.0000000000000000  0.0000000000000000  0.0000000000000000
-     H    2.0000000000000000  0.0000000000000000  0.0000000000000000
-  End
+   Atoms
+      C    0.0000000000000000  0.0000000000000000  0.0000000000000000
+      N    1.0000000000000000  0.0000000000000000  0.0000000000000000
+      H    2.0000000000000000  0.0000000000000000  0.0000000000000000
+   End
 End
 System final
-  Atoms
-     C    0.0000000000000000  0.0000000000000000  0.0000000000000000
-     N    1.0000000000000000  0.0000000000000000  0.0000000000000000
-     H   -1.0000000000000000  0.0000000000000000  0.0000000000000000
-  End
+   Atoms
+      C    0.0000000000000000  0.0000000000000000  0.0000000000000000
+      N    1.0000000000000000  0.0000000000000000  0.0000000000000000
+      H   -1.0000000000000000  0.0000000000000000  0.0000000000000000
+   End
 End
-
-Task NEB
 
 Engine DFTB
   DispersionCorrection D3-BJ
@@ -485,93 +665,62 @@ EndEngine
 """
 
 
-class TestAMSJobWithChainOfMolecules(TestAMSJob):
+class TestAMSJobWithMultipleChemicalSystemsAndPisa(TestAMSJobWithMultipleMoleculesAndPisa):
     """
-    Test suite for AMSJob with a chain of water molecules.
+    Test suite for AMSJob using multiple Chemical Systems for molecule input and PISA for settings input.
+    Sets up a NEB calculation for the isomerisation of HCN.
     """
 
     @staticmethod
     def get_input_molecule():
         """
-        Get instance of the Molecule class passed to the AMSJob
+        Instance of the Molecule class passed to the AMSJob
         """
-        mol = TestAMSJob.get_input_molecule()
-        mol.lattice = [[3, 0, 0]]
-        return mol.supercell(4)
+        skip_if_no_scm_libbase()
+        from scm.libbase import UnifiedChemicalSystem as ChemicalSystem
 
-    @staticmethod
-    def get_input_settings():
-        """
-        Instance of the Settings class passed to the AMSJob
-        """
-        settings = Settings()
-        settings.input.Mopac.SCF.ConvergenceThreshold = 1.0e-8
-        settings.input.Mopac.model = "pm6"
-        settings.input.AMS.Task = "SinglePoint"
-        settings.input.AMS.Properties.Gradients = "Yes"
-        settings.input.AMS.NumericalDifferentiation.Parallel.nCoresPerGroup = 1
-        settings.input.AMS.NumericalDifferentiation.NuclearStepSize = 0.0001
-        settings.input.AMS.EngineDebugging.IgnoreGradientsRequest = "No"
-        settings.input.AMS.System.ElectrostaticEmbedding.ElectricField = "0.0 0.0 0.0"
-        settings.input.AMS.Task = "SinglePoint"
-        settings.input.AMS.Properties.Gradients = "Yes"
-        settings.input.AMS.NumericalDifferentiation.Parallel.nCoresPerGroup = 1
-        settings.input.AMS.NumericalDifferentiation.NuclearStepSize = 0.0001
-        return settings
+        main_molecule = ChemicalSystem()
+        main_molecule.add_atom("C", coords=(0, 0, 0))
+        main_molecule.add_atom("N", coords=(1, 0, 0))
+        main_molecule.add_atom("H", coords=(2, 0, 0))
+        final_molecule = main_molecule.copy()
+        final_molecule.atoms[2].coords[0] = -1
+        molecule = {"": main_molecule, "final": final_molecule}
+
+        return molecule
 
     @staticmethod
     def get_expected_input():
         """
         Get expected input file
         """
-        return """EngineDebugging
-  IgnoreGradientsRequest No
+        return """\
+NEB
+  Images 9
+  Iterations 100
 End
+Task NEB
 
-NumericalDifferentiation
-  NuclearStepSize 0.0001
-  Parallel
-    nCoresPerGroup 1
-  End
-End
-
-Properties
-  Gradients Yes
-End
-
-System
-  Atoms
-              O       0.0000000000       0.0000000000       0.0000000000
-              H       1.0000000000       0.0000000000       0.0000000000
-              H       0.0000000000       1.0000000000       0.0000000000
-              O       3.0000000000       0.0000000000       0.0000000000
-              H       4.0000000000       0.0000000000       0.0000000000
-              H       3.0000000000       1.0000000000       0.0000000000
-              O       6.0000000000       0.0000000000       0.0000000000
-              H       7.0000000000       0.0000000000       0.0000000000
-              H       6.0000000000       1.0000000000       0.0000000000
-              O       9.0000000000       0.0000000000       0.0000000000
-              H      10.0000000000       0.0000000000       0.0000000000
-              H       9.0000000000       1.0000000000       0.0000000000
-  End
-  ElectrostaticEmbedding
-    ElectricField 0.0 0.0 0.0
-  End
-  Lattice
-        12.0000000000     0.0000000000     0.0000000000
-  End
-End
-
-Task SinglePoint
-
-Engine Mopac
-  SCF
-    ConvergenceThreshold 1e-08
-  End
-  model pm6
+Engine DFTB
+  DispersionCorrection D3-BJ
+  Model DFTB3
+  ResourcesDir DFTB.org/3ob-3-1
 EndEngine
 
-"""
+System
+   Atoms
+      C    0.0000000000000000  0.0000000000000000  0.0000000000000000
+      N    1.0000000000000000  0.0000000000000000  0.0000000000000000
+      H    2.0000000000000000  0.0000000000000000  0.0000000000000000
+   End
+End
+System final
+   Atoms
+      C    0.0000000000000000  0.0000000000000000  0.0000000000000000
+      N    1.0000000000000000  0.0000000000000000  0.0000000000000000
+      H   -1.0000000000000000  0.0000000000000000  0.0000000000000000
+   End
+End"""
 
 
 class TestAMSJobWithSystemBlockSettings(TestAMSJob):
@@ -636,6 +785,8 @@ MolecularDynamics
   nSteps 200
 End
 
+Task MolecularDynamics
+
 System
   Atoms
              Ar       0.0000000000       0.0000000000       0.0000000000
@@ -650,15 +801,85 @@ System
   PerturbCoordinates 0.1
   SuperCell 4 4 4
 End
-
-Task MolecularDynamics
-
 """
 
 
 class TestAMSJobWithSystemBlockSettingsAndPisa(TestAMSJobWithSystemBlockSettings):
     """
-    Test suite for AMSJob with system block overrides/settings in the settings object and PISA.
+    Test suite for AMSJob with system block overrides/settings in the PISA settings object.
+    Sets up MD of Lennard-Jones system.
+    """
+
+    @staticmethod
+    def get_input_settings():
+        """
+        Get instance of the Settings class passed to the AMSJob
+        """
+        skip_if_no_scm_pisa()
+        from scm.input_classes.drivers import AMS
+
+        settings = Settings()
+        driver = AMS()
+        driver.Task = "MolecularDynamics"
+        driver.MolecularDynamics.NSteps = 200
+        driver.MolecularDynamics.TimeStep = 5.0
+        driver.MolecularDynamics.Thermostat.Type = "NHC"
+        driver.MolecularDynamics.Thermostat.Temperature = [298.15]
+        driver.MolecularDynamics.Thermostat.Tau = 100
+        driver.MolecularDynamics.Trajectory.SamplingFreq = 20
+        driver.MolecularDynamics.InitialVelocities.Type = "random"
+        driver.MolecularDynamics.InitialVelocities.Temperature = 200
+        driver.System.SuperCell = [4, 4, 4]
+        driver.System.PerturbCoordinates = 0.1
+        driver.System.Charge = 0
+        settings.input = driver
+
+        return settings
+
+    @staticmethod
+    def get_expected_input():
+        """
+        Get expected input file
+        """
+        return """\
+MolecularDynamics
+  InitialVelocities
+    Temperature 200.0
+    Type Random
+  End
+  NSteps 200
+  Thermostat
+    Tau 100.0
+    Temperature 298.15
+    Type NHC
+  End
+  TimeStep 5.0
+  Trajectory
+    SamplingFreq 20
+  End
+End
+
+System
+  Atoms
+             Ar       0.0000000000       0.0000000000       0.0000000000
+             Ar       1.6050000000       0.9266471820       2.6050000000
+  End
+  Charge 0.0
+  Lattice
+         3.2100000000     0.0000000000     0.0000000000
+         1.6050000000     2.7799415461     0.0000000000
+         0.0000000000     0.0000000000     5.2100000000
+  End
+  PerturbCoordinates 0.1
+  SuperCell 4 4 4
+End
+Task MolecularDynamics
+"""
+
+
+class TestAMSJobWithSystemBlockSettingsAndPisaOnly(TestAMSJobWithSystemBlockSettings):
+    """
+    Test suite for AMSJob with system block overrides/settings in the PISA settings.
     Sets up MD of Lennard-Jones system.
     """
 
@@ -674,6 +895,7 @@ class TestAMSJobWithSystemBlockSettingsAndPisa(TestAMSJobWithSystemBlockSettings
         """
         Get instance of the Settings class passed to the AMSJob
         """
+        skip_if_no_scm_pisa()
         from scm.input_classes.drivers import AMS
 
         settings = Settings()
@@ -745,7 +967,7 @@ Task MolecularDynamics
 
 class TestAMSJobWithSystemBlockSettingsAndChemicalSystem(TestAMSJobWithSystemBlockSettings):
     """
-    Test suite for AMSJob with system block overrides/settings in the settings object and a chemical system.
+    Test suite for AMSJob with system block overrides/settings in the settings object and a chemical system as the molecule input.
     Sets up MD of Lennard-Jones system.
     """
 
@@ -787,6 +1009,8 @@ MolecularDynamics
   nSteps 200
 End
 
+Task MolecularDynamics
+
 System
   Atoms
      Ar   0.0000000000000000  0.0000000000000000  0.0000000000000000
@@ -801,37 +1025,657 @@ System
   PerturbCoordinates 0.1
   SuperCell 4 4 4
 End
-
-Task MolecularDynamics
-
 """
 
 
-class TestAMSJobUnhappyInputs:
+class TestAMSJobWithSystemBlockSettingsAndChemicalSystemAndPisa(TestAMSJobWithSystemBlockSettingsAndPisa):
+    """
+    Test suite for AMSJob with system block overrides/settings in the Pisa settings object and a chemical system as the molecule input.
+    Sets up MD of Lennard-Jones system.
+    """
 
-    def test_pisa_with_settings_system_block_and_molecule(self):
+    @staticmethod
+    def get_input_molecule():
+        """
+        Get instance of the Molecule class passed to the AMSJob
+        """
+        skip_if_no_scm_libbase()
+        from scm.libbase import UnifiedChemicalSystem as ChemicalSystem, UnifiedLattice as Lattice
+
+        molecule = ChemicalSystem()
+        molecule.add_atom("Ar", coords=(0, 0, 0))
+        molecule.add_atom("Ar", coords=(1.605, 0.9266471820493496, 2.605))
+        molecule.lattice = Lattice([[3.21, 0.0, 0.0], [1.605, 2.779941546148048, 0.0], [0.0, 0.0, 5.21]])
+        molecule.charge = 42  # value to be overridden
+        return molecule
+
+    @staticmethod
+    def get_expected_input():
+        """
+        Get expected input file
+        """
+        return """\
+MolecularDynamics
+  InitialVelocities
+    Temperature 200.0
+    Type Random
+  End
+  NSteps 200
+  Thermostat
+    Tau 100.0
+    Temperature 298.15
+    Type NHC
+  End
+  TimeStep 5.0
+  Trajectory
+    SamplingFreq 20
+  End
+End
+
+System
+  Atoms
+     Ar   0.0000000000000000  0.0000000000000000  0.0000000000000000
+     Ar   1.6050000000000000  0.9266471820493496  2.6050000000000000
+  End
+  Charge 0.0
+  Lattice
+     3.2100000000000000   0.0000000000000000   0.0000000000000000
+     1.6050000000000000   2.7799415461480477   0.0000000000000000
+     0.0000000000000000   0.0000000000000000   5.2100000000000000
+  End
+  PerturbCoordinates 0.1
+  SuperCell 4 4 4
+End
+Task MolecularDynamics
+"""
+
+
+class TestAMSJobWithSystemBlockSettingsAndMultipleMolecules(TestAMSJob):
+    """
+    Test suite for AMSJob using multiple molecules with system block overrides/settings.
+    Sets up a PES scan.
+    """
+
+    @staticmethod
+    def get_input_molecule():
+        """
+        Get instance of the Molecule class passed to the AMSJob
+        """
+        main_molecule = Molecule()
+        main_molecule.add_atom(Atom(symbol="C", coords=(-0.13949723, -0.08053322, -0.12698191)))
+        main_molecule.add_atom(Atom(symbol="C", coords=(0.14718597, -0.17422444, 1.25723648)))
+        main_molecule.add_atom(Atom(symbol="O", coords=(1.12643603, 0.42644528, 1.83497366)))
+        main_molecule.add_atom(Atom(symbol="C", coords=(-1.17969400, -0.73436273, -0.69479265)))
+        main_molecule.add_atom(Atom(symbol="H", coords=(1.73538143, 1.00860600, 1.24790832)))
+        main_molecule.add_atom(Atom(symbol="H", coords=(0.51558278, 0.54974352, -0.75249667)))
+        main_molecule.add_atom(Atom(symbol="H", coords=(-0.42536492, -0.76321853, 2.00541072)))
+        main_molecule.add_atom(Atom(symbol="H", coords=(-1.40444698, -0.66207335, -1.76629803)))
+        main_molecule.add_atom(Atom(symbol="H", coords=(-1.87423948, -1.37900373, -0.15129934)))
+
+        second_molecule = main_molecule.copy()
+        second_molecule.properties.charge = 42
+
+        molecule = {"": main_molecule, "state2": second_molecule}
+
+        return molecule
+
+    @staticmethod
+    def get_input_settings():
+        """
+        Instance of the Settings class passed to the AMSJob
+        """
+        settings = Settings()
+        settings.input.ams.Task = "PESExploration"
+        settings.input.ams.PESExploration.Job = "LandscapeRefinement"
+        settings.input.ams.PESExploration.LoadEnergyLandscape.Path = "foo.results"
+        settings.input.ams.PESExploration.LoadEnergyLandscape.Remove = "2 5 6 7"
+        settings.input.ams.PESExploration.Optimizer.ConvergedForce = 0.01
+        settings.input.ams.PESExploration.SaddleSearch.RelaxFromSaddlePoint = "T"
+        settings.input.ams.GeometryOptimization.InitialHessian.Type = "Calculate"
+        settings.input.ams.system = []
+        settings.input.ams.system.append(Settings({"Charge": 1.0}))
+        settings.input.ams.system.append(Settings({"_h": "state2", "Charge": 1.0, "PerturbCoordinates": 0.1}))
+        return settings
+
+    @staticmethod
+    def get_expected_input():
+        """
+        Get expected input file
+        """
+        return """\
+GeometryOptimization
+  InitialHessian
+    Type Calculate
+  End
+End
+
+PESExploration
+  Job LandscapeRefinement
+  LoadEnergyLandscape
+    Path foo.results
+    Remove 2 5 6 7
+  End
+  Optimizer
+    ConvergedForce 0.01
+  End
+  SaddleSearch
+    RelaxFromSaddlePoint T
+  End
+End
+
+Task PESExploration
+
+System
+  Atoms
+              C      -0.1394972300      -0.0805332200      -0.1269819100
+              C       0.1471859700      -0.1742244400       1.2572364800
+              O       1.1264360300       0.4264452800       1.8349736600
+              C      -1.1796940000      -0.7343627300      -0.6947926500
+              H       1.7353814300       1.0086060000       1.2479083200
+              H       0.5155827800       0.5497435200      -0.7524966700
+              H      -0.4253649200      -0.7632185300       2.0054107200
+              H      -1.4044469800      -0.6620733500      -1.7662980300
+              H      -1.8742394800      -1.3790037300      -0.1512993400
+  End
+  Charge 1.0
+End
+System state2
+  Atoms
+              C      -0.1394972300      -0.0805332200      -0.1269819100
+              C       0.1471859700      -0.1742244400       1.2572364800
+              O       1.1264360300       0.4264452800       1.8349736600
+              C      -1.1796940000      -0.7343627300      -0.6947926500
+              H       1.7353814300       1.0086060000       1.2479083200
+              H       0.5155827800       0.5497435200      -0.7524966700
+              H      -0.4253649200      -0.7632185300       2.0054107200
+              H      -1.4044469800      -0.6620733500      -1.7662980300
+              H      -1.8742394800      -1.3790037300      -0.1512993400
+  End
+  Charge 1.0
+  PerturbCoordinates 0.1
+End
+"""
+
+
+class TestAMSJobWithSystemBlockSettingsAndMultipleMoleculesAndPisa(
+    TestAMSJobWithSystemBlockSettingsAndMultipleMolecules
+):
+    """
+    Test suite for AMSJob using multiple molecules with system block overrides/settings and PISA for settings input.
+    Sets up a PES scan.
+    """
+
+    @staticmethod
+    def get_input_settings():
+        """
+        Instance of the Settings class passed to the AMSJob
+        """
         skip_if_no_scm_pisa()
-
         from scm.input_classes.drivers import AMS
-        from scm.input_classes.engines import DFTB
 
         settings = Settings()
         driver = AMS()
-        driver.Task = "GeometryOptimization"
-        driver.Properties.NormalModes = "True"
-        driver.Engine = DFTB()
-        driver.Engine.Model = "GFN1-xTB"
-        driver.System.SuperCell = [2, 2, 2]
+        driver.Task = "PESExploration"
+        driver.PESExploration.Job = "LandscapeRefinement"
+        driver.PESExploration.LoadEnergyLandscape.Path = "foo.results"
+        driver.PESExploration.LoadEnergyLandscape.Remove = [2, 5, 6, 7]
+        driver.PESExploration.Optimizer.ConvergedForce = 0.01
+        driver.PESExploration.SaddleSearch.RelaxFromSaddlePoint = "T"
+        driver.GeometryOptimization.InitialHessian.Type = "Calculate"
+        driver.System[0].Charge = 1.0
+        driver.System[1].Charge = 1.0
+        driver.System[1].PerturbCoordinates = 0.1
+        driver.System[1].header = "state2"
         settings.input = driver
+        return settings
 
-        for mol in [TestAMSJob.get_input_molecule(), TestAMSJobWithMultipleMolecules.get_input_molecule()]:
-            self.verify_get_input_errors(mol, settings)
+    @staticmethod
+    def get_expected_input():
+        """
+        Get expected input file
+        """
+        return """\
+GeometryOptimization
+  InitialHessian
+    Type Calculate
+  End
+End
+PESExploration
+  Job LandscapeRefinement
+  LoadEnergyLandscape
+    Path foo.results
+    Remove 2 5 6 7
+  End
+  Optimizer
+    ConvergedForce 0.01
+  End
+  SaddleSearch
+    RelaxFromSaddlePoint True
+  End
+End
 
-    def verify_get_input_errors(self, molecule, settings):
-        job = AMSJob(molecule=molecule, settings=settings)
+System
+  Atoms
+              C      -0.1394972300      -0.0805332200      -0.1269819100
+              C       0.1471859700      -0.1742244400       1.2572364800
+              O       1.1264360300       0.4264452800       1.8349736600
+              C      -1.1796940000      -0.7343627300      -0.6947926500
+              H       1.7353814300       1.0086060000       1.2479083200
+              H       0.5155827800       0.5497435200      -0.7524966700
+              H      -0.4253649200      -0.7632185300       2.0054107200
+              H      -1.4044469800      -0.6620733500      -1.7662980300
+              H      -1.8742394800      -1.3790037300      -0.1512993400
+  End
+  Charge 1.0
+End
 
-        with pytest.raises(PlamsError):
-            job.get_input()
+System state2
+  Atoms
+              C      -0.1394972300      -0.0805332200      -0.1269819100
+              C       0.1471859700      -0.1742244400       1.2572364800
+              O       1.1264360300       0.4264452800       1.8349736600
+              C      -1.1796940000      -0.7343627300      -0.6947926500
+              H       1.7353814300       1.0086060000       1.2479083200
+              H       0.5155827800       0.5497435200      -0.7524966700
+              H      -0.4253649200      -0.7632185300       2.0054107200
+              H      -1.4044469800      -0.6620733500      -1.7662980300
+              H      -1.8742394800      -1.3790037300      -0.1512993400
+  End
+  Charge 1.0
+  PerturbCoordinates 0.1
+End
+Task PESExploration
+"""
+
+
+class TestAMSJobWithSystemBlockSettingsAndMultipleMoleculesAndPisaOnly(
+    TestAMSJobWithSystemBlockSettingsAndMultipleMolecules
+):
+    """
+    Test suite for AMSJob using multiple molecules with system block overrides/settings and PISA for settings and molecule input.
+    Sets up a PES scan.
+    """
+
+    @staticmethod
+    def get_input_molecule():
+        return None
+
+    @staticmethod
+    def get_input_settings():
+        """
+        Instance of the Settings class passed to the AMSJob
+        """
+        skip_if_no_scm_pisa()
+        from scm.input_classes.drivers import AMS
+
+        settings = Settings()
+        driver = AMS()
+        driver.Task = "PESExploration"
+        driver.PESExploration.Job = "LandscapeRefinement"
+        driver.PESExploration.LoadEnergyLandscape.Path = "foo.results"
+        driver.PESExploration.LoadEnergyLandscape.Remove = [2, 5, 6, 7]
+        driver.PESExploration.Optimizer.ConvergedForce = 0.01
+        driver.PESExploration.SaddleSearch.RelaxFromSaddlePoint = "T"
+        driver.GeometryOptimization.InitialHessian.Type = "Calculate"
+        driver.System[0].Atoms = [
+            "C      -0.1394972300      -0.0805332200      -0.1269819100",
+            "C       0.1471859700      -0.1742244400       1.2572364800",
+            "O       1.1264360300       0.4264452800       1.8349736600",
+            "C      -1.1796940000      -0.7343627300      -0.6947926500",
+            "H       1.7353814300       1.0086060000       1.2479083200",
+            "H       0.5155827800       0.5497435200      -0.7524966700",
+            "H      -0.4253649200      -0.7632185300       2.0054107200",
+            "H      -1.4044469800      -0.6620733500      -1.7662980300",
+            "H      -1.8742394800      -1.3790037300      -0.1512993400",
+        ]
+        driver.System[1].Atoms = [
+            "C      -0.1394972300      -0.0805332200      -0.1269819100",
+            "C       0.1471859700      -0.1742244400       1.2572364800",
+            "O       1.1264360300       0.4264452800       1.8349736600",
+            "C      -1.1796940000      -0.7343627300      -0.6947926500",
+            "H       1.7353814300       1.0086060000       1.2479083200",
+            "H       0.5155827800       0.5497435200      -0.7524966700",
+            "H      -0.4253649200      -0.7632185300       2.0054107200",
+            "H      -1.4044469800      -0.6620733500      -1.7662980300",
+            "H      -1.8742394800      -1.3790037300      -0.1512993400",
+        ]
+        driver.System[0].Charge = 1.0
+        driver.System[1].Charge = 1.0
+        driver.System[1].PerturbCoordinates = 0.1
+        driver.System[1].header = "state2"
+        settings.input = driver
+        return settings
+
+    @staticmethod
+    def get_expected_input():
+        """
+        Get expected input file
+        """
+        return """\
+GeometryOptimization
+  InitialHessian
+    Type Calculate
+  End
+End
+PESExploration
+  Job LandscapeRefinement
+  LoadEnergyLandscape
+    Path foo.results
+    Remove 2 5 6 7
+  End
+  Optimizer
+    ConvergedForce 0.01
+  End
+  SaddleSearch
+    RelaxFromSaddlePoint True
+  End
+End
+System
+  Atoms
+    C      -0.1394972300      -0.0805332200      -0.1269819100
+    C       0.1471859700      -0.1742244400       1.2572364800
+    O       1.1264360300       0.4264452800       1.8349736600
+    C      -1.1796940000      -0.7343627300      -0.6947926500
+    H       1.7353814300       1.0086060000       1.2479083200
+    H       0.5155827800       0.5497435200      -0.7524966700
+    H      -0.4253649200      -0.7632185300       2.0054107200
+    H      -1.4044469800      -0.6620733500      -1.7662980300
+    H      -1.8742394800      -1.3790037300      -0.1512993400
+  End
+  Charge 1.0
+End
+System state2
+  Atoms
+    C      -0.1394972300      -0.0805332200      -0.1269819100
+    C       0.1471859700      -0.1742244400       1.2572364800
+    O       1.1264360300       0.4264452800       1.8349736600
+    C      -1.1796940000      -0.7343627300      -0.6947926500
+    H       1.7353814300       1.0086060000       1.2479083200
+    H       0.5155827800       0.5497435200      -0.7524966700
+    H      -0.4253649200      -0.7632185300       2.0054107200
+    H      -1.4044469800      -0.6620733500      -1.7662980300
+    H      -1.8742394800      -1.3790037300      -0.1512993400
+  End
+  Charge 1.0
+  PerturbCoordinates 0.1
+End
+Task PESExploration
+"""
+
+
+class TestAMSJobWithSystemBlockSettingsAndMultipleChemicalSystems(
+    TestAMSJobWithSystemBlockSettingsAndMultipleMolecules
+):
+    """
+    Test suite for AMSJob using multiple chemical systems with system block overrides/settings.
+    Sets up a PES scan.
+    """
+
+    @staticmethod
+    def get_input_molecule():
+        """
+        Get instance of the Molecule class passed to the AMSJob
+        """
+        skip_if_no_scm_libbase()
+        from scm.libbase import UnifiedChemicalSystem as ChemicalSystem
+
+        main_molecule = ChemicalSystem()
+        main_molecule.add_atom("C", coords=(-0.13949723, -0.08053322, -0.12698191))
+        main_molecule.add_atom("C", coords=(0.14718597, -0.17422444, 1.25723648))
+        main_molecule.add_atom("O", coords=(1.12643603, 0.42644528, 1.83497366))
+        main_molecule.add_atom("C", coords=(-1.17969400, -0.73436273, -0.69479265))
+        main_molecule.add_atom("H", coords=(1.73538143, 1.00860600, 1.24790832))
+        main_molecule.add_atom("H", coords=(0.51558278, 0.54974352, -0.75249667))
+        main_molecule.add_atom("H", coords=(-0.42536492, -0.76321853, 2.00541072))
+        main_molecule.add_atom("H", coords=(-1.40444698, -0.66207335, -1.76629803))
+        main_molecule.add_atom("H", coords=(-1.87423948, -1.37900373, -0.15129934))
+
+        second_molecule = main_molecule.copy()
+        second_molecule.charge = 42
+
+        molecule = {"": main_molecule, "state2": second_molecule}
+
+        return molecule
+
+    @staticmethod
+    def get_expected_input():
+        """
+        Get expected input file
+        """
+        return """\
+GeometryOptimization
+  InitialHessian
+    Type Calculate
+  End
+End
+
+PESExploration
+  Job LandscapeRefinement
+  LoadEnergyLandscape
+    Path foo.results
+    Remove 2 5 6 7
+  End
+  Optimizer
+    ConvergedForce 0.01
+  End
+  SaddleSearch
+    RelaxFromSaddlePoint T
+  End
+End
+
+Task PESExploration
+
+System
+  Atoms
+     C   -0.1394972300000000 -0.0805332200000000 -0.1269819100000000
+     C    0.1471859700000000 -0.1742244400000000  1.2572364800000000
+     O    1.1264360299999998  0.4264452800000000  1.8349736600000000
+     C   -1.1796939999999998 -0.7343627300000000 -0.6947926500000000
+     H    1.7353814299999999  1.0086059999999999  1.2479083199999998
+     H    0.5155827800000000  0.5497435200000000 -0.7524966700000000
+     H   -0.4253649200000000 -0.7632185299999998  2.0054107200000000
+     H   -1.4044469799999997 -0.6620733500000000 -1.7662980299999997
+     H   -1.8742394800000000 -1.3790037300000000 -0.1512993400000000
+  End
+  Charge 1.0
+End
+System state2
+  Atoms
+     C   -0.1394972300000000 -0.0805332200000000 -0.1269819100000000
+     C    0.1471859700000000 -0.1742244400000000  1.2572364800000000
+     O    1.1264360299999998  0.4264452800000000  1.8349736600000000
+     C   -1.1796939999999998 -0.7343627300000000 -0.6947926500000000
+     H    1.7353814299999999  1.0086059999999999  1.2479083199999998
+     H    0.5155827800000000  0.5497435200000000 -0.7524966700000000
+     H   -0.4253649200000000 -0.7632185299999998  2.0054107200000000
+     H   -1.4044469799999997 -0.6620733500000000 -1.7662980299999997
+     H   -1.8742394800000000 -1.3790037300000000 -0.1512993400000000
+  End
+  Charge 1.0
+  PerturbCoordinates 0.1
+End
+"""
+
+
+class TestAMSJobWithSystemBlockSettingsAndMultipleChemicalSystemsAndPisa(
+    TestAMSJobWithSystemBlockSettingsAndMultipleMolecules
+):
+    """
+    Test suite for AMSJob using multiple chemical systems with system block overrides/settings and PISA for settings input.
+    Sets up a PES scan.
+    """
+
+    @staticmethod
+    def get_input_settings():
+        """
+        Instance of the Settings class passed to the AMSJob
+        """
+        skip_if_no_scm_pisa()
+        from scm.input_classes.drivers import AMS
+
+        settings = Settings()
+        driver = AMS()
+        driver.Task = "PESExploration"
+        driver.PESExploration.Job = "LandscapeRefinement"
+        driver.PESExploration.LoadEnergyLandscape.Path = "foo.results"
+        driver.PESExploration.LoadEnergyLandscape.Remove = [2, 5, 6, 7]
+        driver.PESExploration.Optimizer.ConvergedForce = 0.01
+        driver.PESExploration.SaddleSearch.RelaxFromSaddlePoint = "T"
+        driver.GeometryOptimization.InitialHessian.Type = "Calculate"
+        driver.System[0].Charge = 1.0
+        driver.System[1].Charge = 1.0
+        driver.System[1].PerturbCoordinates = 0.1
+        driver.System[1].header = "state2"
+        settings.input = driver
+        return settings
+
+    @staticmethod
+    def get_expected_input():
+        """
+        Get expected input file
+        """
+        return """\
+GeometryOptimization
+  InitialHessian
+    Type Calculate
+  End
+End
+PESExploration
+  Job LandscapeRefinement
+  LoadEnergyLandscape
+    Path foo.results
+    Remove 2 5 6 7
+  End
+  Optimizer
+    ConvergedForce 0.01
+  End
+  SaddleSearch
+    RelaxFromSaddlePoint True
+  End
+End
+
+System
+  Atoms
+              C      -0.1394972300      -0.0805332200      -0.1269819100
+              C       0.1471859700      -0.1742244400       1.2572364800
+              O       1.1264360300       0.4264452800       1.8349736600
+              C      -1.1796940000      -0.7343627300      -0.6947926500
+              H       1.7353814300       1.0086060000       1.2479083200
+              H       0.5155827800       0.5497435200      -0.7524966700
+              H      -0.4253649200      -0.7632185300       2.0054107200
+              H      -1.4044469800      -0.6620733500      -1.7662980300
+              H      -1.8742394800      -1.3790037300      -0.1512993400
+  End
+  Charge 1.0
+End
+
+System state2
+  Atoms
+              C      -0.1394972300      -0.0805332200      -0.1269819100
+              C       0.1471859700      -0.1742244400       1.2572364800
+              O       1.1264360300       0.4264452800       1.8349736600
+              C      -1.1796940000      -0.7343627300      -0.6947926500
+              H       1.7353814300       1.0086060000       1.2479083200
+              H       0.5155827800       0.5497435200      -0.7524966700
+              H      -0.4253649200      -0.7632185300       2.0054107200
+              H      -1.4044469800      -0.6620733500      -1.7662980300
+              H      -1.8742394800      -1.3790037300      -0.1512993400
+  End
+  Charge 1.0
+  PerturbCoordinates 0.1
+End
+Task PESExploration
+"""
+
+
+class TestAMSJobWithChainOfMolecules(TestAMSJob):
+    """
+    Test suite for AMSJob with a chain of water molecules.
+    """
+
+    @staticmethod
+    def get_input_molecule():
+        """
+        Get instance of the Molecule class passed to the AMSJob
+        """
+        mol = TestAMSJob.get_input_molecule()
+        mol.lattice = [[3, 0, 0]]
+        return mol.supercell(4)
+
+    @staticmethod
+    def get_input_settings():
+        """
+        Instance of the Settings class passed to the AMSJob
+        """
+        settings = Settings()
+        settings.input.Mopac.SCF.ConvergenceThreshold = 1.0e-8
+        settings.input.Mopac.model = "pm6"
+        settings.input.AMS.Task = "SinglePoint"
+        settings.input.AMS.Properties.Gradients = "Yes"
+        settings.input.AMS.NumericalDifferentiation.Parallel.nCoresPerGroup = 1
+        settings.input.AMS.NumericalDifferentiation.NuclearStepSize = 0.0001
+        settings.input.AMS.EngineDebugging.IgnoreGradientsRequest = "No"
+        settings.input.AMS.System.ElectrostaticEmbedding.ElectricField = "0.0 0.0 0.0"
+        settings.input.AMS.Task = "SinglePoint"
+        settings.input.AMS.Properties.Gradients = "Yes"
+        settings.input.AMS.NumericalDifferentiation.Parallel.nCoresPerGroup = 1
+        settings.input.AMS.NumericalDifferentiation.NuclearStepSize = 0.0001
+        return settings
+
+    @staticmethod
+    def get_expected_input():
+        """
+        Get expected input file
+        """
+        return """\
+EngineDebugging
+  IgnoreGradientsRequest No
+End
+
+NumericalDifferentiation
+  NuclearStepSize 0.0001
+  Parallel
+    nCoresPerGroup 1
+  End
+End
+
+Properties
+  Gradients Yes
+End
+
+Task SinglePoint
+
+System
+  Atoms
+              O       0.0000000000       0.0000000000       0.0000000000
+              H       1.0000000000       0.0000000000       0.0000000000
+              H       0.0000000000       1.0000000000       0.0000000000
+              O       3.0000000000       0.0000000000       0.0000000000
+              H       4.0000000000       0.0000000000       0.0000000000
+              H       3.0000000000       1.0000000000       0.0000000000
+              O       6.0000000000       0.0000000000       0.0000000000
+              H       7.0000000000       0.0000000000       0.0000000000
+              H       6.0000000000       1.0000000000       0.0000000000
+              O       9.0000000000       0.0000000000       0.0000000000
+              H      10.0000000000       0.0000000000       0.0000000000
+              H       9.0000000000       1.0000000000       0.0000000000
+  End
+  ElectrostaticEmbedding
+    ElectricField 0.0 0.0 0.0
+  End
+  Lattice
+        12.0000000000     0.0000000000     0.0000000000
+  End
+End
+
+Engine Mopac
+  SCF
+    ConvergenceThreshold 1e-08
+  End
+  model pm6
+EndEngine
+
+"""
 
 
 class TestAMSJobRun:

--- a/unit_tests/test_interfaces.py
+++ b/unit_tests/test_interfaces.py
@@ -9,7 +9,10 @@ from scm.plams.unit_tests.test_helpers import skip_if_no_ams_installation
 
 def test_hybrid_engine_input():
     """test :meth:`AMSJob.get_input` for writing sub engines in a hybrid engine block of ams."""
-    AMSinput = """System
+    AMSinput = """\
+Task SinglePoint
+
+System
   Atoms
               C      -1.6447506665       1.4391568332       0.0000000000
               C      -0.5773632247       0.3290989412      -0.0074515501
@@ -30,8 +33,6 @@ def test_hybrid_engine_input():
      8 2 1.0
   End
 End
-
-Task SinglePoint
 
 Engine Hybrid
   Energy
@@ -61,13 +62,14 @@ EndEngine
 
 def test_list_block_input():
     """test :meth:`AMSJob.get_input` for writing list-blocks"""
-    AMSinput = """System
+    AMSinput = """\
+Task SinglePoint
+
+System
   Atoms
               C      -1.6447506665       1.4391568332       0.0000000000
   End
 End
-
-Task SinglePoint
 
 Engine Hybrid
   Energy


### PR DESCRIPTION
# Description

Efficiency improvements for generating AMS input files for `AMSJob`. This turned out to be a more complex change than expected due to the fact there are multiple ways of setting up the job:

* The input settings can either be a `Settings` object, or an input class from PISA. These settings can contain a `System` block which may have atoms / system modification keywords (like symmetrise etc.)
* The molecule can either be one or more `Molecule` instances or `ChemicalSystem`

The advantage of PISA/UCS is that these objects can be serialised directly to text, without having to go via a settings object themselves, which can be quite inefficient for large systems.

The complication comes when a system has been supplied on the settings object itself. In this case, for backwards compatibility, the system blocks must be merged. This requires serialisation via settings.

## Summary of Behaviour

* If there is no system block in the input settings and we have PISA, then we can serialise settings straight to text and add the system blocks. If the molecule is a chemical system, this can also be serialised directly to text.
* If there is a system block and we have PISA, we need to merge them. This requires converting all systems to settings and the PISA to settings, merging them, then overwriting the system block text. This was previously broken as it did not merge/deduplicate information correctly.
* If we do not have PISA, and there is no system block in the settings, then chemical systems can be serialised straight to text, and molecules as normal.
* If we do not have PISA, and there is a system block in the settings, then the chemical system must also be serialised to a settings object still

## Summary of Improvements

* In the most common case where there is no system block in the settings, chemical systems will be converted directly to text, avoiding the settings object
* Existing behaviour has been fixed in a backwards compatible way, so worst case we always serialise to settings objects and combine them
* Lots of unit tests added for generating these input files through various permutations/combinations of single/multiple molecules/chemical systems with(out) PISA