### PR TITLE
Improve thread safety of lazy default jobmanager and jobrunner SCMSUITE-10155 SO107

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ This changelog is effective from the 2025 releases.
 * `Molecule.add_hatoms` to use bonding information if available when adding new hydrogen atoms
 
 ### Deprecated
-* `plams` launch script is deprecated in favour of simply running with `amspython`
+* `plams` launch script is deprecated in favor of simply running with `amspython`
 
 ### Removed
 * Legacy `BANDJob`, `DFTBJob`, `UFFJob`, `MOPACJob`, `ReaxFFJob`, `CSHessianADFJob` and `ADFJob` have been removed

--- a/core/settings.py
+++ b/core/settings.py
@@ -790,7 +790,8 @@ class ConfigSettings(Settings):
 
         # Default job runner and job manager are lazily initialised on first access
         # This is to allow users to change their settings before initialisation (due to side effects in init)
-        self._lock = threading.Lock()
+        # Make sure to do the initialisation inside a lock to avoid race-conditions between multiple threads
+        self.__lazylock__ = threading.Lock()  # N.B. nomenclature used purely to avoid adding to settings dictionary
         self.default_jobrunner = None
         self.default_jobmanager = None
 
@@ -924,7 +925,7 @@ class ConfigSettings(Settings):
         """
         from scm.plams.core.jobrunner import JobRunner
 
-        with self._lock:
+        with self.__lazylock__:
             if self["default_jobrunner"] is None:
                 self["default_jobrunner"] = JobRunner()
             return self["default_jobrunner"]
@@ -940,7 +941,7 @@ class ConfigSettings(Settings):
         """
         from scm.plams.core.jobmanager import JobManager
 
-        with self._lock:
+        with self.__lazylock__:
             if self["default_jobmanager"] is None:
                 self["default_jobmanager"] = JobManager(self.jobmanager)
             return self["default_jobmanager"]

--- a/core/settings.py
+++ b/core/settings.py
@@ -1,6 +1,7 @@
 import contextlib
 import textwrap
 from functools import wraps
+import threading
 from typing import TYPE_CHECKING, TypeVar, Union, Tuple, Type
 
 __all__ = [
@@ -789,6 +790,7 @@ class ConfigSettings(Settings):
 
         # Default job runner and job manager are lazily initialised on first access
         # This is to allow users to change their settings before initialisation (due to side effects in init)
+        self._lock = threading.Lock()
         self.default_jobrunner = None
         self.default_jobmanager = None
 
@@ -922,9 +924,10 @@ class ConfigSettings(Settings):
         """
         from scm.plams.core.jobrunner import JobRunner
 
-        if self["default_jobrunner"] is None:
-            self["default_jobrunner"] = JobRunner()
-        return self["default_jobrunner"]
+        with self._lock:
+            if self["default_jobrunner"] is None:
+                self["default_jobrunner"] = JobRunner()
+            return self["default_jobrunner"]
 
     @default_jobrunner.setter
     def default_jobrunner(self, value: "JobRunner") -> None:
@@ -937,9 +940,10 @@ class ConfigSettings(Settings):
         """
         from scm.plams.core.jobmanager import JobManager
 
-        if self["default_jobmanager"] is None:
-            self["default_jobmanager"] = JobManager(self.jobmanager)
-        return self["default_jobmanager"]
+        with self._lock:
+            if self["default_jobmanager"] is None:
+                self["default_jobmanager"] = JobManager(self.jobmanager)
+            return self["default_jobmanager"]
 
     @default_jobmanager.setter
     def default_jobmanager(self, value: "JobManager") -> None:


### PR DESCRIPTION
# Description

Add lock to global config to avoid race conditions in setting up the lazy job manager/runner