### PR TITLE
RDKit constraints

### DIFF
--- a/unit_tests/test_molecule_interfaces.py
+++ b/unit_tests/test_molecule_interfaces.py
@@ -296,6 +296,27 @@ class TestRDKit:
             file = result_dir / f
             assert file.exists()
 
+    def test_rdkit_get_conformations_with_constraints(self):
+        import numpy as np
+        from scm.plams import get_conformations
+
+        mol = from_smiles("CCCCCC1CCCCC1")
+
+        # Find the ring atoms (to be fixed)
+        ring = mol.locate_rings()[0]
+        hs = [[at for at in mol.neighbors(mol.atoms[iat]) if at.symbol == "H"] for iat in ring]
+        fixed_atoms = ring + [mol.index(at) - 1 for atoms in hs for at in atoms]
+        coords = mol.as_array()[fixed_atoms]
+
+        # Add conformers, with fixed atoms, and check constraints
+        molecules = get_conformations(mol, 10, constraint_ats=fixed_atoms)
+        for i, m in enumerate(molecules):
+            crd = m.as_array()[fixed_atoms]
+            diff = crd - coords
+            rms = np.sqrt((diff**2).sum())
+            maxdiff = (abs(diff)).sum()
+            assert rms < 2.0
+
 
 class TestPackmol:
     """

--- a/unit_tests/test_molecule_interfaces.py
+++ b/unit_tests/test_molecule_interfaces.py
@@ -314,7 +314,6 @@ class TestRDKit:
             crd = m.as_array()[fixed_atoms]
             diff = crd - coords
             rms = np.sqrt((diff**2).sum())
-            maxdiff = (abs(diff)).sum()
             assert rms < 2.0
 
 


### PR DESCRIPTION
There was a bug in get_conformers (RDKit interface), where any provided constraints were ignored. I think this is an RDKit version issue, as it used to work at some point. In any case, I found a workaround and added a unittest.

Note: This is note used anywhere else in AMS, except that it is important for the conformers tool, especially now that we have constraints via the amsworker.