### PR TITLE
Additional Settings Methods SCMSUITE-10162 SO107

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This changelog is effective from the 2025 releases.
 * Logging of AMS job error messages to stdout and logfile on job failure
 * Method `get_errormsg` enforced on the `Job` base class, with a default implementation
 * Added an interface to the Serenity program through methods such as `SerenityJob`, `SerenityResults` and `SerenitySettings`
+* Methods `Settings.contains_nested` and `Settings.pop_nested` for checking if nested keys exist in a settings object and popping them
 
 ### Changed
 * Functions for optional packages (e.g. RDKit, ASE) are available even when these packages are not installed, but will raise an `MissingOptionalPackageError` when called
@@ -41,6 +42,7 @@ This changelog is effective from the 2025 releases.
 * Use standard library logger for `log` function
 * Make `Job` class inherit from `ABC` and mark abstract methods 
 * Exceptions raised in `prerun` and `postrun` will always be caught and populate error message
+* `Settings.get_nested` takes a default argument which is returned if the nested key is not present in the settings instance
 
 ### Fixed
 * `Molecule.properties.charge` is a numeric instead of string type when loading molecule from a file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ This changelog is effective from the 2025 releases.
 * Logging of AMS job error messages to stdout and logfile on job failure
 * Method `get_errormsg` enforced on the `Job` base class, with a default implementation
 * Added an interface to the Serenity program through methods such as `SerenityJob`, `SerenityResults` and `SerenitySettings`
-* Methods `Settings.contains_nested` and `Settings.pop_nested` for checking if nested keys exist in a settings object and popping them
+* Methods `Settings.nested_keys`, `Settings.branch_keys` for accessing nested keys and `Settings.contains_nested` and `Settings.pop_nested` for checking if nested keys exist in a settings object and popping them
 
 ### Changed
 * Functions for optional packages (e.g. RDKit, ASE) are available even when these packages are not installed, but will raise an `MissingOptionalPackageError` when called

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This changelog is effective from the 2025 releases.
 * Method `get_errormsg` enforced on the `Job` base class, with a default implementation
 * Added an interface to the Serenity program through methods such as `SerenityJob`, `SerenityResults` and `SerenitySettings`
 * Methods `Settings.nested_keys`, `Settings.branch_keys` for accessing nested keys and `Settings.contains_nested` and `Settings.pop_nested` for checking if nested keys exist in a settings object and popping them
+* Method `Settings.compare` added to compare and contrast items in two settings objects
 
 ### Changed
 * Functions for optional packages (e.g. RDKit, ASE) are available even when these packages are not installed, but will raise an `MissingOptionalPackageError` when called

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ This changelog is effective from the 2025 releases.
 * Logging of AMS job error messages to stdout and logfile on job failure
 * Method `get_errormsg` enforced on the `Job` base class, with a default implementation
 * Added an interface to the Serenity program through methods such as `SerenityJob`, `SerenityResults` and `SerenitySettings`
-* Methods `Settings.nested_keys`, `Settings.branch_keys` for accessing nested keys and `Settings.contains_nested` and `Settings.pop_nested` for checking if nested keys exist in a settings object and popping them
+* Methods `Settings.nested_keys`, `Settings.block_keys` for accessing nested keys and `Settings.contains_nested` and `Settings.pop_nested` for checking if nested keys exist in a settings object and popping them
 * Method `Settings.compare` added to compare and contrast items in two settings objects
 
 ### Changed

--- a/__init__.py
+++ b/__init__.py
@@ -140,6 +140,7 @@ from scm.plams.tools.geometry import (
 )
 from scm.plams.tools.kftools import KFFile, KFHistory, KFReader
 from scm.plams.tools.periodic_table import PT, PeriodicTable
+from scm.plams.tools.table_formatter import format_in_table
 from scm.plams.tools.plot import (
     get_correlation_xy,
     plot_band_structure,
@@ -306,6 +307,7 @@ __all__ = [
     "reaction_energy",
     "PeriodicTable",
     "PT",
+    "format_in_table",
     "plot_band_structure",
     "plot_molecule",
     "plot_grid_molecules",

--- a/core/settings.py
+++ b/core/settings.py
@@ -455,6 +455,7 @@ class Settings(dict):
             [('a',), ('a', 'b'), ('a', 'b', 'c')]
 
         """
+
         def iter_block(bk):
             return bk.items() if isinstance(bk, Settings) else enumerate(bk)
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -217,6 +217,7 @@ class Settings(dict):
 
         for key in sorted_keys:
             self.pop_nested(key)
+        return self
 
     def difference(self: TSelf, other: "Settings") -> TSelf:
         """

--- a/core/settings.py
+++ b/core/settings.py
@@ -311,13 +311,14 @@ class Settings(dict):
 
         Setting *suppress_missing* to ``True`` will raise a :exc:`KeyError` if a key in *key_tuple* cannot be accessed in this instance,
 
-         .. code:: python
+        .. code:: python
 
             >>> s = Settings()
             >>> s.a.b.c = 1
             >>> value = s.contains_nested(('a', 'b', 'c'))
             >>> print(value)
             True
+
         """
         # Allow a slightly wider definition for the key_tuple than the type-hint suggests for backwards-compatibility
         if not isinstance(key_tuple, ColIterable) or isinstance(key_tuple, (str, bytes)):

--- a/core/settings.py
+++ b/core/settings.py
@@ -459,20 +459,20 @@ class Settings(dict):
         def iter_block(bk):
             return bk.items() if isinstance(bk, Settings) else enumerate(bk)
 
-        branch_keys = list(self.branch_keys(flatten_list, include_empty))
-        for bk in branch_keys:
+        block_keys = list(self.block_keys(flatten_list, include_empty))
+        for bk in block_keys:
             yield bk
             for k, v in iter_block(self.get_nested(bk)):
                 # Maintain ordering by skipping branch keys here
                 fk = bk + (k,)
-                if (include_empty or v) and fk not in branch_keys:
+                if (include_empty or v) and fk not in block_keys:
                     yield fk
 
-    def branch_keys(
+    def block_keys(
         self, flatten_list: bool = True, include_empty: bool = False
     ) -> Generator[Tuple[Hashable, ...], None, None]:
         """
-        Get the nested keys corresponding to the internal nodes in this instance, also referred to as 'branches'.
+        Get the nested keys corresponding to the internal nodes in this instance, also referred to as 'blocks' or 'branches'.
         These internal nodes correspond to |Settings| objects.
 
         If *flatten_list* is set to ``True``, all nested lists will be flattened and elements converted to internal nodes.

--- a/core/settings.py
+++ b/core/settings.py
@@ -260,11 +260,11 @@ class Settings(dict):
         """Like regular ``setdefault``, but ignore the case and if the value is a dict, convert it to |Settings|."""
         if isinstance(default, dict) and not isinstance(default, Settings):
             default = Settings(default)
-        return dict.setdefault(self, self.find_case(key), default)
+        return dict.setdefault(self, self.find_case(key), default)  # type: ignore
 
     def as_dict(self) -> Dict:
         """Return a copy of this instance with all |Settings| replaced by regular Python dictionaries."""
-        d = {}
+        d: Dict = {}
         for k, v in self.items():
             if isinstance(v, Settings):
                 d[k] = v.as_dict()

--- a/doc/source/examples/AMSSettingsInput/AMSSettingsInput.common_footer.rst
+++ b/doc/source/examples/AMSSettingsInput/AMSSettingsInput.common_footer.rst
@@ -1,0 +1,5 @@
+Complete Python code
+--------------------
+
+.. literalinclude:: ../../../../examples/AMSSettingsInput/ams_settings_input.py
+    :language: python

--- a/doc/source/examples/AMSSettingsInput/AMSSettingsInput.common_header.rst
+++ b/doc/source/examples/AMSSettingsInput/AMSSettingsInput.common_header.rst
@@ -1,0 +1,4 @@
+To follow along, either
+
+* Download :download:`ams_settings_input.py <../../../../examples/AMSSettingsInput/ams_settings_input.py>` (run as ``$AMSBIN/amspython ams_settings_input.py``).
+* Download :download:`ams_settings_input.ipynb <../../../../examples/AMSSettingsInput/ams_settings_input.ipynb>` (see also: how to install `Jupyterlab <../../../Scripting/Python_Stack/Python_Stack.html#install-and-run-jupyter-lab-jupyter-notebooks>`__ in AMS)

--- a/doc/source/examples/AMSSettingsInput/AMSSettingsInput.rst
+++ b/doc/source/examples/AMSSettingsInput/AMSSettingsInput.rst
@@ -5,7 +5,7 @@ AMS Settings: Input (Task, Engine, etc.)
 
 This example shows how to build the input for AMS jobs using |Settings| objects.
 
-More information on the structure of the input for AMS can be found `here <../../AMS/Input_Output.html>`__.
+More information on the structure of the input for AMS can be found `here <../../../ams/Input_Output.html>`__.
 
 .. include:: AMSSettingsInput.common_header.rst
 .. include:: ams_settings_input.ipynb.rst

--- a/doc/source/examples/AMSSettingsInput/AMSSettingsInput.rst
+++ b/doc/source/examples/AMSSettingsInput/AMSSettingsInput.rst
@@ -5,7 +5,7 @@ AMS Settings: Input (Task, Engine, etc.)
 
 This example shows how to build the input for AMS jobs using |Settings| objects.
 
-More information on the structure of the input for AMS can be found `here <../../../ams/Input_Output.html>`__.
+For more information on the structure of the input for AMS, see :ref:`AMS_preparing_input`.
 
 .. include:: AMSSettingsInput.common_header.rst
 .. include:: ams_settings_input.ipynb.rst

--- a/doc/source/examples/AMSSettingsInput/AMSSettingsInput.rst
+++ b/doc/source/examples/AMSSettingsInput/AMSSettingsInput.rst
@@ -1,0 +1,12 @@
+.. _AMSSettingsInputExample:
+
+AMS Settings: Input (Task, Engine, etc.)
+========================================
+
+This example shows how to build the input for AMS jobs using |Settings| objects.
+
+More information on the structure of the input for AMS can be found `here <../../AMS/Input_Output.html>`__.
+
+.. include:: AMSSettingsInput.common_header.rst
+.. include:: ams_settings_input.ipynb.rst
+.. include:: AMSSettingsInput.common_footer.rst

--- a/doc/source/examples/AMSSettingsInput/ams_settings_input.ipynb.rst
+++ b/doc/source/examples/AMSSettingsInput/ams_settings_input.ipynb.rst
@@ -8,21 +8,21 @@ Task, Engine and Property Blocks
 
     from scm.plams import Settings, AMSJob
 
-To start with, in order to see the input that will be passed to AMS,
-create an AMSJob and print the input:
+To start with, in order to see the input that will be passed to AMS from
+the Settings, make a function to create an AMSJob and print the input:
 
 .. code:: ipython3
 
     def print_input(settings):
         print(AMSJob(settings=settings).get_input())
 
-Tasks can be specified under the ``input.AMS.Task`` key:
+Tasks can be specified in the settings under the ``input.AMS.Task`` key:
 
 .. code:: ipython3
 
     go_settings = Settings()
     go_settings.input.AMS.Task = "GeometryOptimization"
-    go_settings.input.AMS.GeometryOptimization.Convergence.Gradients=1e-5
+    go_settings.input.AMS.GeometryOptimization.Convergence.Gradients = 1e-5
     print_input(go_settings)
 
 
@@ -82,8 +82,8 @@ for the engine of interest:
 Combining Settings
 ~~~~~~~~~~~~~~~~~~
 
-Settings objects can be combined for easy reuse and job setup. Settings
-can be merged using the ``+`` and ``+=`` operators.
+Settings objects can also be combined for easy reuse and job setup.
+Settings can be merged using the ``+`` and ``+=`` operators.
 
 .. code:: ipython3
 
@@ -115,14 +115,14 @@ can be merged using the ``+`` and ``+=`` operators.
     
 
 
-Note however that this is a “soft” update, so values of existing keys
-will not be overwritten:
+Note however that this merge is a “soft” update, so values of existing
+keys will not be overwritten:
 
 .. code:: ipython3
 
     pbe_settings = Settings()
     pbe_settings.input.ADF.Basis.Type = "TZP"
-    pbe_settings.input.ADF.xc.gga="pbe"   
+    pbe_settings.input.ADF.xc.gga = "pbe"
     settings += pbe_settings
     print_input(settings)
 
@@ -154,8 +154,8 @@ will not be overwritten:
     
 
 
-To achieve this behaviour, the ``update`` method can be used, which
-overwrites existing keys:
+To achieve “hard update” behaviour, the ``update`` method can be used,
+which overwrites existing keys:
 
 .. code:: ipython3
 
@@ -200,6 +200,27 @@ Settings can also be removed using the ``-`` and ``-=`` operators:
 
 .. parsed-literal::
 
+    GeometryOptimization
+      Convergence
+        Gradients 1e-05
+      End
+    End
+    
+    Properties
+    End
+    
+    Task GeometryOptimization
+    
+    
+    Engine ADF
+      Basis
+        Type TZP
+      End
+      xc
+        gga pbe
+      End
+    EndEngine
+    
     
 
 
@@ -210,14 +231,14 @@ Multiple values in a settings block can be configured using a list:
     hybrid_settings = go_settings.copy()
     hybrid_settings.input.AMS.Hybrid.Energy.Term = []
     for i in range(5):
-        factor = (-1) ** (i%2) * 1.0
+        factor = (-1) ** (i % 2) * 1.0
         region = "*" if i == 0 else "one" if i < 3 else "two"
         engine_id = "adf-lda" if i == 0 or factor == -1 else "adf-gga"
         term = Settings({"Factor": factor, "Region": region, "EngineID": engine_id})
         hybrid_settings.input.AMS.Hybrid.Energy.Term.append(term)
     hybrid_settings.input.AMS.Hybrid.Engine = [lda_settings.input.ADF.copy(), pbe_settings.input.ADF.copy()]
-    hybrid_settings.input.AMS.Hybrid.Engine[0]._h = "ADF adf-lda" 
-    hybrid_settings.input.AMS.Hybrid.Engine[1]._h = "ADF adf-gga" 
+    hybrid_settings.input.AMS.Hybrid.Engine[0]._h = "ADF adf-lda"
+    hybrid_settings.input.AMS.Hybrid.Engine[1]._h = "ADF adf-gga"
     print_input(hybrid_settings)
 
 
@@ -377,14 +398,32 @@ removed and modified entries.
 
 .. code:: ipython3
 
+    import os
+    
     settings1 = go_settings + lda_settings + nm_settings
     settings2 = go_settings.copy()
     settings2.input.AMS.Task = "SinglePoint"
     settings2.input.DFTB.Model = "GFN1-xTB"
-    print(settings2.compare(settings1))
+    comparison = settings2.compare(settings1)
+    print(
+        f"Items in settings2 not in settings1:{os.linesep}{os.linesep.join(f'  - {k}: {v}' for k, v in comparison['added'].items())}"
+    )
+    print(
+        f"Items in settings1 not in settings2:{os.linesep}{os.linesep.join(f'  - {k}: {v}' for k, v in comparison['removed'].items())}"
+    )
+    print(
+        f"Items modified from settings1 to settings2:{os.linesep}{os.linesep.join(f'  - {k}: {v[1]} -> {v[0]}' for k, v in comparison['modified'].items())}"
+    )
 
 
 .. parsed-literal::
 
-    {'added': {('input', 'DFTB', 'Model'): 'GFN1-xTB'}, 'removed': {('input', 'ADF', 'Basis', 'Type'): 'DZP', ('input', 'AMS', 'Properties', 'NormalModes'): 'Yes'}, 'modified': {('input', 'AMS', 'Task'): ('SinglePoint', 'GeometryOptimization')}}
+    Items in settings2 not in settings1:
+      - ('input', 'DFTB', 'Model'): GFN1-xTB
+    Items in settings1 not in settings2:
+      - ('input', 'ADF', 'Basis', 'Type'): DZP
+      - ('input', 'AMS', 'Properties', 'NormalModes'): Yes
+    Items modified from settings1 to settings2:
+      - ('input', 'AMS', 'Task'): GeometryOptimization -> SinglePoint
+
 

--- a/doc/source/examples/AMSSettingsInput/ams_settings_input.ipynb.rst
+++ b/doc/source/examples/AMSSettingsInput/ams_settings_input.ipynb.rst
@@ -1,0 +1,390 @@
+Worked Example
+--------------
+
+Task, Engine and Property Blocks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: ipython3
+
+    from scm.plams import Settings, AMSJob
+
+To start with, in order to see the input that will be passed to AMS,
+create an AMSJob and print the input:
+
+.. code:: ipython3
+
+    def print_input(settings):
+        print(AMSJob(settings=settings).get_input())
+
+Tasks can be specified under the ``input.AMS.Task`` key:
+
+.. code:: ipython3
+
+    go_settings = Settings()
+    go_settings.input.AMS.Task = "GeometryOptimization"
+    go_settings.input.AMS.GeometryOptimization.Convergence.Gradients=1e-5
+    print_input(go_settings)
+
+
+.. parsed-literal::
+
+    GeometryOptimization
+      Convergence
+        Gradients 1e-05
+      End
+    End
+    
+    Task GeometryOptimization
+    
+    
+
+
+Properties can be specified under the ``input.AMS.Properties`` key:
+
+.. code:: ipython3
+
+    nm_settings = Settings()
+    nm_settings.input.ams.Properties.NormalModes = "Yes"
+    print_input(nm_settings)
+
+
+.. parsed-literal::
+
+    Properties
+      NormalModes Yes
+    End
+    
+    
+
+
+Engine settings can be specified under the ``input.AMS.<Engine>`` key,
+for the engine of interest:
+
+.. code:: ipython3
+
+    lda_settings = Settings()
+    lda_settings.input.ADF.Basis.Type = "DZP"
+    print_input(lda_settings)
+
+
+.. parsed-literal::
+
+    
+    Engine ADF
+      Basis
+        Type DZP
+      End
+    EndEngine
+    
+    
+
+
+Combining Settings
+~~~~~~~~~~~~~~~~~~
+
+Settings objects can be combined for easy reuse and job setup. Settings
+can be merged using the ``+`` and ``+=`` operators.
+
+.. code:: ipython3
+
+    settings = go_settings + lda_settings + nm_settings
+    print_input(settings)
+
+
+.. parsed-literal::
+
+    GeometryOptimization
+      Convergence
+        Gradients 1e-05
+      End
+    End
+    
+    Properties
+      NormalModes Yes
+    End
+    
+    Task GeometryOptimization
+    
+    
+    Engine ADF
+      Basis
+        Type DZP
+      End
+    EndEngine
+    
+    
+
+
+Note however that this is a “soft” update, so values of existing keys
+will not be overwritten:
+
+.. code:: ipython3
+
+    pbe_settings = Settings()
+    pbe_settings.input.ADF.Basis.Type = "TZP"
+    pbe_settings.input.ADF.xc.gga="pbe"   
+    settings += pbe_settings
+    print_input(settings)
+
+
+.. parsed-literal::
+
+    GeometryOptimization
+      Convergence
+        Gradients 1e-05
+      End
+    End
+    
+    Properties
+      NormalModes Yes
+    End
+    
+    Task GeometryOptimization
+    
+    
+    Engine ADF
+      Basis
+        Type DZP
+      End
+      xc
+        gga pbe
+      End
+    EndEngine
+    
+    
+
+
+To achieve this behaviour, the ``update`` method can be used, which
+overwrites existing keys:
+
+.. code:: ipython3
+
+    settings.update(pbe_settings)
+    print_input(settings)
+
+
+.. parsed-literal::
+
+    GeometryOptimization
+      Convergence
+        Gradients 1e-05
+      End
+    End
+    
+    Properties
+      NormalModes Yes
+    End
+    
+    Task GeometryOptimization
+    
+    
+    Engine ADF
+      Basis
+        Type TZP
+      End
+      xc
+        gga pbe
+      End
+    EndEngine
+    
+    
+
+
+Settings can also be removed using the ``-`` and ``-=`` operators:
+
+.. code:: ipython3
+
+    settings -= nm_settings
+    print_input(settings)
+
+
+.. parsed-literal::
+
+    
+
+
+Multiple values in a settings block can be configured using a list:
+
+.. code:: ipython3
+
+    hybrid_settings = go_settings.copy()
+    hybrid_settings.input.AMS.Hybrid.Energy.Term = []
+    for i in range(5):
+        factor = (-1) ** (i%2) * 1.0
+        region = "*" if i == 0 else "one" if i < 3 else "two"
+        engine_id = "adf-lda" if i == 0 or factor == -1 else "adf-gga"
+        term = Settings({"Factor": factor, "Region": region, "EngineID": engine_id})
+        hybrid_settings.input.AMS.Hybrid.Energy.Term.append(term)
+    hybrid_settings.input.AMS.Hybrid.Engine = [lda_settings.input.ADF.copy(), pbe_settings.input.ADF.copy()]
+    hybrid_settings.input.AMS.Hybrid.Engine[0]._h = "ADF adf-lda" 
+    hybrid_settings.input.AMS.Hybrid.Engine[1]._h = "ADF adf-gga" 
+    print_input(hybrid_settings)
+
+
+.. parsed-literal::
+
+    GeometryOptimization
+      Convergence
+        Gradients 1e-05
+      End
+    End
+    
+    Hybrid
+      Energy
+        Term
+          EngineID adf-lda
+          Factor 1.0
+          Region *
+        End
+        Term
+          EngineID adf-lda
+          Factor -1.0
+          Region one
+        End
+        Term
+          EngineID adf-gga
+          Factor 1.0
+          Region one
+        End
+        Term
+          EngineID adf-lda
+          Factor -1.0
+          Region two
+        End
+        Term
+          EngineID adf-gga
+          Factor 1.0
+          Region two
+        End
+      End
+      Engine ADF adf-lda
+        Basis
+          Type DZP
+        End
+      EndEngine
+      Engine ADF adf-gga
+        Basis
+          Type TZP
+        End
+        xc
+          gga pbe
+        End
+      EndEngine
+    
+    End
+    
+    Task GeometryOptimization
+    
+    
+
+
+Note also in the example below, the use of the special ``_h`` “header”
+key, which can be used to add data to the header line for a block.
+
+Nested Keys
+~~~~~~~~~~~
+
+It can be useful to access values from a Settings object using “nested”
+keys. These are tuples of keys, where each successive element of the
+tuple corresponds to a further layer in the settings. Lists are
+flattened so their elements can be accessed with the corresponding
+index.
+
+.. code:: ipython3
+
+    list(hybrid_settings.nested_keys())
+
+
+
+
+.. parsed-literal::
+
+    [('input',),
+     ('input', 'AMS'),
+     ('input', 'AMS', 'Task'),
+     ('input', 'AMS', 'GeometryOptimization'),
+     ('input', 'AMS', 'GeometryOptimization', 'Convergence'),
+     ('input', 'AMS', 'GeometryOptimization', 'Convergence', 'Gradients'),
+     ('input', 'AMS', 'Hybrid'),
+     ('input', 'AMS', 'Hybrid', 'Energy'),
+     ('input', 'AMS', 'Hybrid', 'Energy', 'Term'),
+     ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 0),
+     ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 0, 'Factor'),
+     ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 0, 'Region'),
+     ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 0, 'EngineID'),
+     ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 1),
+     ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 1, 'Factor'),
+     ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 1, 'Region'),
+     ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 1, 'EngineID'),
+     ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 2),
+     ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 2, 'Factor'),
+     ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 2, 'Region'),
+     ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 2, 'EngineID'),
+     ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 3),
+     ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 3, 'Factor'),
+     ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 3, 'Region'),
+     ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 3, 'EngineID'),
+     ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 4),
+     ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 4, 'Factor'),
+     ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 4, 'Region'),
+     ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 4, 'EngineID'),
+     ('input', 'AMS', 'Hybrid', 'Engine'),
+     ('input', 'AMS', 'Hybrid', 'Engine', 0),
+     ('input', 'AMS', 'Hybrid', 'Engine', 0, '_h'),
+     ('input', 'AMS', 'Hybrid', 'Engine', 0, 'Basis'),
+     ('input', 'AMS', 'Hybrid', 'Engine', 0, 'Basis', 'Type'),
+     ('input', 'AMS', 'Hybrid', 'Engine', 1),
+     ('input', 'AMS', 'Hybrid', 'Engine', 1, '_h'),
+     ('input', 'AMS', 'Hybrid', 'Engine', 1, 'Basis'),
+     ('input', 'AMS', 'Hybrid', 'Engine', 1, 'Basis', 'Type'),
+     ('input', 'AMS', 'Hybrid', 'Engine', 1, 'xc'),
+     ('input', 'AMS', 'Hybrid', 'Engine', 1, 'xc', 'gga')]
+
+
+
+.. code:: ipython3
+
+    hybrid_settings.get_nested(("input", "AMS", "Task"))
+
+
+
+
+.. parsed-literal::
+
+    'GeometryOptimization'
+
+
+
+.. code:: ipython3
+
+    if hybrid_settings.contains_nested(("input", "AMS", "Hybrid", "Engine", 0)):
+        hybrid_settings.set_nested(("input", "AMS", "Hybrid", "Engine", 0, "Basis", "Type"), "TZP")
+    print(hybrid_settings.get_nested(("input", "AMS", "Hybrid", "Engine", 0, "Basis")))
+
+
+.. parsed-literal::
+
+    Type: 	TZP
+    
+
+
+Comparison
+~~~~~~~~~~
+
+Two settings objects can be compared to check the differences between
+them. The result will show the nested key and value of any added,
+removed and modified entries.
+
+.. code:: ipython3
+
+    settings1 = go_settings + lda_settings + nm_settings
+    settings2 = go_settings.copy()
+    settings2.input.AMS.Task = "SinglePoint"
+    settings2.input.DFTB.Model = "GFN1-xTB"
+    print(settings2.compare(settings1))
+
+
+.. parsed-literal::
+
+    {'added': {('input', 'DFTB', 'Model'): 'GFN1-xTB'}, 'removed': {('input', 'ADF', 'Basis', 'Type'): 'DZP', ('input', 'AMS', 'Properties', 'NormalModes'): 'Yes'}, 'modified': {('input', 'AMS', 'Task'): ('SinglePoint', 'GeometryOptimization')}}
+

--- a/doc/source/examples/examples.rst
+++ b/doc/source/examples/examples.rst
@@ -17,6 +17,7 @@ Getting Started
  
    WaterOptimization/WaterOptimization
    AMSSettingsSystem/AMSSettingsSystem
+   AMSSettingsInput/AMSSettingsInput
    He2DissociationCurve/He2DissociationCurve
    ManyJobsInParallel/ManyJobsInParallel
    Logging/Logging

--- a/examples/AMSSettingsInput/ams_settings_input.ipynb
+++ b/examples/AMSSettingsInput/ams_settings_input.ipynb
@@ -21,7 +21,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To start with, in order to see the input that will be passed to AMS, create an AMSJob and print the input:"
+    "To start with, in order to see the input that will be passed to AMS from the Settings, make a function to create an AMSJob and print the input:"
    ]
   },
   {
@@ -38,7 +38,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Tasks can be specified under the `input.AMS.Task` key:"
+    "Tasks can be specified in the settings under the `input.AMS.Task` key:"
    ]
   },
   {
@@ -65,7 +65,7 @@
    "source": [
     "go_settings = Settings()\n",
     "go_settings.input.AMS.Task = \"GeometryOptimization\"\n",
-    "go_settings.input.AMS.GeometryOptimization.Convergence.Gradients=1e-5\n",
+    "go_settings.input.AMS.GeometryOptimization.Convergence.Gradients = 1e-5\n",
     "print_input(go_settings)"
    ]
   },
@@ -143,8 +143,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Settings objects can be combined for easy reuse and job setup.\n",
-    "Settings can be merged using the `+` and `+=` operators."
+    "Settings objects can also be combined for easy reuse and job setup. Settings can be merged using the `+` and `+=` operators."
    ]
   },
   {
@@ -188,7 +187,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note however that this is a \"soft\" update, so values of existing keys will not be overwritten:"
+    "Note however that this merge is a \"soft\" update, so values of existing keys will not be overwritten:"
    ]
   },
   {
@@ -229,7 +228,7 @@
    "source": [
     "pbe_settings = Settings()\n",
     "pbe_settings.input.ADF.Basis.Type = \"TZP\"\n",
-    "pbe_settings.input.ADF.xc.gga=\"pbe\"   \n",
+    "pbe_settings.input.ADF.xc.gga = \"pbe\"\n",
     "settings += pbe_settings\n",
     "print_input(settings)"
    ]
@@ -238,7 +237,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To achieve this behaviour, the `update` method can be used, which overwrites existing keys:"
+    "To achieve \"hard update\" behaviour, the `update` method can be used, which overwrites existing keys:"
    ]
   },
   {
@@ -297,6 +296,27 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "GeometryOptimization\n",
+      "  Convergence\n",
+      "    Gradients 1e-05\n",
+      "  End\n",
+      "End\n",
+      "\n",
+      "Properties\n",
+      "End\n",
+      "\n",
+      "Task GeometryOptimization\n",
+      "\n",
+      "\n",
+      "Engine ADF\n",
+      "  Basis\n",
+      "    Type TZP\n",
+      "  End\n",
+      "  xc\n",
+      "    gga pbe\n",
+      "  End\n",
+      "EndEngine\n",
+      "\n",
       "\n"
      ]
     }
@@ -382,14 +402,14 @@
     "hybrid_settings = go_settings.copy()\n",
     "hybrid_settings.input.AMS.Hybrid.Energy.Term = []\n",
     "for i in range(5):\n",
-    "    factor = (-1) ** (i%2) * 1.0\n",
+    "    factor = (-1) ** (i % 2) * 1.0\n",
     "    region = \"*\" if i == 0 else \"one\" if i < 3 else \"two\"\n",
     "    engine_id = \"adf-lda\" if i == 0 or factor == -1 else \"adf-gga\"\n",
     "    term = Settings({\"Factor\": factor, \"Region\": region, \"EngineID\": engine_id})\n",
     "    hybrid_settings.input.AMS.Hybrid.Energy.Term.append(term)\n",
     "hybrid_settings.input.AMS.Hybrid.Engine = [lda_settings.input.ADF.copy(), pbe_settings.input.ADF.copy()]\n",
-    "hybrid_settings.input.AMS.Hybrid.Engine[0]._h = \"ADF adf-lda\" \n",
-    "hybrid_settings.input.AMS.Hybrid.Engine[1]._h = \"ADF adf-gga\" \n",
+    "hybrid_settings.input.AMS.Hybrid.Engine[0]._h = \"ADF adf-lda\"\n",
+    "hybrid_settings.input.AMS.Hybrid.Engine[1]._h = \"ADF adf-gga\"\n",
     "print_input(hybrid_settings)"
    ]
   },
@@ -536,17 +556,41 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'added': {('input', 'DFTB', 'Model'): 'GFN1-xTB'}, 'removed': {('input', 'ADF', 'Basis', 'Type'): 'DZP', ('input', 'AMS', 'Properties', 'NormalModes'): 'Yes'}, 'modified': {('input', 'AMS', 'Task'): ('SinglePoint', 'GeometryOptimization')}}\n"
+      "Items in settings2 not in settings1:\n",
+      "  - ('input', 'DFTB', 'Model'): GFN1-xTB\n",
+      "Items in settings1 not in settings2:\n",
+      "  - ('input', 'ADF', 'Basis', 'Type'): DZP\n",
+      "  - ('input', 'AMS', 'Properties', 'NormalModes'): Yes\n",
+      "Items modified from settings1 to settings2:\n",
+      "  - ('input', 'AMS', 'Task'): GeometryOptimization -> SinglePoint\n"
      ]
     }
    ],
    "source": [
+    "import os\n",
+    "\n",
     "settings1 = go_settings + lda_settings + nm_settings\n",
     "settings2 = go_settings.copy()\n",
     "settings2.input.AMS.Task = \"SinglePoint\"\n",
     "settings2.input.DFTB.Model = \"GFN1-xTB\"\n",
-    "print(settings2.compare(settings1))"
+    "comparison = settings2.compare(settings1)\n",
+    "print(\n",
+    "    f\"Items in settings2 not in settings1:{os.linesep}{os.linesep.join(f'  - {k}: {v}' for k, v in comparison['added'].items())}\"\n",
+    ")\n",
+    "print(\n",
+    "    f\"Items in settings1 not in settings2:{os.linesep}{os.linesep.join(f'  - {k}: {v}' for k, v in comparison['removed'].items())}\"\n",
+    ")\n",
+    "print(\n",
+    "    f\"Items modified from settings1 to settings2:{os.linesep}{os.linesep.join(f'  - {k}: {v[1]} -> {v[0]}' for k, v in comparison['modified'].items())}\"\n",
+    ")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/AMSSettingsInput/ams_settings_input.ipynb
+++ b/examples/AMSSettingsInput/ams_settings_input.ipynb
@@ -1,0 +1,573 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Task, Engine and Property Blocks\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from scm.plams import Settings, AMSJob"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To start with, in order to see the input that will be passed to AMS, create an AMSJob and print the input:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def print_input(settings):\n",
+    "    print(AMSJob(settings=settings).get_input())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Tasks can be specified under the `input.AMS.Task` key:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GeometryOptimization\n",
+      "  Convergence\n",
+      "    Gradients 1e-05\n",
+      "  End\n",
+      "End\n",
+      "\n",
+      "Task GeometryOptimization\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "go_settings = Settings()\n",
+    "go_settings.input.AMS.Task = \"GeometryOptimization\"\n",
+    "go_settings.input.AMS.GeometryOptimization.Convergence.Gradients=1e-5\n",
+    "print_input(go_settings)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Properties can be specified under the `input.AMS.Properties` key:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Properties\n",
+      "  NormalModes Yes\n",
+      "End\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "nm_settings = Settings()\n",
+    "nm_settings.input.ams.Properties.NormalModes = \"Yes\"\n",
+    "print_input(nm_settings)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Engine settings can be specified under the `input.AMS.<Engine>` key, for the engine of interest:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Engine ADF\n",
+      "  Basis\n",
+      "    Type DZP\n",
+      "  End\n",
+      "EndEngine\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "lda_settings = Settings()\n",
+    "lda_settings.input.ADF.Basis.Type = \"DZP\"\n",
+    "print_input(lda_settings)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Combining Settings"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Settings objects can be combined for easy reuse and job setup.\n",
+    "Settings can be merged using the `+` and `+=` operators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GeometryOptimization\n",
+      "  Convergence\n",
+      "    Gradients 1e-05\n",
+      "  End\n",
+      "End\n",
+      "\n",
+      "Properties\n",
+      "  NormalModes Yes\n",
+      "End\n",
+      "\n",
+      "Task GeometryOptimization\n",
+      "\n",
+      "\n",
+      "Engine ADF\n",
+      "  Basis\n",
+      "    Type DZP\n",
+      "  End\n",
+      "EndEngine\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "settings = go_settings + lda_settings + nm_settings\n",
+    "print_input(settings)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note however that this is a \"soft\" update, so values of existing keys will not be overwritten:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GeometryOptimization\n",
+      "  Convergence\n",
+      "    Gradients 1e-05\n",
+      "  End\n",
+      "End\n",
+      "\n",
+      "Properties\n",
+      "  NormalModes Yes\n",
+      "End\n",
+      "\n",
+      "Task GeometryOptimization\n",
+      "\n",
+      "\n",
+      "Engine ADF\n",
+      "  Basis\n",
+      "    Type DZP\n",
+      "  End\n",
+      "  xc\n",
+      "    gga pbe\n",
+      "  End\n",
+      "EndEngine\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "pbe_settings = Settings()\n",
+    "pbe_settings.input.ADF.Basis.Type = \"TZP\"\n",
+    "pbe_settings.input.ADF.xc.gga=\"pbe\"   \n",
+    "settings += pbe_settings\n",
+    "print_input(settings)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To achieve this behaviour, the `update` method can be used, which overwrites existing keys:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GeometryOptimization\n",
+      "  Convergence\n",
+      "    Gradients 1e-05\n",
+      "  End\n",
+      "End\n",
+      "\n",
+      "Properties\n",
+      "  NormalModes Yes\n",
+      "End\n",
+      "\n",
+      "Task GeometryOptimization\n",
+      "\n",
+      "\n",
+      "Engine ADF\n",
+      "  Basis\n",
+      "    Type TZP\n",
+      "  End\n",
+      "  xc\n",
+      "    gga pbe\n",
+      "  End\n",
+      "EndEngine\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "settings.update(pbe_settings)\n",
+    "print_input(settings)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Settings can also be removed using the `-` and `-=` operators:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "settings -= nm_settings\n",
+    "print_input(settings)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Multiple values in a settings block can be configured using a list:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GeometryOptimization\n",
+      "  Convergence\n",
+      "    Gradients 1e-05\n",
+      "  End\n",
+      "End\n",
+      "\n",
+      "Hybrid\n",
+      "  Energy\n",
+      "    Term\n",
+      "      EngineID adf-lda\n",
+      "      Factor 1.0\n",
+      "      Region *\n",
+      "    End\n",
+      "    Term\n",
+      "      EngineID adf-lda\n",
+      "      Factor -1.0\n",
+      "      Region one\n",
+      "    End\n",
+      "    Term\n",
+      "      EngineID adf-gga\n",
+      "      Factor 1.0\n",
+      "      Region one\n",
+      "    End\n",
+      "    Term\n",
+      "      EngineID adf-lda\n",
+      "      Factor -1.0\n",
+      "      Region two\n",
+      "    End\n",
+      "    Term\n",
+      "      EngineID adf-gga\n",
+      "      Factor 1.0\n",
+      "      Region two\n",
+      "    End\n",
+      "  End\n",
+      "  Engine ADF adf-lda\n",
+      "    Basis\n",
+      "      Type DZP\n",
+      "    End\n",
+      "  EndEngine\n",
+      "  Engine ADF adf-gga\n",
+      "    Basis\n",
+      "      Type TZP\n",
+      "    End\n",
+      "    xc\n",
+      "      gga pbe\n",
+      "    End\n",
+      "  EndEngine\n",
+      "\n",
+      "End\n",
+      "\n",
+      "Task GeometryOptimization\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "hybrid_settings = go_settings.copy()\n",
+    "hybrid_settings.input.AMS.Hybrid.Energy.Term = []\n",
+    "for i in range(5):\n",
+    "    factor = (-1) ** (i%2) * 1.0\n",
+    "    region = \"*\" if i == 0 else \"one\" if i < 3 else \"two\"\n",
+    "    engine_id = \"adf-lda\" if i == 0 or factor == -1 else \"adf-gga\"\n",
+    "    term = Settings({\"Factor\": factor, \"Region\": region, \"EngineID\": engine_id})\n",
+    "    hybrid_settings.input.AMS.Hybrid.Energy.Term.append(term)\n",
+    "hybrid_settings.input.AMS.Hybrid.Engine = [lda_settings.input.ADF.copy(), pbe_settings.input.ADF.copy()]\n",
+    "hybrid_settings.input.AMS.Hybrid.Engine[0]._h = \"ADF adf-lda\" \n",
+    "hybrid_settings.input.AMS.Hybrid.Engine[1]._h = \"ADF adf-gga\" \n",
+    "print_input(hybrid_settings)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note also in the example below, the use of the special `_h` \"header\" key, which can be used to add data to the header line for a block."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Nested Keys"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It can be useful to access values from a Settings object using \"nested\" keys. These are tuples of keys, where each successive element of the tuple corresponds to a further layer in the settings. Lists are flattened so their elements can be accessed with the corresponding index."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[('input',),\n",
+       " ('input', 'AMS'),\n",
+       " ('input', 'AMS', 'Task'),\n",
+       " ('input', 'AMS', 'GeometryOptimization'),\n",
+       " ('input', 'AMS', 'GeometryOptimization', 'Convergence'),\n",
+       " ('input', 'AMS', 'GeometryOptimization', 'Convergence', 'Gradients'),\n",
+       " ('input', 'AMS', 'Hybrid'),\n",
+       " ('input', 'AMS', 'Hybrid', 'Energy'),\n",
+       " ('input', 'AMS', 'Hybrid', 'Energy', 'Term'),\n",
+       " ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 0),\n",
+       " ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 0, 'Factor'),\n",
+       " ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 0, 'Region'),\n",
+       " ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 0, 'EngineID'),\n",
+       " ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 1),\n",
+       " ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 1, 'Factor'),\n",
+       " ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 1, 'Region'),\n",
+       " ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 1, 'EngineID'),\n",
+       " ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 2),\n",
+       " ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 2, 'Factor'),\n",
+       " ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 2, 'Region'),\n",
+       " ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 2, 'EngineID'),\n",
+       " ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 3),\n",
+       " ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 3, 'Factor'),\n",
+       " ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 3, 'Region'),\n",
+       " ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 3, 'EngineID'),\n",
+       " ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 4),\n",
+       " ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 4, 'Factor'),\n",
+       " ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 4, 'Region'),\n",
+       " ('input', 'AMS', 'Hybrid', 'Energy', 'Term', 4, 'EngineID'),\n",
+       " ('input', 'AMS', 'Hybrid', 'Engine'),\n",
+       " ('input', 'AMS', 'Hybrid', 'Engine', 0),\n",
+       " ('input', 'AMS', 'Hybrid', 'Engine', 0, '_h'),\n",
+       " ('input', 'AMS', 'Hybrid', 'Engine', 0, 'Basis'),\n",
+       " ('input', 'AMS', 'Hybrid', 'Engine', 0, 'Basis', 'Type'),\n",
+       " ('input', 'AMS', 'Hybrid', 'Engine', 1),\n",
+       " ('input', 'AMS', 'Hybrid', 'Engine', 1, '_h'),\n",
+       " ('input', 'AMS', 'Hybrid', 'Engine', 1, 'Basis'),\n",
+       " ('input', 'AMS', 'Hybrid', 'Engine', 1, 'Basis', 'Type'),\n",
+       " ('input', 'AMS', 'Hybrid', 'Engine', 1, 'xc'),\n",
+       " ('input', 'AMS', 'Hybrid', 'Engine', 1, 'xc', 'gga')]"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "list(hybrid_settings.nested_keys())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'GeometryOptimization'"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "hybrid_settings.get_nested((\"input\", \"AMS\", \"Task\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Type: \tTZP\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "if hybrid_settings.contains_nested((\"input\", \"AMS\", \"Hybrid\", \"Engine\", 0)):\n",
+    "    hybrid_settings.set_nested((\"input\", \"AMS\", \"Hybrid\", \"Engine\", 0, \"Basis\", \"Type\"), \"TZP\")\n",
+    "print(hybrid_settings.get_nested((\"input\", \"AMS\", \"Hybrid\", \"Engine\", 0, \"Basis\")))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Comparison"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Two settings objects can be compared to check the differences between them. The result will show the nested key and value of any added, removed and modified entries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'added': {('input', 'DFTB', 'Model'): 'GFN1-xTB'}, 'removed': {('input', 'ADF', 'Basis', 'Type'): 'DZP', ('input', 'AMS', 'Properties', 'NormalModes'): 'Yes'}, 'modified': {('input', 'AMS', 'Task'): ('SinglePoint', 'GeometryOptimization')}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "settings1 = go_settings + lda_settings + nm_settings\n",
+    "settings2 = go_settings.copy()\n",
+    "settings2.input.AMS.Task = \"SinglePoint\"\n",
+    "settings2.input.DFTB.Model = \"GFN1-xTB\"\n",
+    "print(settings2.compare(settings1))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/AMSSettingsInput/ams_settings_input.py
+++ b/examples/AMSSettingsInput/ams_settings_input.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env amspython
+# coding: utf-8
+
+# ## Task, Engine and Property Blocks
+# 
+# 
+
+from scm.plams import Settings, AMSJob
+
+
+# To start with, in order to see the input that will be passed to AMS, create an AMSJob and print the input:
+
+def print_input(settings):
+    print(AMSJob(settings=settings).get_input())
+
+
+# Tasks can be specified under the `input.AMS.Task` key:
+
+go_settings = Settings()
+go_settings.input.AMS.Task = "GeometryOptimization"
+go_settings.input.AMS.GeometryOptimization.Convergence.Gradients=1e-5
+print_input(go_settings)
+
+
+# Properties can be specified under the `input.AMS.Properties` key:
+
+nm_settings = Settings()
+nm_settings.input.ams.Properties.NormalModes = "Yes"
+print_input(nm_settings)
+
+
+# Engine settings can be specified under the `input.AMS.<Engine>` key, for the engine of interest:
+
+lda_settings = Settings()
+lda_settings.input.ADF.Basis.Type = "DZP"
+print_input(lda_settings)
+
+
+# ## Combining Settings
+
+# Settings objects can be combined for easy reuse and job setup.
+# Settings can be merged using the `+` and `+=` operators.
+
+settings = go_settings + lda_settings + nm_settings
+print_input(settings)
+
+
+# Note however that this is a "soft" update, so values of existing keys will not be overwritten:
+
+pbe_settings = Settings()
+pbe_settings.input.ADF.Basis.Type = "TZP"
+pbe_settings.input.ADF.xc.gga="pbe"   
+settings += pbe_settings
+print_input(settings)
+
+
+# To achieve this behaviour, the `update` method can be used, which overwrites existing keys:
+
+settings.update(pbe_settings)
+print_input(settings)
+
+
+# Settings can also be removed using the `-` and `-=` operators:
+
+settings -= nm_settings
+print_input(settings)
+
+
+# Multiple values in a settings block can be configured using a list:
+
+hybrid_settings = go_settings.copy()
+hybrid_settings.input.AMS.Hybrid.Energy.Term = []
+for i in range(5):
+    factor = (-1) ** (i%2) * 1.0
+    region = "*" if i == 0 else "one" if i < 3 else "two"
+    engine_id = "adf-lda" if i == 0 or factor == -1 else "adf-gga"
+    term = Settings({"Factor": factor, "Region": region, "EngineID": engine_id})
+    hybrid_settings.input.AMS.Hybrid.Energy.Term.append(term)
+hybrid_settings.input.AMS.Hybrid.Engine = [lda_settings.input.ADF.copy(), pbe_settings.input.ADF.copy()]
+hybrid_settings.input.AMS.Hybrid.Engine[0]._h = "ADF adf-lda" 
+hybrid_settings.input.AMS.Hybrid.Engine[1]._h = "ADF adf-gga" 
+print_input(hybrid_settings)
+
+
+# Note also in the example below, the use of the special `_h` "header" key, which can be used to add data to the header line for a block.
+
+# ## Nested Keys
+
+# It can be useful to access values from a Settings object using "nested" keys. These are tuples of keys, where each successive element of the tuple corresponds to a further layer in the settings. Lists are flattened so their elements can be accessed with the corresponding index.
+
+list(hybrid_settings.nested_keys())
+
+
+hybrid_settings.get_nested(("input", "AMS", "Task"))
+
+
+if hybrid_settings.contains_nested(("input", "AMS", "Hybrid", "Engine", 0)):
+    hybrid_settings.set_nested(("input", "AMS", "Hybrid", "Engine", 0, "Basis", "Type"), "TZP")
+print(hybrid_settings.get_nested(("input", "AMS", "Hybrid", "Engine", 0, "Basis")))
+
+
+# ## Comparison
+
+# Two settings objects can be compared to check the differences between them. The result will show the nested key and value of any added, removed and modified entries.
+
+settings1 = go_settings + lda_settings + nm_settings
+settings2 = go_settings.copy()
+settings2.input.AMS.Task = "SinglePoint"
+settings2.input.DFTB.Model = "GFN1-xTB"
+print(settings2.compare(settings1))
+

--- a/tools/table_formatter.py
+++ b/tools/table_formatter.py
@@ -3,6 +3,9 @@ from typing import Dict, List
 import numpy as np
 
 
+__all__ = ["format_in_table"]
+
+
 def format_in_table(
     data: Dict[str, List],
     max_col_width: int = -1,

--- a/tools/table_formatter.py
+++ b/tools/table_formatter.py
@@ -25,7 +25,7 @@ def format_in_table(
 
     :param data: data to format in the table
     :param max_col_width: can be integer positive value or -1, defaults to -1 (no maximum width)
-    :param max_rows: can be integer positive value or -1, defaults to 10
+    :param max_rows: can be integer positive value or -1, defaults to 30
     :return: formatted string table
     """
     elip = "..."

--- a/tools/table_formatter.py
+++ b/tools/table_formatter.py
@@ -11,17 +11,15 @@ def format_in_table(
     """
     Create a table from a dictionary of data, with the keys as column headers and the values as rows.
 
-    This will appear as follows:
+    This will appear in a Markdown compatible format, as follows:
 
     .. code-block:: python
 
-        +---+------+----------+
         | A | B    | C        |
-        +---+------+----------+
+        |---|------|----------|
         | 1 | one  | row o... |
         | . | ...  | ...      |
         | 5 | five | row f... |
-        +---+------+----------+
 
     :param data: data to format in the table
     :param max_col_width: can be integer positive value or -1, defaults to -1 (no maximum width)
@@ -55,10 +53,10 @@ def format_in_table(
     ]
 
     # Create the separator line
-    separator = f"+-{'-+-'.join('-' * width for width in col_widths)}-+"
+    separator = f"|-{'-|-'.join('-' * width for width in col_widths)}-|"
 
     # Prepare the table
-    table_rows = [separator]
+    table_rows = []
     header_row = f"| {' | '.join(f'{truncated_header[i].ljust(col_widths[i])}' for i in range(len(keys)))} |"
     table_rows.append(header_row)
     table_rows.append(separator)
@@ -82,7 +80,6 @@ def format_in_table(
         for row in values[-rows_at_end:]:
             row_text = f"| {' | '.join(f'{str(row[i]).ljust(col_widths[i])}' for i in range(len(keys)))} |"
             table_rows.append(row_text)
-    table_rows.append(separator)
 
     table = "\n".join(table_rows)
 

--- a/tools/table_formatter.py
+++ b/tools/table_formatter.py
@@ -15,13 +15,13 @@ def format_in_table(
 
     .. code-block:: python
 
-        +---+-------+----------+
-        | A |   B   |    C     |
-        +---+-------+----------+
-        | 1 |  one  | row 1... |
-        | . |  ...  |   ...    |
-        | 5 |  five | row 5... |
-        +---+-------+----------+
+        +---+------+----------+
+        | A | B    | C        |
+        +---+------+----------+
+        | 1 | one  | row o... |
+        | . | ...  | ...      |
+        | 5 | five | row f... |
+        +---+------+----------+
 
     :param data: data to format in the table
     :param max_col_width: can be integer positive value or -1, defaults to -1 (no maximum width)
@@ -59,28 +59,28 @@ def format_in_table(
 
     # Prepare the table
     table_rows = [separator]
-    header_row = f"| {' | '.join(f'{truncated_header[i].center(col_widths[i])}' for i in range(len(keys)))} |"
+    header_row = f"| {' | '.join(f'{truncated_header[i].ljust(col_widths[i])}' for i in range(len(keys)))} |"
     table_rows.append(header_row)
     table_rows.append(separator)
 
     if write_all_rows:
         # Make all rows
         for row in values:
-            row_text = f"| {' | '.join(f'{str(row[i]).center(col_widths[i])}' for i in range(len(keys)))} |"
+            row_text = f"| {' | '.join(f'{str(row[i]).ljust(col_widths[i])}' for i in range(len(keys)))} |"
             table_rows.append(row_text)
     else:
         # First part of the rows
         for row in values[:rows_at_start]:
-            row_text = f"| {' | '.join(f'{str(row[i]).center(col_widths[i])}' for i in range(len(keys)))} |"
+            row_text = f"| {' | '.join(f'{str(row[i]).ljust(col_widths[i])}' for i in range(len(keys)))} |"
             table_rows.append(row_text)
 
         # Separator row with '...'
-        dots_row = f"| {' | '.join(f'{elip[:col_widths[i]].center(col_widths[i])}' for i in range(len(keys)))} |"
+        dots_row = f"| {' | '.join(f'{elip[:col_widths[i]].ljust(col_widths[i])}' for i in range(len(keys)))} |"
         table_rows.append(dots_row)
 
         # Last part of the rows
         for row in values[-rows_at_end:]:
-            row_text = f"| {' | '.join(f'{str(row[i]).center(col_widths[i])}' for i in range(len(keys)))} |"
+            row_text = f"| {' | '.join(f'{str(row[i]).ljust(col_widths[i])}' for i in range(len(keys)))} |"
             table_rows.append(row_text)
     table_rows.append(separator)
 

--- a/tools/table_formatter.py
+++ b/tools/table_formatter.py
@@ -1,0 +1,89 @@
+from typing import Dict, List
+
+import numpy as np
+
+
+def format_in_table(
+    data: Dict[str, List],
+    max_col_width: int = -1,
+    max_rows: int = 30,
+) -> str:
+    """
+    Create a table from a dictionary of data, with the keys as column headers and the values as rows.
+
+    This will appear as follows:
+
+    .. code-block:: python
+
+        +---+-------+----------+
+        | A |   B   |    C     |
+        +---+-------+----------+
+        | 1 |  one  | row 1... |
+        | . |  ...  |   ...    |
+        | 5 |  five | row 5... |
+        +---+-------+----------+
+
+    :param data: data to format in the table
+    :param max_col_width: can be integer positive value or -1, defaults to -1 (no maximum width)
+    :param max_rows: can be integer positive value or -1, defaults to 10
+    :return: formatted string table
+    """
+    elip = "..."
+
+    def truncate(s, max_len):
+        s = str(s)
+        return f"{s[:max_len]}{elip}" if 0 < max_len < len(s) else s
+
+    # Extract keys for headers
+    keys = list(data.keys())
+
+    # Truncate headers and values based on maximum column width
+    truncated_header = [truncate(str(key), max_col_width) for key in keys]
+    columns = [[truncate(value, max_col_width) for value in col_values] for col_values in data.values()]
+
+    # Transpose columns to get rows
+    values = np.array(columns, dtype=object).T
+
+    # Calculate column widths dynamically based on truncated headers and values and values of displayed rows
+    num_rows = len(values)
+    write_all_rows = num_rows <= max_rows or max_rows == -1
+    rows_at_start = num_rows if write_all_rows else max_rows // 2
+    rows_at_end = 0 if write_all_rows else max_rows - rows_at_start
+    width_values = [v for i, v in enumerate(values) if i < rows_at_start or i >= (num_rows - rows_at_end)]
+    col_widths = [
+        max(len(truncated_header[i]), max(len(str(row[i])) for row in width_values)) for i in range(len(keys))
+    ]
+
+    # Create the separator line
+    separator = f"+-{'-+-'.join('-' * width for width in col_widths)}-+"
+
+    # Prepare the table
+    table_rows = [separator]
+    header_row = f"| {' | '.join(f'{truncated_header[i].center(col_widths[i])}' for i in range(len(keys)))} |"
+    table_rows.append(header_row)
+    table_rows.append(separator)
+
+    if write_all_rows:
+        # Make all rows
+        for row in values:
+            row_text = f"| {' | '.join(f'{str(row[i]).center(col_widths[i])}' for i in range(len(keys)))} |"
+            table_rows.append(row_text)
+    else:
+        # First part of the rows
+        for row in values[:rows_at_start]:
+            row_text = f"| {' | '.join(f'{str(row[i]).center(col_widths[i])}' for i in range(len(keys)))} |"
+            table_rows.append(row_text)
+
+        # Separator row with '...'
+        dots_row = f"| {' | '.join(f'{elip[:col_widths[i]].center(col_widths[i])}' for i in range(len(keys)))} |"
+        table_rows.append(dots_row)
+
+        # Last part of the rows
+        for row in values[-rows_at_end:]:
+            row_text = f"| {' | '.join(f'{str(row[i]).center(col_widths[i])}' for i in range(len(keys)))} |"
+            table_rows.append(row_text)
+    table_rows.append(separator)
+
+    table = "\n".join(table_rows)
+
+    return table

--- a/unit_tests/test_settings.py
+++ b/unit_tests/test_settings.py
@@ -445,6 +445,41 @@ class TestSettings:
         with pytest.raises(TypeError):
             nested_settings.pop_nested("elements")
 
+    def test_settings_get_branch_keys(self, nested_settings):
+        sett = Settings()
+        sett.elements = nested_settings.elements
+        sett.empty  # Add empty branches
+        sett.elements.Fe.empty
+
+        keys = list(sett.get_branch_keys())
+        assert keys == [("elements",), ("elements", "H"), ("elements", "O"), ("elements", "Fe")]
+
+        keys = list(sett.get_branch_keys(flatten_list=True))
+        assert keys == [
+            ("elements",),
+            ("elements", "H"),
+            ("elements", "H", "common_isotopes"),
+            ("elements", "H", "common_isotopes", 0),
+            ("elements", "H", "common_isotopes", 1),
+            ("elements", "H", "properties"),
+            ("elements", "O"),
+            ("elements", "O", "common_isotopes"),
+            ("elements", "O", "common_isotopes", 0),
+            ("elements", "O", "common_isotopes", 1),
+            ("elements", "Fe"),
+            ("elements", "Fe", "properties"),
+        ]
+
+        keys = list(sett.get_branch_keys(include_empty=True))
+        assert keys == [
+            ("elements",),
+            ("elements", "H"),
+            ("elements", "O"),
+            ("elements", "Fe"),
+            ("elements", "Fe", "empty"),
+            ("empty",),
+        ]
+
     def test_settings_compare_added_removed_and_modified(self, nested_settings):
         no_diff = nested_settings.compare(nested_settings)
 

--- a/unit_tests/test_settings.py
+++ b/unit_tests/test_settings.py
@@ -445,16 +445,188 @@ class TestSettings:
         with pytest.raises(TypeError):
             nested_settings.pop_nested("elements")
 
-    def test_settings_get_branch_keys(self, nested_settings):
+    def test_settings_nested_keys(self, nested_settings):
         sett = Settings()
         sett.elements = nested_settings.elements
         sett.empty  # Add empty branches
         sett.elements.Fe.empty
+        sett.elements.empty_list = []
+        sett.elements.half_empty = [Settings(), Settings({"k": "v", "empty": ""})]
 
-        keys = list(sett.get_branch_keys())
+        keys = list(sett.nested_keys(flatten_list=False))
+        assert keys == [
+            ("elements",),
+            ("elements", "half_empty"),
+            ("elements", "H"),
+            ("elements", "H", "name"),
+            ("elements", "H", "num"),
+            ("elements", "H", "mass"),
+            ("elements", "H", "common_isotopes"),
+            ("elements", "H", "properties"),
+            ("elements", "O"),
+            ("elements", "O", "name"),
+            ("elements", "O", "num"),
+            ("elements", "O", "mass"),
+            ("elements", "O", "common_isotopes"),
+            ("elements", "Fe"),
+            ("elements", "Fe", "name"),
+            ("elements", "Fe", "num"),
+            ("elements", "Fe", "mass"),
+            ("elements", "Fe", "metal"),
+            ("elements", "Fe", "properties"),
+        ]
+        assert all([sett.contains_nested(k) for k in keys])
+
+        keys = list(sett.nested_keys(flatten_list=False, include_empty=True))
+        assert keys == [
+            ("elements",),
+            ("elements", "empty_list"),
+            ("elements", "half_empty"),
+            ("elements", "H"),
+            ("elements", "H", "name"),
+            ("elements", "H", "num"),
+            ("elements", "H", "mass"),
+            ("elements", "H", "metal"),
+            ("elements", "H", "common_isotopes"),
+            ("elements", "H", "properties"),
+            ("elements", "O"),
+            ("elements", "O", "name"),
+            ("elements", "O", "num"),
+            ("elements", "O", "mass"),
+            ("elements", "O", "metal"),
+            ("elements", "O", "common_isotopes"),
+            ("elements", "Fe"),
+            ("elements", "Fe", "name"),
+            ("elements", "Fe", "num"),
+            ("elements", "Fe", "mass"),
+            ("elements", "Fe", "metal"),
+            ("elements", "Fe", "properties"),
+            ("elements", "Fe", "empty"),
+            ("empty",),
+        ]
+        assert all([sett.contains_nested(k) for k in keys])
+
+        keys = list(sett.nested_keys())
+        assert keys == [
+            ("elements",),
+            ("elements", "H"),
+            ("elements", "H", "name"),
+            ("elements", "H", "num"),
+            ("elements", "H", "mass"),
+            ("elements", "H", "common_isotopes"),
+            ("elements", "H", "common_isotopes", 0),
+            ("elements", "H", "common_isotopes", 0, "name"),
+            ("elements", "H", "common_isotopes", 0, "mass"),
+            ("elements", "H", "common_isotopes", 0, "abundance"),
+            ("elements", "H", "common_isotopes", 1),
+            ("elements", "H", "common_isotopes", 1, "name"),
+            ("elements", "H", "common_isotopes", 1, "mass"),
+            ("elements", "H", "common_isotopes", 1, "abundance"),
+            ("elements", "H", "properties"),
+            ("elements", "H", "properties", 0),
+            ("elements", "H", "properties", 1),
+            ("elements", "O"),
+            ("elements", "O", "name"),
+            ("elements", "O", "num"),
+            ("elements", "O", "mass"),
+            ("elements", "O", "common_isotopes"),
+            ("elements", "O", "common_isotopes", 0),
+            ("elements", "O", "common_isotopes", 0, "name"),
+            ("elements", "O", "common_isotopes", 0, "mass"),
+            ("elements", "O", "common_isotopes", 0, "abundance"),
+            ("elements", "O", "common_isotopes", 1),
+            ("elements", "O", "common_isotopes", 1, "name"),
+            ("elements", "O", "common_isotopes", 1, "mass"),
+            ("elements", "O", "common_isotopes", 1, "abundance"),
+            ("elements", "Fe"),
+            ("elements", "Fe", "name"),
+            ("elements", "Fe", "num"),
+            ("elements", "Fe", "mass"),
+            ("elements", "Fe", "metal"),
+            ("elements", "Fe", "properties"),
+            ("elements", "Fe", "properties", 0),
+            ("elements", "half_empty"),
+            ("elements", "half_empty", 1),
+            ("elements", "half_empty", 1, "k"),
+        ]
+        assert all([sett.contains_nested(k) for k in keys])
+
+        keys = list(sett.nested_keys(include_empty=True))
+        assert keys == [
+            ("elements",),
+            ("elements", "empty_list"),
+            ("elements", "H"),
+            ("elements", "H", "name"),
+            ("elements", "H", "num"),
+            ("elements", "H", "mass"),
+            ("elements", "H", "metal"),
+            ("elements", "H", "common_isotopes"),
+            ("elements", "H", "common_isotopes", 0),
+            ("elements", "H", "common_isotopes", 0, "name"),
+            ("elements", "H", "common_isotopes", 0, "mass"),
+            ("elements", "H", "common_isotopes", 0, "abundance"),
+            ("elements", "H", "common_isotopes", 1),
+            ("elements", "H", "common_isotopes", 1, "name"),
+            ("elements", "H", "common_isotopes", 1, "mass"),
+            ("elements", "H", "common_isotopes", 1, "abundance"),
+            ("elements", "H", "properties"),
+            ("elements", "H", "properties", 0),
+            ("elements", "H", "properties", 1),
+            ("elements", "O"),
+            ("elements", "O", "name"),
+            ("elements", "O", "num"),
+            ("elements", "O", "mass"),
+            ("elements", "O", "metal"),
+            ("elements", "O", "common_isotopes"),
+            ("elements", "O", "common_isotopes", 0),
+            ("elements", "O", "common_isotopes", 0, "name"),
+            ("elements", "O", "common_isotopes", 0, "mass"),
+            ("elements", "O", "common_isotopes", 0, "abundance"),
+            ("elements", "O", "common_isotopes", 1),
+            ("elements", "O", "common_isotopes", 1, "name"),
+            ("elements", "O", "common_isotopes", 1, "mass"),
+            ("elements", "O", "common_isotopes", 1, "abundance"),
+            ("elements", "Fe"),
+            ("elements", "Fe", "name"),
+            ("elements", "Fe", "num"),
+            ("elements", "Fe", "mass"),
+            ("elements", "Fe", "metal"),
+            ("elements", "Fe", "properties"),
+            ("elements", "Fe", "properties", 0),
+            ("elements", "Fe", "empty"),
+            ("elements", "half_empty"),
+            ("elements", "half_empty", 0),
+            ("elements", "half_empty", 1),
+            ("elements", "half_empty", 1, "k"),
+            ("elements", "half_empty", 1, "empty"),
+            ("empty",),
+        ]
+        assert all([sett.contains_nested(k) for k in keys])
+
+    def test_settings_branch_keys(self, nested_settings):
+        sett = Settings()
+        sett.elements = nested_settings.elements
+        sett.empty  # Add empty branches
+        sett.elements.Fe.empty
+        sett.elements.empty_list = []
+        sett.elements.half_empty = [Settings(), Settings({"k": "v", "empty": ""})]
+
+        keys = list(sett.branch_keys(flatten_list=False))
         assert keys == [("elements",), ("elements", "H"), ("elements", "O"), ("elements", "Fe")]
+        assert all([sett.contains_nested(k) for k in keys])
 
-        keys = list(sett.get_branch_keys(flatten_list=True))
+        keys = list(sett.branch_keys(flatten_list=False, include_empty=True))
+        assert keys == [
+            ("elements",),
+            ("elements", "H"),
+            ("elements", "O"),
+            ("elements", "Fe"),
+            ("elements", "Fe", "empty"),
+            ("empty",),
+        ]
+        assert all([sett.contains_nested(k) for k in keys])
+
+        keys = list(sett.branch_keys())
         assert keys == [
             ("elements",),
             ("elements", "H"),
@@ -468,17 +640,32 @@ class TestSettings:
             ("elements", "O", "common_isotopes", 1),
             ("elements", "Fe"),
             ("elements", "Fe", "properties"),
+            ("elements", "half_empty"),
+            ("elements", "half_empty", 1),
         ]
+        assert all([sett.contains_nested(k) for k in keys])
 
-        keys = list(sett.get_branch_keys(include_empty=True))
+        keys = list(sett.branch_keys(include_empty=True))
         assert keys == [
             ("elements",),
             ("elements", "H"),
+            ("elements", "H", "common_isotopes"),
+            ("elements", "H", "common_isotopes", 0),
+            ("elements", "H", "common_isotopes", 1),
+            ("elements", "H", "properties"),
             ("elements", "O"),
+            ("elements", "O", "common_isotopes"),
+            ("elements", "O", "common_isotopes", 0),
+            ("elements", "O", "common_isotopes", 1),
             ("elements", "Fe"),
+            ("elements", "Fe", "properties"),
             ("elements", "Fe", "empty"),
+            ("elements", "half_empty"),
+            ("elements", "half_empty", 0),
+            ("elements", "half_empty", 1),
             ("empty",),
         ]
+        assert all([sett.contains_nested(k) for k in keys])
 
     def test_settings_compare_added_removed_and_modified(self, nested_settings):
         no_diff = nested_settings.compare(nested_settings)

--- a/unit_tests/test_settings.py
+++ b/unit_tests/test_settings.py
@@ -603,7 +603,7 @@ class TestSettings:
         ]
         assert all([sett.contains_nested(k) for k in keys])
 
-    def test_settings_branch_keys(self, nested_settings):
+    def test_settings_block_keys(self, nested_settings):
         sett = Settings()
         sett.elements = nested_settings.elements
         sett.empty  # Add empty branches
@@ -611,11 +611,11 @@ class TestSettings:
         sett.elements.empty_list = []
         sett.elements.half_empty = [Settings(), Settings({"k": "v", "empty": ""})]
 
-        keys = list(sett.branch_keys(flatten_list=False))
+        keys = list(sett.block_keys(flatten_list=False))
         assert keys == [("elements",), ("elements", "H"), ("elements", "O"), ("elements", "Fe")]
         assert all([sett.contains_nested(k) for k in keys])
 
-        keys = list(sett.branch_keys(flatten_list=False, include_empty=True))
+        keys = list(sett.block_keys(flatten_list=False, include_empty=True))
         assert keys == [
             ("elements",),
             ("elements", "H"),
@@ -626,7 +626,7 @@ class TestSettings:
         ]
         assert all([sett.contains_nested(k) for k in keys])
 
-        keys = list(sett.branch_keys())
+        keys = list(sett.block_keys())
         assert keys == [
             ("elements",),
             ("elements", "H"),
@@ -645,7 +645,7 @@ class TestSettings:
         ]
         assert all([sett.contains_nested(k) for k in keys])
 
-        keys = list(sett.branch_keys(include_empty=True))
+        keys = list(sett.block_keys(include_empty=True))
         assert keys == [
             ("elements",),
             ("elements", "H"),

--- a/unit_tests/test_tools_table_formatter.py
+++ b/unit_tests/test_tools_table_formatter.py
@@ -20,15 +20,13 @@ class TestFormatInTable:
         assert (
             t
             == """\
-+-----+-------+-------+------------+-----------------+
 | A   | B     | CCCCC | D          | EEEEEEEE        |
-+-----+-------+-------+------------+-----------------+
+|-----|-------|-------|------------|-----------------|
 | 1   | one   | max   | evenbigger | header          |
 | 22  | two   | col   | than       | also            |
 | -3  | three | width | maximum    | evenbiggerrrrrr |
 | 44  | four  | is    | column     | than            |
-| -55 | five  | five  | width      | max             |
-+-----+-------+-------+------------+-----------------+"""
+| -55 | five  | five  | width      | max             |"""
         )
 
     def test_format_in_table_with_max_column_width_and_max_rows(self, data):
@@ -36,37 +34,31 @@ class TestFormatInTable:
         assert (
             t
             == """\
-+-----+------+-------+----------+----------+
 | A   | B    | CCCCC | D        | EEEEE... |
-+-----+------+-------+----------+----------+
+|-----|------|-------|----------|----------|
 | 1   | one  | max   | evenb... | heade... |
 | ... | ...  | ...   | ...      | ...      |
 | 44  | four | is    | colum... | than     |
-| -55 | five | five  | width    | max      |
-+-----+------+-------+----------+----------+"""
+| -55 | five | five  | width    | max      |"""
         )
 
         t = format_in_table(data, max_col_width=3, max_rows=2)
         assert (
             t
             == """\
-+-----+--------+--------+--------+--------+
 | A   | B      | CCC... | D      | EEE... |
-+-----+--------+--------+--------+--------+
+|-----|--------|--------|--------|--------|
 | 1   | one    | max    | eve... | hea... |
 | ... | ...    | ...    | ...    | ...    |
-| -55 | fiv... | fiv... | wid... | max    |
-+-----+--------+--------+--------+--------+"""
+| -55 | fiv... | fiv... | wid... | max    |"""
         )
 
         t = format_in_table(data, max_col_width=100, max_rows=1)
         assert (
             t
             == """\
-+-----+------+-------+-------+----------+
 | A   | B    | CCCCC | D     | EEEEEEEE |
-+-----+------+-------+-------+----------+
+|-----|------|-------|-------|----------|
 | ... | ...  | ...   | ...   | ...      |
-| -55 | five | five  | width | max      |
-+-----+------+-------+-------+----------+"""
+| -55 | five | five  | width | max      |"""
         )

--- a/unit_tests/test_tools_table_formatter.py
+++ b/unit_tests/test_tools_table_formatter.py
@@ -1,0 +1,72 @@
+import pytest
+
+from scm.plams.tools.table_formatter import format_in_table
+
+
+class TestFormatInTable:
+
+    @pytest.fixture
+    def data(self):
+        return {
+            "A": [1, 22, -3, 44, -55],
+            "B": ["one", "two", "three", "four", "five"],
+            "CCCCC": ["max", "col", "width", "is", "five"],
+            "D": ["evenbigger", "than", "maximum", "column", "width"],
+            "EEEEEEEE": ["header", "also", "evenbiggerrrrrr", "than", "max"],
+        }
+
+    def test_format_in_table_default(self, data):
+        t = format_in_table(data)
+        assert (
+            t
+            == """\
++-----+-------+-------+------------+-----------------+
+|  A  |   B   | CCCCC |     D      |     EEEEEEEE    |
++-----+-------+-------+------------+-----------------+
+|  1  |  one  |  max  | evenbigger |      header     |
+|  22 |  two  |  col  |    than    |       also      |
+|  -3 | three | width |  maximum   | evenbiggerrrrrr |
+|  44 |  four |   is  |   column   |       than      |
+| -55 |  five |  five |   width    |       max       |
++-----+-------+-------+------------+-----------------+"""
+        )
+
+    def test_format_in_table_with_max_column_width_and_max_rows(self, data):
+        t = format_in_table(data, max_col_width=5, max_rows=3)
+        assert (
+            t
+            == """\
++-----+------+-------+----------+----------+
+|  A  |  B   | CCCCC |    D     | EEEEE... |
++-----+------+-------+----------+----------+
+|  1  | one  |  max  | evenb... | heade... |
+| ... | ...  |  ...  |   ...    |   ...    |
+|  44 | four |   is  | colum... |   than   |
+| -55 | five |  five |  width   |   max    |
++-----+------+-------+----------+----------+"""
+        )
+
+        t = format_in_table(data, max_col_width=3, max_rows=2)
+        assert (
+            t
+            == """\
++-----+--------+--------+--------+--------+
+|  A  |   B    | CCC... |   D    | EEE... |
++-----+--------+--------+--------+--------+
+|  1  |  one   |  max   | eve... | hea... |
+| ... |  ...   |  ...   |  ...   |  ...   |
+| -55 | fiv... | fiv... | wid... |  max   |
++-----+--------+--------+--------+--------+"""
+        )
+
+        t = format_in_table(data, max_col_width=100, max_rows=1)
+        assert (
+            t
+            == """\
++-----+------+-------+-------+----------+
+|  A  |  B   | CCCCC |   D   | EEEEEEEE |
++-----+------+-------+-------+----------+
+| ... | ...  |  ...  |  ...  |   ...    |
+| -55 | five |  five | width |   max    |
++-----+------+-------+-------+----------+"""
+        )

--- a/unit_tests/test_tools_table_formatter.py
+++ b/unit_tests/test_tools_table_formatter.py
@@ -21,13 +21,13 @@ class TestFormatInTable:
             t
             == """\
 +-----+-------+-------+------------+-----------------+
-|  A  |   B   | CCCCC |     D      |     EEEEEEEE    |
+| A   | B     | CCCCC | D          | EEEEEEEE        |
 +-----+-------+-------+------------+-----------------+
-|  1  |  one  |  max  | evenbigger |      header     |
-|  22 |  two  |  col  |    than    |       also      |
-|  -3 | three | width |  maximum   | evenbiggerrrrrr |
-|  44 |  four |   is  |   column   |       than      |
-| -55 |  five |  five |   width    |       max       |
+| 1   | one   | max   | evenbigger | header          |
+| 22  | two   | col   | than       | also            |
+| -3  | three | width | maximum    | evenbiggerrrrrr |
+| 44  | four  | is    | column     | than            |
+| -55 | five  | five  | width      | max             |
 +-----+-------+-------+------------+-----------------+"""
         )
 
@@ -37,12 +37,12 @@ class TestFormatInTable:
             t
             == """\
 +-----+------+-------+----------+----------+
-|  A  |  B   | CCCCC |    D     | EEEEE... |
+| A   | B    | CCCCC | D        | EEEEE... |
 +-----+------+-------+----------+----------+
-|  1  | one  |  max  | evenb... | heade... |
-| ... | ...  |  ...  |   ...    |   ...    |
-|  44 | four |   is  | colum... |   than   |
-| -55 | five |  five |  width   |   max    |
+| 1   | one  | max   | evenb... | heade... |
+| ... | ...  | ...   | ...      | ...      |
+| 44  | four | is    | colum... | than     |
+| -55 | five | five  | width    | max      |
 +-----+------+-------+----------+----------+"""
         )
 
@@ -51,22 +51,31 @@ class TestFormatInTable:
             t
             == """\
 +-----+--------+--------+--------+--------+
-|  A  |   B    | CCC... |   D    | EEE... |
+| A   | B      | CCC... | D      | EEE... |
 +-----+--------+--------+--------+--------+
-|  1  |  one   |  max   | eve... | hea... |
-| ... |  ...   |  ...   |  ...   |  ...   |
-| -55 | fiv... | fiv... | wid... |  max   |
+| 1   | one    | max    | eve... | hea... |
+| ... | ...    | ...    | ...    | ...    |
+| -55 | fiv... | fiv... | wid... | max    |
 +-----+--------+--------+--------+--------+"""
         )
 
         t = format_in_table(data, max_col_width=100, max_rows=1)
+        t = format_in_table(
+            {
+                "A": range(1, 6),
+                "B": ["one", "two", "three", "four", "five"],
+                "C": ["row one", "row two", "row three", "row four", "row five"],
+            },
+            max_col_width=5,
+            max_rows=2,
+        )
         assert (
             t
             == """\
 +-----+------+-------+-------+----------+
-|  A  |  B   | CCCCC |   D   | EEEEEEEE |
+| A   | B    | CCCCC | D     | EEEEEEEE |
 +-----+------+-------+-------+----------+
-| ... | ...  |  ...  |  ...  |   ...    |
-| -55 | five |  five | width |   max    |
+| ... | ...  | ...   | ...   | ...      |
+| -55 | five | five  | width | max      |
 +-----+------+-------+-------+----------+"""
         )

--- a/unit_tests/test_tools_table_formatter.py
+++ b/unit_tests/test_tools_table_formatter.py
@@ -60,15 +60,6 @@ class TestFormatInTable:
         )
 
         t = format_in_table(data, max_col_width=100, max_rows=1)
-        t = format_in_table(
-            {
-                "A": range(1, 6),
-                "B": ["one", "two", "three", "four", "five"],
-                "C": ["row one", "row two", "row three", "row four", "row five"],
-            },
-            max_col_width=5,
-            max_rows=2,
-        )
         assert (
             t
             == """\


### PR DESCRIPTION
# Description

First set of added/modified methods to `Settings` to help with manipulation and analysis.

Changes are related to those in branch `GiulioBenedini/plams_settings_extra` (GB)

* Methods `remove` and `difference` aliased to `-=` and `-` allow subtraction of a settings object from another. These are based on `GB.subtract`
* Method `contains_nested` added to check whether a nested key tuple is in the settings. Note that only the tuple is supported, not the dot syntax for now i.e. `('a', 'b', 'c')` not `a.b.c.`. This is because it is easier to be consistent if these key tuples are input/output to the settings
* `get_nested` now has a default argument as in `GB.get_default`, this is slightly breaking as it used to return an empty `Settings` if a key could not be found, but I think this is worth it for consistency
* Add `pop_nested` as per `GB.pop_nested`
* Add `nested_keys` and `block_keys` the latter being similar to `GB.get_blocks_path`, renamed as blocks is an AMS-specific concept
* Add `compare` method similar to `GB.compare`, but it includes the added/removed and modified items in one return dict
* Add `format_in_table` similar to `GB.format_in_table` to pretty print data in a table

See unit tests and new documentation example on building AMS input settings for example usage