### PR TITLE
Do not produce error on logging for deleted jobs SO--

### DIFF
--- a/core/formatters.py
+++ b/core/formatters.py
@@ -37,7 +37,7 @@ class JobCSVFormatter(CSVFormatter):
         if job.status not in [JobStatus.CREATED, JobStatus.STARTED]:
             message.update({"job_path": job.path})
 
-            if job.status not in [JobStatus.REGISTERED, JobStatus.RUNNING]:
+            if job.status not in [JobStatus.REGISTERED, JobStatus.RUNNING, JobStatus.DELETED]:
                 message.update({"job_ok": job.ok()})
                 message.update({"job_check": job.check()})
                 message.update({"job_get_errormsg": job.get_errormsg()})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ analysis = [
 ]
 
 docs = [
-    "sphinx>=6.2.1",
+    "sphinx>=6.2.1,<8.2",
     "sphinx_copybutton>=0.5.2",
     "sphinx_design>=0.5.0",
     "ipython>=7.22.0"

--- a/unit_tests/test_logging.py
+++ b/unit_tests/test_logging.py
@@ -9,6 +9,7 @@ import pytest
 import time
 import random
 
+from scm.plams.core.functions import delete_job
 from scm.plams.core.errors import FileError, PlamsError
 from scm.plams.core.logging import get_logger, TextLogger, CSVLogger
 from scm.plams.core.formatters import JobCSVFormatter
@@ -640,6 +641,9 @@ class TestJobCSVFormatter:
             logger.log(job1, 3)
             logger.log(job2, 3)
 
+            delete_job(job1)
+            logger.log(job1, 3)
+
             dir = os.getcwd()
             path1 = os.path.join(dir, "plams_workdir", "test_job_csv_formatter")
             path2 = os.path.join(dir, "plams_workdir", "test_job_csv_formatter.002")
@@ -668,6 +672,10 @@ class TestJobCSVFormatter:
                 assert (
                     read_row()
                     == f"test_job_csv_formatter,test_job_csv_formatter.002,crashed,{path2},False,False,some error,<timestamp> created -> <timestamp> started -> <timestamp> registered -> <timestamp> running -> <timestamp> crashed,,"
+                )
+                assert (
+                    read_row()
+                    == f"test_job_csv_formatter,test_job_csv_formatter,deleted,{path1},,,,<timestamp> created -> <timestamp> started -> <timestamp> registered -> <timestamp> running -> <timestamp> finished -> <timestamp> successful -> <timestamp> deleted,,"
                 )
 
             logger.close()


### PR DESCRIPTION
# Description 

Avoid `scm.plams.core.errors.ResultsError: Using Results associated with deleted job` when calling `ok` for jobs during logging process.