### PR TITLE
Fix NoneType exception in amsjob check SCMSUITE-10161 SO--

### DIFF
--- a/interfaces/adfsuite/ams.py
+++ b/interfaces/adfsuite/ams.py
@@ -2305,8 +2305,17 @@ class AMSJob(SingleJob):
         """Check if ``termination status`` variable from ``General`` section of main KF file equals ``NORMAL TERMINATION``."""
         try:
             status = self.results.readrkf("General", "termination status")
-        except:
+        except (FileError, KeyError) as e:
+            log(str(e), 1)
             return False
+        except:
+            log(f"Could not read termination status from file {self.results.rkfpath()}", 1)
+            return False
+
+        if status is None:
+            log(f"Could not read termination status from file {self.results.rkfpath()}", 1)
+            return False
+
         if "NORMAL TERMINATION" in status:
             if "errors" in status:
                 log("Job {} reported errors. Please check the output".format(self._full_name()), 1)

--- a/unit_tests/test_amsjob.py
+++ b/unit_tests/test_amsjob.py
@@ -1,7 +1,8 @@
 import dill as pickle
 import pytest
+from unittest.mock import MagicMock
 
-from scm.plams.interfaces.adfsuite.ams import AMSJob
+from scm.plams.interfaces.adfsuite.ams import AMSJob, AMSResults
 from scm.plams.core.settings import Settings
 
 
@@ -41,3 +42,24 @@ def test_pickle_pisa():
     job2 = pickle.loads(pickle_bytes)
     assert isinstance(job2, AMSJob)
     assert job2.settings == job.settings
+
+
+@pytest.mark.parametrize(
+    "status,expected",
+    [
+        ["NORMAL TERMINATION", True],
+        ["NORMAL TERMINATION with warnings", True],
+        ["NORMAL TERMINATION with errors", False],
+        ["Input error", False],
+        [None, False],
+    ],
+)
+def test_check_returns_true_for_normal_termination_with_no_errors_otherwise_false(status, expected):
+    # Given job with results of certain status
+    job = AMSJob()
+    job.results = MagicMock(spec=AMSResults)
+    job.results.readrkf.return_value = status
+
+    # When check the job
+    # Then job check is ok only for normal termination with no errors
+    assert job.check() == expected


### PR DESCRIPTION
Small fix for `NoneType` exception in `AMSJob.check`