### PR TITLE
Convert JobRunner Parallelisation Attributes to Properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ This changelog is effective from the 2025 releases.
 * Make `Job` class inherit from `ABC` and mark abstract methods 
 * Exceptions raised in `prerun` and `postrun` will always be caught and populate error message
 * `Settings.get_nested` takes a default argument which is returned if the nested key is not present in the settings instance
+* `JobRunner.parallel`, `JobRunner.maxjobs` and `JobRunner.maxthreads` are properties which can take values of `0` or `>1` and `JobRunner.semaphore` has been moved to a protected attribute `JobRunner._job_limit`
 
 ### Fixed
 * `Molecule.properties.charge` is a numeric instead of string type when loading molecule from a file
@@ -52,6 +53,7 @@ This changelog is effective from the 2025 releases.
 * `AMSJob.check` handles a `NoneType` status, returning `False`
 * `MultiJob.run` locking resolved when errors raised within `prerun` and `postrun` methods
 * `Molecule.add_hatoms` to use bonding information if available when adding new hydrogen atoms
+* Changes made to `JobRunner.maxjobs` after initialization are correctly applied
 
 ### Deprecated
 * `plams` launch script is deprecated in favor of simply running with `amspython`

--- a/core/jobrunner.py
+++ b/core/jobrunner.py
@@ -92,7 +92,7 @@ class JobRunner(metaclass=_MetaRunner):
     A |JobRunner| instance can be passed to |run| with a keyword argument ``jobrunner``. If this argument is omitted, the instance stored in ``config.default_jobrunner`` is used.
     """
 
-    def __init__(self, parallel:bool=False, maxjobs:int=0, maxthreads:int=256):
+    def __init__(self, parallel: bool = False, maxjobs: int = 0, maxthreads: int = 256):
         # Initialize protected attributes
         self._parallel = False
         self._maxjobs = 0
@@ -170,7 +170,9 @@ class JobRunner(metaclass=_MetaRunner):
         if value < 0:
             raise ValueError(f"Value of 'maxthreads' must be 0 or greater than 1, but was {value}.")
         if value == 1:
-            raise ValueError("Value of 'maxthreads' must be 0 or greater than 1. To run in serial, set 'parallel=False'.")
+            raise ValueError(
+                "Value of 'maxthreads' must be 0 or greater than 1. To run in serial, set 'parallel=False'."
+            )
 
         # Wait for any threads using the semaphore to finish up before changing the instance
         if self._maxthreads and self._jobthread_limit:
@@ -179,7 +181,6 @@ class JobRunner(metaclass=_MetaRunner):
 
         self._maxthreads = value
         self._jobthread_limit = threading.BoundedSemaphore(value) if value else None
-
 
     def call(self, runscript, workdir, out, err, runflags):
         """call(runscript, workdir, out, err, runflags)

--- a/core/jobrunner.py
+++ b/core/jobrunner.py
@@ -51,12 +51,12 @@ def _in_limited_thread(func):
 
 
 def _limit(func):
-    """Decorator for an instance method. If ``semaphore`` attribute of given instance is not ``None``, use this attribute to wrap decorated method via :ref:`with<with-locks>` statement."""
+    """Decorator for an instance method. If ``_job_limit`` attribute of given instance is not ``None``, use this attribute to wrap decorated method via :ref:`with<with-locks>` statement."""
 
     @functools.wraps(func)
     def wrapper(self, *args, **kwargs):
-        if self.semaphore:
-            with self.semaphore:
+        if self._job_limit:
+            with self._job_limit:
                 return func(self, *args, **kwargs)
         else:
             return func(self, *args, **kwargs)
@@ -92,11 +92,94 @@ class JobRunner(metaclass=_MetaRunner):
     A |JobRunner| instance can be passed to |run| with a keyword argument ``jobrunner``. If this argument is omitted, the instance stored in ``config.default_jobrunner`` is used.
     """
 
-    def __init__(self, parallel=False, maxjobs=0, maxthreads=256):
+    def __init__(self, parallel:bool=False, maxjobs:int=0, maxthreads:int=256):
+        # Initialize protected attributes
+        self._parallel = False
+        self._maxjobs = 0
+        self._job_limit = None
+        self._maxthreads = 0
+        self._jobthread_limit = None
+
+        # Set properties
         self.parallel = parallel
         self.maxjobs = maxjobs
-        self.semaphore = threading.BoundedSemaphore(maxjobs) if maxjobs else None
-        self._jobthread_limit = threading.BoundedSemaphore(maxthreads) if maxthreads else None
+        self.maxthreads = maxthreads
+
+    @property
+    def parallel(self) -> bool:
+        """
+        Whether jobs can be run simultaneously or not. Defaults to ``False``.
+
+        When set to ``True``, jobs can be run in parallel, with the level of parallelization determined by the properties :attr:`~scm.plams.core.jobrunner.JobRunner.maxjobs` and :attr:`~scm.plams.core.jobrunner.JobRunner.maxthreads`.
+        """
+        return self._parallel
+
+    @parallel.setter
+    def parallel(self, value: bool) -> None:
+        self._parallel = value
+
+    @property
+    def maxjobs(self) -> int:
+        """
+        Maximum number of jobs which can be run in parallel. Defaults to ``0``.
+
+        When set to ``0``, no job limit is enforced.
+
+        Note that to take effect, this requires :attr:`~scm.plams.core.jobrunner.JobRunner.parallel` to be ``True``.
+        The number of jobs may also be limited by :attr:`~scm.plams.core.jobrunner.JobRunner.maxthreads`.
+
+        When jobs are running using this, updating this value will block until its usage is complete.
+        """
+        return self._maxjobs
+
+    @maxjobs.setter
+    def maxjobs(self, value: int) -> None:
+        if value < 0:
+            raise ValueError(f"Value of 'maxjobs' must be 0 or greater than 1, but was {value}.")
+        if value == 1:
+            raise ValueError("Value of 'maxjobs' must be 0 or greater than 1. To run in serial, set 'parallel=False'.")
+
+        # Wait for any threads using the semaphore to finish up before changing the instance
+        if self._maxjobs and self._job_limit:
+            for _ in range(self._maxjobs):
+                self._job_limit.acquire()
+
+        self._maxjobs = value
+        self._job_limit = threading.BoundedSemaphore(value) if value else None
+
+    @property
+    def maxthreads(self) -> int:
+        """
+        Maximum number of threads which can be started in parallel. Defaults to ``256``.
+
+        When set to ``0``, no thread limit is enforced.
+
+        As each job is runs in a separate thread, this number necessarily acts as an upper limit for the number of jobs that can run in parallel.
+        If the limit is exhausted, running further jobs with this |JobRunner| instance will block execution until another already running job thread terminates.
+        The ``maxthreads`` limit should be set as large as possible, but not so large as to exceed any limits imposed by the operating system.
+
+        Note that to take effect, this requires :attr:`~scm.plams.core.jobrunner.JobRunner.parallel` to be ``True``.
+        The number of jobs may also be limited by :attr:`~scm.plams.core.jobrunner.JobRunner.maxjobs`.
+
+        When jobs are running using this, updating this value will block until its usage is complete.
+        """
+        return self._maxthreads
+
+    @maxthreads.setter
+    def maxthreads(self, value: int) -> None:
+        if value < 0:
+            raise ValueError(f"Value of 'maxthreads' must be 0 or greater than 1, but was {value}.")
+        if value == 1:
+            raise ValueError("Value of 'maxthreads' must be 0 or greater than 1. To run in serial, set 'parallel=False'.")
+
+        # Wait for any threads using the semaphore to finish up before changing the instance
+        if self._maxthreads and self._jobthread_limit:
+            for _ in range(self._maxthreads):
+                self._jobthread_limit.acquire()
+
+        self._maxthreads = value
+        self._jobthread_limit = threading.BoundedSemaphore(value) if value else None
+
 
     def call(self, runscript, workdir, out, err, runflags):
         """call(runscript, workdir, out, err, runflags)

--- a/core/threading_utils.py
+++ b/core/threading_utils.py
@@ -1,0 +1,90 @@
+import threading
+
+
+class LimitedSemaphore:
+    """
+    A semaphore with an adjustable limit on the maximum value
+    """
+
+    def __init__(self, max_value: int):
+        if max_value < 0:
+            raise ValueError(f"max_value must be greater or equal to 0, was {max_value}")
+
+        self._max_value = max_value
+        self._value = max_value
+        self._setter_waiting = False
+        self._set_lock = threading.Lock()
+        self._condition = threading.Condition(threading.Lock())
+
+    def acquire(self):
+        """
+        Acquire a semaphore, decrementing internal counter by one.
+
+        If internal counter is greater than zero on entry, return immediately,
+        otherwise block and wait until another thread has called release.
+        """
+        with self._condition:
+            # Give priority to the max_value setter and then wait until a semaphore is available
+            while self._setter_waiting or self._value == 0:
+                self._condition.wait()
+            self._value -= 1
+
+    __enter__ = acquire
+
+    def release(self, n: int = 1):
+        """
+        Release a semaphore, incrementing the internal counter by one or more.
+
+        When the counter goes above the configured maximum value, raises a ValueError.
+
+        When the counter is zero on entry and another thread is waiting for it
+        to become larger than zero again, wake up that thread.
+        """
+        if n < 1:
+            raise ValueError(f"n must be one or more, was {n}")
+
+        with self._condition:
+            # Increase counter if within limit and notify waiting threads
+            if self._value + n > self._max_value:
+                raise ValueError(f"LimitedSemaphore released too many times, maximum is set to {self._max_value}")
+            self._value += n
+            self._condition.notify_all()
+
+    def __exit__(self, t, v, tb):
+        self.release()
+
+    @property
+    def max_value(self) -> int:
+        """
+        Maximum value for the internal counter.
+
+        If the semaphore exceeds this a ValueError will be raised.
+
+        Setting the maximum value higher than the current maximum will immediately allow further acquire calls.
+        Conversely, reducing the maximum will block until enough threads have released to satisfy the new maximum.
+        """
+        with self._condition:
+            return self._max_value
+
+    @max_value.setter
+    def max_value(self, max_value: int):
+        with self._set_lock:
+            with self._condition:
+                diff = max_value - self._max_value
+                if diff == 0:
+                    return
+
+                # Block new acquires
+                self._setter_waiting = True
+
+                # If decreasing max value, wait for enough releases to safely increase max
+                # If increasing max value, can just go ahead
+                if diff < 0:
+                    while diff + self._value < 0:
+                        self._condition.wait()
+
+                # Modify the (max) value and notify waiting threads
+                self._value += diff
+                self._max_value = max_value
+                self._setter_waiting = False
+                self._condition.notify_all()

--- a/unit_tests/test_jobrunner.py
+++ b/unit_tests/test_jobrunner.py
@@ -1,5 +1,4 @@
 import pytest
-import time
 
 from scm.plams.core.jobrunner import JobRunner
 from scm.plams.unit_tests.test_basejob import DummySingleJob, log_call
@@ -100,30 +99,20 @@ class TestJobRunner:
         # When set maxjobs to 0
         # Then no semaphore
         jobrunner.maxjobs = 0
-        assert jobrunner._maxjobs == 0
+        assert jobrunner.maxjobs == 0
         assert jobrunner._job_limit is None
 
         # When set maxjobs to a new value
         # Then semaphore set
         jobrunner.maxjobs = 10
-        assert jobrunner._maxjobs == 10
+        assert jobrunner.maxjobs == 10
         assert jobrunner._job_limit is not None
-        assert jobrunner._job_limit._value == 10
-
-        # When job acquires semaphore
-        # Then block in updating maxjobs
-        job = DummySingleJob(wait=0.5)
-        start = time.perf_counter()
-        jobrunner._run_job(job, config.default_jobmanager)
-        time.sleep(0.2)  # need this to give time for the call method
-        jobrunner.maxjobs = 20
-        end = time.perf_counter()
-        assert end - start > 0.5
+        assert jobrunner._job_limit.max_value == 10
 
         # When set maxjobs to 0
         # Then no semaphore
         jobrunner.maxjobs = 0
-        assert jobrunner._maxjobs == 0
+        assert jobrunner.maxjobs == 0
         assert jobrunner._job_limit is None
 
         # When set maxthreads to <0 or 1
@@ -136,29 +125,20 @@ class TestJobRunner:
         # When set maxthreads to 0
         # Then no semaphore
         jobrunner.maxthreads = 0
-        assert jobrunner._maxthreads == 0
+        assert jobrunner.maxthreads == 0
         assert jobrunner._jobthread_limit is None
 
         # When set maxthreads to a new value
         # Then semaphore set
         jobrunner.maxthreads = 10
-        assert jobrunner._maxthreads == 10
+        assert jobrunner.maxthreads == 10
         assert jobrunner._jobthread_limit is not None
-        assert jobrunner._jobthread_limit._value == 10
-
-        # When job acquires semaphore
-        # Then block in updating maxthreads
-        job = DummySingleJob(wait=0.5)
-        start = time.perf_counter()
-        jobrunner._run_job(job, config.default_jobmanager)
-        jobrunner.maxthreads = 20
-        end = time.perf_counter()
-        assert end - start > 0.5
+        assert jobrunner._jobthread_limit.max_value == 10
 
         # When set maxthreads to 0
         # Then no semaphore
         jobrunner.maxthreads = 0
-        assert jobrunner._maxthreads == 0
+        assert jobrunner.maxthreads == 0
         assert jobrunner._job_limit is None
 
     def verify_serial(self, jobrunner, config):

--- a/unit_tests/test_jobrunner.py
+++ b/unit_tests/test_jobrunner.py
@@ -203,7 +203,7 @@ class TestJobRunner:
 
         max_parallel_jobs = 0
         current_jobs = 0
-        for time, change in events:
+        for _, change in events:
             current_jobs += change
             max_parallel_jobs = max(max_parallel_jobs, current_jobs)
 

--- a/unit_tests/test_jobrunner.py
+++ b/unit_tests/test_jobrunner.py
@@ -1,0 +1,211 @@
+import pytest
+import time
+
+from scm.plams.core.jobrunner import JobRunner
+from scm.plams.unit_tests.test_basejob import DummySingleJob, log_call
+
+
+class LoggedJobRunner(JobRunner):
+    """
+    Test job runner which logs call timings.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.call_log = {}
+
+    def add_call_log_entry(self, entry):
+        if entry.method in self.call_log:
+            if isinstance(self.call_log[entry.method], list):
+                self.call_log[entry.method].append(entry)
+            else:
+                self.call_log[entry.method] = [self.call_log[entry.method], entry]
+        else:
+            self.call_log[entry.method] = entry
+
+    @log_call
+    def call(self, runscript, workdir, out, err, runflags):
+        return super().call(runscript, workdir, out, err, runflags)
+
+
+class TestJobRunner:
+
+    def test_serial_execution(self, config):
+        # Given a job runner with parallel set to False in c'tor or via setter
+        jobrunner1 = LoggedJobRunner()
+        jobrunner2 = LoggedJobRunner(parallel=True)
+        jobrunner2.parallel = False
+
+        # When run jobs
+        # Then verify run in serial
+        self.verify_serial(jobrunner1, config)
+        self.verify_serial(jobrunner2, config)
+
+    @pytest.mark.parametrize(
+        "maxjobs,maxthreads,use_setter",
+        [
+            (2, 256, False),
+            (3, 256, True),
+            (4, 256, False),
+            (5, 256, True),
+            (0, 2, False),
+            (0, 3, True),
+            (0, 4, False),
+            (0, 5, True),
+            (0, 10, False),
+            (4, 2, False),
+            (2, 4, False),
+        ],
+    )
+    def test_parallel_execution_with_limit(self, maxjobs, maxthreads, use_setter, config):
+        # Given a job runner with parallel constraint in c'tor or via setter
+        if use_setter:
+            jobrunner = LoggedJobRunner(parallel=True)
+            jobrunner.maxjobs = maxjobs
+            jobrunner.maxthreads = maxthreads
+        else:
+            jobrunner = LoggedJobRunner(parallel=True, maxjobs=maxjobs, maxthreads=maxthreads)
+
+        # When run jobs
+        # Then verify run in parallel with constraints
+        self.verify_parallel_limit(jobrunner, config, maxjobs, maxthreads)
+
+    def test_serial_to_parallel_toggle(self, config):
+        # Given a serial job runner
+        jobrunner = LoggedJobRunner(maxjobs=2)
+
+        # When run jobs
+        # Then runs in serial
+        self.verify_serial(jobrunner, config)
+
+        # When set to parallel and maxjobs increased
+        jobrunner.parallel = True
+        jobrunner.maxjobs = 0
+
+        # When run jobs
+        # Then runs in parallel
+        self.verify_parallel_limit(jobrunner, config, 0, 256)
+
+    def test_limit_setters(self, config):
+        # Given jobrunner
+        jobrunner = LoggedJobRunner(parallel=True)
+
+        # When set maxjobs to <0 or 1
+        # Then get error
+        with pytest.raises(ValueError):
+            jobrunner.maxjobs = -1
+        with pytest.raises(ValueError):
+            jobrunner.maxjobs = 1
+
+        # When set maxjobs to 0
+        # Then no semaphore
+        jobrunner.maxjobs = 0
+        assert jobrunner._maxjobs == 0
+        assert jobrunner._job_limit is None
+
+        # When set maxjobs to a new value
+        # Then semaphore set
+        jobrunner.maxjobs = 10
+        assert jobrunner._maxjobs == 10
+        assert jobrunner._job_limit is not None
+        assert jobrunner._job_limit._value == 10
+
+        # When job acquires semaphore
+        # Then block in updating maxjobs
+        job = DummySingleJob(wait=0.5)
+        start = time.perf_counter()
+        jobrunner._run_job(job, config.default_jobmanager)
+        time.sleep(0.2)  # need this to give time for the call method
+        jobrunner.maxjobs = 20
+        end = time.perf_counter()
+        assert end - start > 0.5
+
+        # When set maxjobs to 0
+        # Then no semaphore
+        jobrunner.maxjobs = 0
+        assert jobrunner._maxjobs == 0
+        assert jobrunner._job_limit is None
+
+        # When set maxthreads to <0 or 1
+        # Then get error
+        with pytest.raises(ValueError):
+            jobrunner.maxthreads = -1
+        with pytest.raises(ValueError):
+            jobrunner.maxthreads = 1
+
+        # When set maxthreads to 0
+        # Then no semaphore
+        jobrunner.maxthreads = 0
+        assert jobrunner._maxthreads == 0
+        assert jobrunner._jobthread_limit is None
+
+        # When set maxthreads to a new value
+        # Then semaphore set
+        jobrunner.maxthreads = 10
+        assert jobrunner._maxthreads == 10
+        assert jobrunner._jobthread_limit is not None
+        assert jobrunner._jobthread_limit._value == 10
+
+        # When job acquires semaphore
+        # Then block in updating maxthreads
+        job = DummySingleJob(wait=0.5)
+        start = time.perf_counter()
+        jobrunner._run_job(job, config.default_jobmanager)
+        jobrunner.maxthreads = 20
+        end = time.perf_counter()
+        assert end - start > 0.5
+
+        # When set maxthreads to 0
+        # Then no semaphore
+        jobrunner.maxthreads = 0
+        assert jobrunner._maxthreads == 0
+        assert jobrunner._job_limit is None
+
+    def verify_serial(self, jobrunner, config):
+        # When run 5 jobs
+        jobs = []
+        for i in range(5):
+            job = DummySingleJob(wait=0.1)
+            jobs.append(job)
+            jobrunner._run_job(job, config.default_jobmanager)
+
+        # Then check either that successive jobs are only executed after the previous has finished
+        for i, j in enumerate(jobs):
+            j.results.wait()
+            if i > 0:
+                # Then successive jobs are only executed after the previous has finished
+                assert jobs[i].call_log["_execute"].timestamp >= jobs[i - 1].call_log["_finalize"].timestamp
+
+    def verify_parallel_limit(self, jobrunner, config, maxjobs, maxthreads):
+        jobs = []
+        thread_limited = maxthreads < maxjobs or maxjobs == 0
+        limit = maxthreads if thread_limited else maxjobs
+
+        # When run 5 jobs in parallel with limit
+        for i in range(5):
+            job = DummySingleJob(wait=0.2)
+            jobs.append(job)
+            jobrunner._run_job(job, config.default_jobmanager)
+
+        times = []
+        for i, j in enumerate(jobs):
+            j.results.wait()
+            if thread_limited:
+                start = jobs[i].call_log["_prepare"].timestamp
+                end = jobs[i].call_log["_finalize"].timestamp
+            else:
+                start = jobrunner.call_log["call"][i].timestamp
+                end = jobs[i].call_log["_finalize"].timestamp
+            times.append((start, end))
+
+        events = [e for s, e in times for e in [(s, 1), (e, -1)]]
+        events.sort(key=lambda x: (x[0], x[1]))
+
+        max_parallel_jobs = 0
+        current_jobs = 0
+        for time, change in events:
+            current_jobs += change
+            max_parallel_jobs = max(max_parallel_jobs, current_jobs)
+
+        # Then number of jobs running in parallel is within limit
+        assert max_parallel_jobs <= limit

--- a/unit_tests/test_threading_utils.py
+++ b/unit_tests/test_threading_utils.py
@@ -1,0 +1,141 @@
+import time
+
+import pytest
+from datetime import datetime, timedelta
+import threading
+
+from scm.plams.core.threading_utils import LimitedSemaphore
+
+
+class TestLimitedSemaphore:
+
+    def test_can_acquire_and_release_without_blocking_within_limit(self):
+        # Given semaphore with max
+        semaphore = LimitedSemaphore(3)
+
+        # When acquire then release within limit
+        # Then does not block
+        for i in range(10):
+            semaphore.acquire()
+            with semaphore:
+                semaphore.acquire()
+                semaphore.release()
+            semaphore.acquire()
+            semaphore.acquire()
+            semaphore.release(3)
+
+    def test_release_above_limit_errors(self):
+        # Given semaphore with max
+        semaphore = LimitedSemaphore(3)
+
+        # When release above limit
+        # Then raises error
+        with pytest.raises(ValueError):
+            semaphore.release()
+        semaphore.acquire()
+        with pytest.raises(ValueError):
+            semaphore.release(2)
+
+    def test_acquire_blocks_until_released(self):
+        # Given semaphore with max
+        semaphore = LimitedSemaphore(3)
+
+        # When acquire
+        log_values = {}
+        thread1 = self.start_in_thread(self.acquire_and_log, 0, semaphore, 3, "a1", log_values)
+        thread2 = self.start_in_thread(self.acquire_and_log, 0.05, semaphore, 3, "a2", log_values)
+
+        # Then extra threads wait for release
+        time.sleep(0.1)
+        semaphore.release(3)
+        thread1.join()
+        thread2.join()
+
+        assert log_values["a2"] - log_values["a1"] > timedelta(seconds=0.1)
+
+    def test_set_max_value(self):
+        # Given semaphore with initial max
+        semaphore = LimitedSemaphore(3)
+        assert semaphore.max_value == 3
+
+        # When increase max on thread with delay
+        log_values = {}
+        self.acquire_and_log(semaphore, 3, "a1", log_values)
+        self.start_in_thread(self.set_max_value_and_log, 0.2, semaphore, 10, "m10", log_values)
+
+        # Then can acquire after max increased
+        self.acquire_and_log(semaphore, 7, "a2", log_values)
+        assert log_values["a2"] - log_values["a1"] > timedelta(seconds=0.2)
+        assert semaphore.max_value == 10
+
+        # When decrease max
+        t = self.start_in_thread(self.set_max_value_and_log, 0.0, semaphore, 2, "m2", log_values)
+
+        # Then waits for enough releases to take effect
+        self.release_and_log(semaphore, 5, "r1", log_values)
+        assert semaphore.max_value == 10
+        self.release_and_log(semaphore, 3, "r2", log_values)
+        t.join()
+        assert semaphore.max_value == 2
+
+        # When decrease to zero
+        t = self.start_in_thread(self.set_max_value_and_log, 0.0, semaphore, 0, "m0", log_values)
+        self.release_and_log(semaphore, 2, "r2", log_values)
+        t.join()
+        assert semaphore.max_value == 0
+
+        # Then cannot acquire until increased
+        t = self.start_in_thread(self.acquire_and_log, 0, semaphore, 3, "a3", log_values)
+        self.start_in_thread(self.set_max_value_and_log, 0.2, semaphore, 100, "m100", log_values)
+        t.join()
+        assert log_values["a3"] - log_values["m0"] > timedelta(seconds=0.2)
+
+    def test_many_threads(self):
+        # Set limit many times and perform many acquires/releases, check completes
+        limits = [2, 8, 1, 16, 0, 128, 32, 0, 64, 256, 4, 0, 256, 32, 16, 0, 64]
+        semaphore = LimitedSemaphore(0)
+        log_values = {}
+
+        def acquire_delay_release(n, d):
+            def acquire_delay_release():
+                with semaphore:
+                    time.sleep(d)
+
+            threads = [threading.Thread(target=acquire_delay_release) for _ in range(n)]
+            for thread in threads:
+                thread.start()
+            return threads
+
+        threads = []
+        for i, limit in enumerate(limits):
+            t = acquire_delay_release(128, 0.05)
+            threads.append(t)
+            self.set_max_value_and_log(semaphore, limit, f"m{i}", log_values)
+            assert semaphore._value <= semaphore.max_value
+            assert semaphore.max_value == limit
+
+        for ts in threads:
+            for t in ts:
+                t.join()
+
+    def start_in_thread(self, func, delay, *args):
+        time.sleep(delay)
+        thread = threading.Thread(target=func, args=args)
+        thread.start()
+        return thread
+
+    @staticmethod
+    def acquire_and_log(semaphore, n, key, log_values):
+        for _ in range(n):
+            semaphore.acquire()
+        log_values[key] = datetime.utcnow()
+
+    @staticmethod
+    def release_and_log(semaphore, n, key, log_values):
+        semaphore.release(n)
+        log_values[key] = datetime.utcnow()
+
+    @staticmethod
+    def set_max_value_and_log(semaphore, n, key, log_values):
+        semaphore.max_value = n
+        log_values[key] = datetime.utcnow()


### PR DESCRIPTION
# Description 

Improvements to the interface of the `JobRunner`. Previously, the parallelisation and level of parallelisation needed to be specified on initialisation. This is ok, but the publicly exposed attributes could also be modified having an undetermined effect on the class. For example:
```
   plams.config.default_jobrunner.parallel = True
   plams.config.default_jobrunner.maxjobs = 3
```
would use a parallel runner but not set the maximum job limit, as the underlying semaphore would not be updated.

This change therefore:
* Changes `parallel`, `maxjobs` and `maxthreads` to be properties
* Sets up the semaphores when altering the values of `maxjobs` and `maxthreads`
* Renames `semaphore` to `_job_limit` for consistency and to highlight no-one should ever access this - technically breaking
* Checks the values for maxjobs/maxthreads are 0 or >1. If maxjobs is set to 1, the process locks.

The alternative would also be just to have these as readonly properties so enforce that they can be set only on initialisation. I am on the fence either way - this would be a slightly simpler change, but would not allow this nice setting directly through the default job runner.