### PR TITLE
Fix black version to 24.8.0 SO--

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,8 +74,8 @@ examples = [
 dev = [
     "pytest>=7.4.0",
     "coverage>=7.5.3",
-    "black>=24",
-    "black[jupyter]>=24",
+    "black==24.8.0",
+    "black[jupyter]==24.8.0",
     "flake8==5.0.4",
     "mypy==1.12.0"
 ]


### PR DESCRIPTION
This is the last version of black that is amspython compatible (python 3.8).

2025 version has small differences, but folks probably still want to use a version installable into amspython.