### PR TITLE
Fix for finalize when job fails during execution and GridRunner regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This changelog is effective from the 2025 releases.
 
 ### Fixed
 * Method to guess density in `packmol_around` changed to resolve large underestimations in molecular volumes
+* Regression in `GridRunner` which caused some SLURM and PBS commands to silently fail and jobs to be incorrectly awaited
 
 ## 2025.103
 

--- a/core/basejob.py
+++ b/core/basejob.py
@@ -38,8 +38,9 @@ def _fail_on_exception(func):
     def wrapper(self: "Job", *args, **kwargs):
         try:
             return func(self, *args, **kwargs)
-        except Exception:
+        except Exception as ex:
             # Mark job status as failed and the results as complete
+            log(f"Encountered exception {ex} in {self.name}, marking job as {JobStatus.FAILED}", 5)  # type: ignore
             self.status = JobStatus.FAILED
             self.results.finished.set()  # type: ignore
             self.results.done.set()  # type: ignore
@@ -305,7 +306,7 @@ class Job(ABC):
             log("Collecting results of {}".format(self.name), 7)
             self.results.collect()
             self.results.finished.set()
-            if self.status != JobStatus.CRASHED:
+            if self.status != JobStatus.CRASHED and self.status != JobStatus.FAILED:
                 self.status = JobStatus.FINISHED
                 self._log_status(3)
                 if self.check():

--- a/core/jobrunner.py
+++ b/core/jobrunner.py
@@ -275,27 +275,25 @@ class GridRunner(JobRunner):
     # if [...].commands.finished exists it is used to check if the job is finished. It should be a function that takes a single string (job_id) as an argument and returns True or False
     # otherwise [...].commands.check is combined with job_id, executed as a subprocess and returned exit code is tested (nonzero return code indicates that job has finished)
 
-    @staticmethod
-    def __slurm_get_jobid(output: str):
+    # N.B. these SLURM/PBS functions are always used in a static way
+    # but as stored and accessed via Settings, cannot be decorated as such
+    def __slurm_get_jobid(output: str):  # type: ignore
         s = output.split()
         if len(s) > 0 and all([ch.isdigit() for ch in s[-1]]):
             return s[-1]
         return None
 
-    @staticmethod
-    def __slurm_running(output: str):
+    def __slurm_running(output: str):  # type: ignore
         lines = output.splitlines()[1:]
         return [line.split()[0] for line in lines]
 
-    @staticmethod
-    def __pbs_get_jobid(output: str):
+    def __pbs_get_jobid(output: str):  # type: ignore
         s = output.split(".")
         if len(s) > 0 and all([ch.isdigit() for ch in s[0]]):
             return s[0]
         return None
 
-    @staticmethod
-    def __pbs_running(output: str):
+    def __pbs_running(output: str):  # type: ignore
         lines = output.splitlines()[2:]
         return [line.split()[0].split(".")[0] for line in lines]
 
@@ -311,8 +309,8 @@ class GridRunner(JobRunner):
     config.pbs.special.queue = "-q "
     config.pbs.commands.submit = "qsub"
     config.pbs.commands.check = "qstat"
-    config.pbs.commands.getid = __pbs_get_jobid.__func__
-    config.pbs.commands.running = __pbs_running.__func__
+    config.pbs.commands.getid = __pbs_get_jobid
+    config.pbs.commands.running = __pbs_running
     # Slurm
     config.slurm.workdir = "-D"
     config.slurm.output = "-o"
@@ -324,8 +322,8 @@ class GridRunner(JobRunner):
     config.slurm.special.queue = "-p "
     config.slurm.commands.submit = "sbatch"
     config.slurm.commands.check = "squeue"
-    config.slurm.commands.getid = __slurm_get_jobid.__func__
-    config.slurm.commands.running = __slurm_running.__func__
+    config.slurm.commands.getid = __slurm_get_jobid
+    config.slurm.commands.running = __slurm_running
 
     def __init__(self, grid="auto", sleepstep=5, parallel=True, maxjobs=0):
         JobRunner.__init__(self, parallel=parallel, maxjobs=maxjobs)

--- a/core/jobrunner.py
+++ b/core/jobrunner.py
@@ -311,8 +311,8 @@ class GridRunner(JobRunner):
     config.pbs.special.queue = "-q "
     config.pbs.commands.submit = "qsub"
     config.pbs.commands.check = "qstat"
-    config.pbs.commands.getid = __pbs_get_jobid
-    config.pbs.commands.running = __pbs_running
+    config.pbs.commands.getid = __pbs_get_jobid.__func__
+    config.pbs.commands.running = __pbs_running.__func__
     # Slurm
     config.slurm.workdir = "-D"
     config.slurm.output = "-o"
@@ -324,8 +324,8 @@ class GridRunner(JobRunner):
     config.slurm.special.queue = "-p "
     config.slurm.commands.submit = "sbatch"
     config.slurm.commands.check = "squeue"
-    config.slurm.commands.getid = __slurm_get_jobid
-    config.slurm.commands.running = __slurm_running
+    config.slurm.commands.getid = __slurm_get_jobid.__func__
+    config.slurm.commands.running = __slurm_running.__func__
 
     def __init__(self, grid="auto", sleepstep=5, parallel=True, maxjobs=0):
         JobRunner.__init__(self, parallel=parallel, maxjobs=maxjobs)

--- a/unit_tests/test_basejob.py
+++ b/unit_tests/test_basejob.py
@@ -229,6 +229,31 @@ sleep 0.0 && sed 's/input/output/g' plamsjob.in
         assert "self.postrun()" in job2.get_errormsg()
         assert "RuntimeError: something went wrong" in job2.get_errormsg()
 
+    def test_run_marks_jobs_as_failed_and_stores_exception_on_execution_error(self):
+        # Given job which errors in execution
+        job1 = DummySingleJob()
+
+        def filename_errors(t):
+            import inspect
+
+            s = inspect.stack()
+            caller = s[1].function
+            if caller == "_execute":
+                raise RuntimeError("something went wrong")
+            else:
+                return job1._filenames[t].replace("$JN", job1.name)
+
+        job1._filename = filename_errors
+
+        # When run job
+        job1.run()
+
+        # Then status is marked as failed
+        assert job1.status == JobStatus.FAILED
+        assert not job1.ok()
+        assert "_execute" in job1.get_errormsg()
+        assert "RuntimeError: something went wrong" in job1.get_errormsg()
+
     @pytest.mark.parametrize(
         "mode,expected",
         [
@@ -629,6 +654,36 @@ class TestMultiJob:
         assert not multi_job.ok()
         assert multi_job.status == JobStatus.FAILED
         assert [j.status for j in jobs] == [JobStatus.SUCCESSFUL, JobStatus.FAILED, JobStatus.FAILED]
+
+    def test_run_multiple_independent_single_jobs_error_in_execute(self, config):
+        runner = JobRunner(parallel=True, maxjobs=3)
+        config.sleepstep = 0.1
+
+        # Given 3 jobs which are dependent
+        jobs = [DummySingleJob() for _ in range(3)]
+
+        def filename_errors(t):
+            import inspect
+
+            s = inspect.stack()
+            caller = s[1].function
+            if caller == "_execute":
+                raise RuntimeError("something went wrong")
+            else:
+                return jobs[1]._filenames[t].replace("$JN", jobs[1].name)
+
+        jobs[1]._filename = filename_errors
+
+        multi_job = MultiJob(children=jobs)
+
+        # When run multi-job
+        multi_job.run(jobrunner=runner).wait()
+
+        # Then multi-job failed
+        assert not multi_job.check()
+        assert not multi_job.ok()
+        assert multi_job.status == JobStatus.FAILED
+        assert [j.status for j in jobs] == [JobStatus.SUCCESSFUL, JobStatus.FAILED, JobStatus.SUCCESSFUL]
 
     def test_run_multiple_independent_multijobs_all_succeed(self, config):
         runner = JobRunner(parallel=True, maxjobs=3)


### PR DESCRIPTION
## Description 

Issue #291 flagged that the GridRunner no longer waits correctly for results.

The reason for this was two-fold:

* Commit https://github.com/SCM-NV/PLAMS/commit/22d763346417cb8e085f38626ba488dc2fc0a541 introduced the `staticmethod` decorators on some functions used by the grid runner, but these could not be called directly as they were stored in a dictionary, raising a `TypeError: 'staticmethod' object is not callable`
* An exception in `_execute` should cause the job to fail, but in this case `_finalize` was still being called and overwriting the job code back to success

Both these issues have been fixed, and the fix will also need to be added to `fix2025`.

There appears to be an integration testing hole for the GridRunner in AMS which needs to be addressed.