### PR TITLE
Fix job loading for dill files from PLAMS<2025

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ This changelog is effective from the 2025 releases.
 
 ## [Unreleased]
 
+### Fixed
+* `SingleJob.load`, `JobManager.load_job` and `load` can load jobs from a `.dill` file from PLAMS<2025
+
+## 2025.102
+
 ## 2025.101
 
 ### Added

--- a/core/basejob.py
+++ b/core/basejob.py
@@ -542,6 +542,12 @@ class SingleJob(Job):
         else:
             with open(path, "rb") as f:
                 job = pickle.load(f)
+                # For backwards compatibility (before attributes added/converted to properties)
+                if not hasattr(job, "_status"):
+                    job._status = job.__dict__["status"]
+                    job._status_log = []
+                if not hasattr(job, "_error_msg"):
+                    job._error_msg = None
             job.path = os.path.dirname(os.path.abspath(path))
             job.results.collect()
 

--- a/core/jobmanager.py
+++ b/core/jobmanager.py
@@ -158,6 +158,13 @@ class JobManager:
         with open(filename, "rb") as f:
             try:
                 job = pickle.load(f)
+                # For backwards compatibility (before attributes added/converted to properties)
+                if not hasattr(job, "_status"):
+                    job._status = job.__dict__["status"]
+                    job._status_log = []
+                if not hasattr(job, "_error_msg"):
+                    job._error_msg = None
+
             except Exception as e:
                 log("Unpickling of {} failed. Caught the following Exception:\n{}".format(filename, e), 1)
                 return None

--- a/unit_tests/test_basejob.py
+++ b/unit_tests/test_basejob.py
@@ -398,6 +398,30 @@ sleep 0.0 && sed 's/input/output/g' plamsjob.in
         assert job1.settings == job2.settings
         assert job1._filenames == job2._filenames
 
+    def test_load_legacy_job_succeeds(self):
+        # Given job run before additional properties were added
+        job1 = DummySingleJob()
+        job1.run()
+        job1.results.wait()
+        status = job1.status
+        delattr(job1, "_status")
+        delattr(job1, "_status_log")
+        job1.__dict__["status"] = status
+        job1.pickle()
+
+        # When call load
+        job2 = DummySingleJob.load(job1.path)
+
+        # Then job loaded successfully
+        assert job1.name == job2.name
+        assert job1.id == job2.id
+        assert job1.path == job2.path
+        assert job1.settings == job2.settings
+        assert job1._filenames == job2._filenames
+        assert job2.status == "successful"
+        assert job2.status_log == []
+        assert job2.get_errormsg() is None
+
     def test_job_summaries_logged(self, config):
         job1 = DummySingleJob()
         job2 = DummySingleJob(inp=job1.input)


### PR DESCRIPTION
# Description

.dill files could not be loaded from pre PLAMS 2025 and work due to the converting of `status` to a property, and the addition of further attributes