### PR TITLE
Add input_to_settings method to input parser SCMSUITE-10370 SO107

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ This changelog is effective from the 2025 releases.
 ## [Unreleased]
 
 ### Added
-* The `AMSAnalysisJobs` now have Pisa support, accept multiple AMSJobs as input, and no longer overwrite user supplied input settings.
+* `AMSAnalysisJobs` now have Pisa support, accept multiple AMSJobs as input, and no longer overwrite user supplied input settings.
+* `context_config` and `get_context` methods to allow context-based override of global `config` settings
+* `input_to_settings` method to convert AMS text input to a settings object
+* `get_system_blocks_as_molecules_from_input` method to extract molecules from AMS text input
 
 ## 2025.102
 

--- a/__init__.py
+++ b/__init__.py
@@ -58,6 +58,7 @@ from scm.plams.interfaces.adfsuite.forcefieldparams import (
     ForceFieldPatch,
     forcefield_params_from_kf,
 )
+from scm.plams.interfaces.adfsuite.inputparser import get_system_blocks_as_molecules_from_input, input_to_settings
 from scm.plams.interfaces.adfsuite.quickjobs import (
     preoptimize,
     refine_density,
@@ -249,6 +250,8 @@ __all__ = [
     "MissingOptionalPackageError",
     "ForceFieldPatch",
     "forcefield_params_from_kf",
+    "get_system_blocks_as_molecules_from_input",
+    "input_to_settings",
     "AMSWorker",
     "AMSWorkerResults",
     "AMSWorkerError",

--- a/interfaces/adfsuite/ams.py
+++ b/interfaces/adfsuite/ams.py
@@ -2257,9 +2257,9 @@ class AMSResults(Results):
         if "ams" in self.rkfs:
             user_input = self.readrkf("General", "user input")
             try:
-                from scm.plams.interfaces.adfsuite.inputparser import InputParserFacade
+                from scm.plams.interfaces.adfsuite.inputparser import input_to_settings
 
-                inp = InputParserFacade().to_settings("ams", user_input)
+                inp = input_to_settings(user_input)
             except:
                 log("Failed to recreate input settings from {}".format(self.rkfs["ams"].path))
                 return None
@@ -3070,9 +3070,9 @@ class AMSJob(SingleJob):
     @staticmethod
     def _serialize_single_molecule(name: str, mol: Union[Molecule, "ChemicalSystem"]) -> Settings:
         def serialize_unichemsys_to_settings(mol: "ChemicalSystem") -> Settings:
-            from scm.plams.interfaces.adfsuite.inputparser import InputParserFacade
+            from scm.plams.interfaces.adfsuite.inputparser import input_to_settings
 
-            sett = InputParserFacade().to_settings(AMSJob._command, str(mol))
+            sett = input_to_settings(str(mol), program=AMSJob._command)
             return sett.ams.system[0]
 
         def serialize_molecule_to_settings(mol: Molecule, name: Optional[str] = None) -> Settings:
@@ -3366,10 +3366,10 @@ class AMSJob(SingleJob):
 
             If *settings* is included in the keyword arguments to this method, the |Settings| created from the *text_input* will be soft updated with the settings from the keyword argument. In other word, the *text_input* takes precedence over the *settings* keyword argument.
         """
-        from scm.plams.interfaces.adfsuite.inputparser import InputParserFacade
+        from scm.plams.interfaces.adfsuite.inputparser import input_to_settings
 
         sett = Settings()
-        sett.input = InputParserFacade().to_settings(cls._command, text_input)
+        sett.input = input_to_settings(text_input, program=cls._command)
         mol = cls.settings_to_mol(sett)
         if mol:
             if "molecule" in kwargs:

--- a/interfaces/adfsuite/inputparser.py
+++ b/interfaces/adfsuite/inputparser.py
@@ -157,7 +157,7 @@ def get_system_blocks_as_molecules_from_input(input_file: "InputFileLibbase") ->
 
 def input_to_settings(
     text_input: str,
-    program: Optional[str] = "ams",
+    program: str = "ams",
     string_leafs: bool = True,
     parser: Optional[Union["InputParserLibbase", InputParser, InputParserFacade]] = None,
 ) -> "Settings":
@@ -174,7 +174,7 @@ def input_to_settings(
     :param parser: use specific parser or defaults to internal parser if ``None``
     :return: |Settings| object with the structure of the parsed AMS input
     """
-    input_parser: Union["InputParserLibbase", InputParser, InputParserFacade] = parser or InputParserFacade()
+    input_parser = parser or InputParserFacade()
     if program in ["ams", "acerxn"]:
         # Settings for the program are special:
         # * Root level input needs to go under settings.input.ams.

--- a/interfaces/adfsuite/inputparser.py
+++ b/interfaces/adfsuite/inputparser.py
@@ -58,7 +58,7 @@ class InputParser:
             raise ValueError(f"Input parsing failed. {exc.get_errormsg()}") from exc
         return json.loads(json_input)
 
-    # For alignment with the libbase InputParser and yet to maintain backwards compatibility
+    # Renamed for alignment with the libbase InputParser and yet to maintain backwards compatibility
     _run = to_dict
 
     def to_settings(self, program, text_input):

--- a/interfaces/adfsuite/inputparser.py
+++ b/interfaces/adfsuite/inputparser.py
@@ -1,21 +1,20 @@
 import os
 import json
 import threading
-from typing import List
+from typing import List, Union, Tuple, Optional, Dict, TYPE_CHECKING
 
 from scm.plams.core.settings import Settings
+from scm.plams.core.errors import PlamsError
+from scm.plams.mol.molecule import Molecule
+from scm.plams.core.functions import requires_optional_package
 from scm.plams.interfaces.adfsuite.amsworker import AMSWorker, AMSWorkerError
+from scm.plams.interfaces.adfsuite.ams import AMSJob
 
-__all__: List[str] = []
+if TYPE_CHECKING:
+    from scm.libbase import InputParser as InputParserLibbase
+    from scm.libbase import InputFile as InputFileLibbase
 
-# !!!!!!!  DEPRECATED  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-# The class in this module has been deprecated. The equivalent in scm.libbase
-# should be used instead where possible. The scm.libbase version does the input
-# parsing via direct calls into libscm_base, instead of spawning an AMSWorker
-# and then pushing the input through the pipe. This implementation exists here
-# only to remove the dependency on scm.libbase when running in python
-# environments without access to the base library.
-# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+__all__: List[str] = ["get_system_blocks_as_molecules_from_input", "input_to_settings"]
 
 
 class InputParser:
@@ -24,6 +23,15 @@ class InputParser:
 
     This is a legacy implementation for environments without access to scm.libbase.
     """
+
+    # !!!!!!!  DEPRECATED  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    # This class has been deprecated. The equivalent in scm.libbase
+    # should be used instead where possible. The scm.libbase version does the input
+    # parsing via direct calls into libscm_base, instead of spawning an AMSWorker
+    # and then pushing the input through the pipe. This implementation exists here
+    # only to remove the dependency on scm.libbase when running in python
+    # environments without access to the base library.
+    # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
     def __init__(self):
         sett = Settings()
@@ -42,7 +50,7 @@ class InputParser:
     def __exit__(self, *args):
         self.stop()
 
-    def _run(self, program, text_input, string_leafs=True):
+    def to_dict(self, program, text_input, string_leafs=True):
         """Run a string of text input through the input parser and produce a Python dictionary representing the JSONified input."""
         try:
             json_input = self.worker.ParseInput(program, text_input, string_leafs)
@@ -50,65 +58,19 @@ class InputParser:
             raise ValueError(f"Input parsing failed. {exc.get_errormsg()}") from exc
         return json.loads(json_input)
 
+    # For alignment with the libbase InputParser and yet to maintain backwards compatibility
+    _run = to_dict
+
     def to_settings(self, program, text_input):
         """Transform a string with text input into a PLAMS Settings object."""
-
-        if program in ["ams", "acerxn"]:
-            input_settings = Settings()
-            lines = text_input.splitlines()
-
-            # Find the lines corresponding to the engine block.
-            while 1:
-                lines, engine_lines = self.separate_engine_lines(lines)
-                if engine_lines is None:
-                    break
-                # We have found a separate engine block.
-                engine_name = engine_lines[0].split()[1]
-                if len(engine_lines) == 2:
-                    # If it's empty we already know the result of parsing it.
-                    input_settings[engine_name] = Settings()
-                else:
-                    input_settings[engine_name] = Settings(
-                        self._run(engine_name.lower(), "\n".join(engine_lines[1:-1]))
-                    )
-
-            input_settings["ams"] = Settings(self._run(program, "\n".join(lines)))
-
-        else:
-            input_settings = Settings(self._run(program, text_input))
-
-        return input_settings
+        return input_to_settings(text_input, program=program, parser=self)
 
     @staticmethod
     def separate_engine_lines(lines):
         """
         Separate the engine lines from other lines of AMS input text
         """
-        # Find the lines corresponding to the engine block.
-        engine_lines = None
-        engine_first, engine_last = None, None
-        inner_engines = 0
-        ends = 0
-        for i, l in enumerate(lines):
-            if l == "" or l.isspace():
-                continue
-            if l.split(maxsplit=1)[0].lower() == "engine":
-                if engine_first is None:
-                    engine_first = i
-                    continue
-                else:
-                    inner_engines += 1
-            elif l.split(maxsplit=1)[0].lower() == "endengine":
-                ends += 1
-            if ends > inner_engines:
-                engine_last = i
-                break
-        if engine_first is not None and engine_last is not None:
-            # We have found a separate engine block.
-            engine_lines = lines[engine_first : engine_last + 1]
-            # We have dealt with the engine lines, let's remove them from the input.
-            del lines[engine_first : engine_last + 1]
-        return lines, engine_lines
+        return _separate_engine_lines(lines)
 
 
 class InputParserFacade:
@@ -120,11 +82,11 @@ class InputParserFacade:
     """
 
     try:
-        from scm.libbase import InputParser as InputParserScmLibbase
+        from scm.libbase import InputParser as InputParserLibbase
 
         # Cache a single instance of the parser to avoid having to repeatedly reload input file definition JSON
         # But for this need to make access to the parser thread-safe
-        input_parser_scm_libbase = InputParserScmLibbase()
+        input_parser_scm_libbase = InputParserLibbase()
         input_parser_lock = threading.Lock()
         _has_scm_libbase = True
     except ImportError:
@@ -140,24 +102,142 @@ class InputParserFacade:
         else:
             return InputParser()
 
-    def to_settings(self, program: str, text_input: str):
-        """Transform a string with text input into a PLAMS Settings object."""
-
-        if self._has_scm_libbase:
-            with self.input_parser_lock:
-                return self.parser.to_settings(program, text_input)
-        else:
-            with self.parser as parser:
-                return parser.to_settings(program, text_input)
-
     def to_dict(self, program: str, text_input: str, string_leafs: bool = True):
         """
-        Run a string of text input through the input parser and produce
-        a Python dictionary representing the JSONified input.
+        Run a string of text input through the input parser and produce a Python dictionary representing the JSONified input.
         """
         if self._has_scm_libbase:
             with self.input_parser_lock:
                 return self.parser.to_dict(program, text_input, string_leafs)
         else:
             with self.parser as parser:
-                return parser._run(program, text_input, string_leafs)
+                return parser.to_dict(program, text_input, string_leafs)
+
+
+@requires_optional_package("scm.libbase")
+def get_system_blocks_as_molecules_from_input(input_file: "InputFileLibbase") -> Dict[str, Molecule]:
+    """
+    Get a dictionary of mappings between the System blocks in the input to |Molecule| instances.
+
+    The keys in the dictionary are the names of the systems from the headers of the blocks, e.g.::
+
+        System initial
+            ...
+        End
+
+    would be returned as dict["initial"].
+    The main system without a name in the header will have the empty string as key.
+
+    :param input_file: input file containing the text with the System blocks
+    :return: dictionary of mappings between the system block names and molecules
+    """
+    if not input_file.is_defined("System") and input_file.is_defined("LoadSystem"):
+        raise PlamsError(
+            f"Attempting to read System blocks for program '{input_file.program}' that does not have them defined"
+        )
+
+    if input_file.number_of_entries("System") > 0:
+        tmp = Settings()
+        tmp.input.ams.System = Settings(json.loads(input_file.get_json())).System
+        mols = AMSJob.settings_to_mol(tmp)
+    else:
+        mols = {}
+
+    for i in range(input_file.number_of_entries("LoadSystem")):
+        header = input_file.get_header(f"LoadSystem[{i}]")
+        if header in mols:
+            raise PlamsError(f"Input error: duplicate system headers found in input: {header}")
+        mols[header] = Molecule()
+        mols[header].readrkf(
+            input_file.get_string(f"LoadSystem[{i}]%File"), input_file.get_string(f"LoadSystem[{i}]%Section")
+        )
+
+    return mols
+
+
+def input_to_settings(
+    text_input: str,
+    program: Optional[str] = "ams",
+    string_leafs: bool = True,
+    parser: Optional[Union["InputParserLibbase", InputParser, InputParserFacade]] = None,
+) -> "Settings":
+    """
+    Transform a string with text input into a |Settings| object.
+
+    For AMS driver input the root level input will be set under settings.ams,
+    while the engine block will be parsed separately and returned under settings.%engine%,
+    where %engine% is the name of the engine, e.g. adf or dftb.
+
+    :param text_input: AMS text input to covert to settings
+    :param program: name of the program, defaults to ``ams``
+    :param string_leafs: include string leafs, defaults to ``True``
+    :param parser: use specific parser or defaults to internal parser if ``None``
+    :return: |Settings| object with the structure of the parsed AMS input
+    """
+    input_parser: Union["InputParserLibbase", InputParser, InputParserFacade] = parser or InputParserFacade()
+    if program in ["ams", "acerxn"]:
+        # Settings for the program are special:
+        # * Root level input needs to go under settings.input.ams.
+        # * Engine block needs to go  to settings.input.%engine% where
+        #   %engine% is the name of the engine, e.g. adf.
+        input_settings = Settings()
+        lines = text_input.splitlines()
+
+        # Find the lines corresponding to the engine block.
+        while True:
+            lines, engine_lines = _separate_engine_lines(lines)
+            if engine_lines is None:
+                break
+            # We have found a separate engine block.
+            engine_name = engine_lines[0].split()[1]
+            if len(engine_lines) == 2:
+                # If it's empty we already know the result of parsing it.
+                input_settings[engine_name] = Settings()
+            else:
+                input_settings[engine_name] = Settings(
+                    input_parser.to_dict(engine_name.lower(), "\n".join(engine_lines[1:-1]), string_leafs)
+                )
+
+        input_settings["ams"] = Settings(input_parser.to_dict(program, "\n".join(lines), string_leafs))
+
+    else:
+        input_settings = Settings(input_parser.to_dict(program, text_input, string_leafs))
+
+    return input_settings
+
+
+def _separate_engine_lines(lines: List[str]) -> Tuple[List[str], Optional[List[str]]]:
+    """
+    Separate the engine lines from other lines of AMS input text.
+
+    :param lines: lines of AMS input text
+    :return: tuple consisting of the original lines without the engine lines and the engine lines themselves
+    """
+
+    # Find the lines corresponding to the engine block.
+    engine_lines = None
+    engine_first, engine_last = None, None
+    inner_engines = 0
+    ends = 0
+    for i, line in enumerate(lines):
+        if line == "" or line.isspace():
+            continue
+        if line.split(maxsplit=1)[0].lower() == "engine":
+            if engine_first is None:
+                engine_first = i
+                continue
+            else:
+                inner_engines += 1
+        elif line.split(maxsplit=1)[0].lower() == "endengine":
+            ends += 1
+        if ends > inner_engines:
+            engine_last = i
+            break
+
+    if engine_first is not None and engine_last is not None:
+        # We have found a separate engine block.
+        engine_lines = lines[engine_first : engine_last + 1]
+        # We have dealt with the engine lines, let's remove them from the input.
+        del lines[engine_first : engine_last + 1]
+
+    return lines, engine_lines

--- a/interfaces/adfsuite/scmjob.py
+++ b/interfaces/adfsuite/scmjob.py
@@ -363,13 +363,13 @@ class SCMJob(SingleJob):
         on the heredoc delimiter (see *heredoc_delimit*).
 
         """
-        from scm.plams.interfaces.adfsuite.inputparser import InputParserFacade
+        from scm.plams.interfaces.adfsuite.inputparser import input_to_settings
 
         s = Settings()
         with open(filename, "r") as f:
             inp_file = parse_heredoc(f.read(), heredoc_delimit)
 
-        s.input = InputParserFacade().to_settings(cls._json_definitions or cls._command, inp_file)
+        s.input = input_to_settings(inp_file, program=cls._json_definitions or cls._command)
         if not s.input:
             raise JobError(f"from_inputfile: failed to parse '{filename}'")
 

--- a/tools/job_analysis.py
+++ b/tools/job_analysis.py
@@ -16,7 +16,7 @@ from scm.plams.core.functions import requires_optional_package, load, config_con
 from scm.plams.tools.table_formatter import format_in_table
 from scm.plams.interfaces.molecule.rdkit import to_smiles
 from scm.plams.mol.molecule import Molecule
-from scm.plams.interfaces.adfsuite.inputparser import InputParserFacade
+from scm.plams.interfaces.adfsuite.inputparser import input_to_settings
 
 try:
     from scm.libbase import UnifiedChemicalSystem as ChemicalSystem
@@ -1503,9 +1503,7 @@ class JobAnalysis:
                 if hasattr(job.settings, "input") and isinstance(job.settings.input, DriverBlock):
                     # Note use own input parser facade here to use caching
                     program = self._pisa_programs[job.settings.input.name].name.split(".")[0]
-                    settings.input = InputParserFacade().to_settings(
-                        program=program, text_input=job.settings.input.get_input_string()
-                    )
+                    settings.input = input_to_settings(job.settings.input.get_input_string(), program=program)
         return settings
 
     def add_settings_input_fields(self, include_system_block: bool = False, flatten_list: bool = True) -> "JobAnalysis":


### PR DESCRIPTION
## Description

Refactoring to remove dependency of `scm.libbase` on plams. 

The methods `get_system_blocks_as_molecules_from_input` and `input_to_settings` have been added to PLAMS, which replace similar methods on the libbase `InputParser`.

As a happy side effect, `input_to_settings` is actually nicer to use now I think, as now you don't need to instantiate an explicit input parser.
```
InputParser().to_settings(program=program, text_input=self.get_input_string())
# vs
input_to_settings(program=program, text_input=self.get_input_string())
```
Furthermore, this is actually more efficient as the `InputParserFacade` caches the `InputParser` so doesn't need to reload the json files every time one is created.

The `InputParserFacade` now really becomes an internal implementation detail.