### PR TITLE
packmol: use guessed density if box bounds and no n_atoms specified

### DIFF
--- a/src/scm/plams/interfaces/molecule/packmol.py
+++ b/src/scm/plams/interfaces/molecule/packmol.py
@@ -537,8 +537,6 @@ def packmol(
     """
     # Input arguments allow for lots of combinations.
     # Let's try to check that the specified combination makes sense ...
-    if n_atoms is None and n_molecules is None and density is None:
-        raise ValueError("Illegal combination of arguments: must specify either n_atoms, n_molecules or density")
     if n_atoms is not None and box_bounds is not None and density is not None:
         raise ValueError("Illegal combination of arguments: n_atoms, box_bounds and density specified at the same time")
     # Detect the special case when 1 molecule is not specified e.g. the solvent for a few specified solute molecules
@@ -639,6 +637,17 @@ def packmol(
         mole_fractions = [1.0 / len(molecules)] * len(molecules)
     if any(x < 0 for x in mole_fractions):
         raise ValueError(f"All mole fractions must be >= 0. Mole fractions specified: {mole_fractions}")
+
+    if (
+        density is None
+        and n_atoms is None
+        and n_molecules is None
+        and mole_fractions is not None
+        and box_bounds is not None
+    ):
+        # "pack water in this box", "pack water around this slab", just relying on the guessed density.
+        # molecules is a list now
+        density = guess_density(molecules, mole_fractions)
 
     xs = np.array(mole_fractions)
     sum_xs = np.sum(xs)

--- a/unit_tests/test_packmol.py
+++ b/unit_tests/test_packmol.py
@@ -288,7 +288,7 @@ class TestPackMol:
     chloride = from_smiles("[Cl-]")
 
     unhappy_test_cases = [
-        UnhappyTestCase(molecules=water, expected_error="must specify either n_atoms, n_molecules or density"),
+        UnhappyTestCase(molecules=water, expected_error="Illegal combination of arguments"),
         UnhappyTestCase(
             molecules=water,
             n_atoms=300,
@@ -763,6 +763,25 @@ class TestPackMol:
             expected_mole_fractions=[0.96, 0.02, 0.02],
             expected_volume=8000,
             expected_density=0.3811881797008519,
+        ),
+        HappyTestCase(
+            molecules=[water],
+            box_bounds=[0, 0, 0, 10, 10, 10],
+            expected_n_atoms=102,
+            expected_n_molecules=[34],
+            expected_mole_fractions=[1.0],
+            expected_volume=1000,
+            expected_density=1.017117108681339,  # guessed density for water
+        ),
+        HappyTestCase(
+            molecules=[water, acetonitrile],
+            mole_fractions=[1.0, 3.0],
+            box_bounds=[0, 0, 0, 13, 13, 13],
+            expected_n_atoms=147,
+            expected_n_molecules=[7, 21],
+            expected_mole_fractions=[0.25, 0.75],
+            expected_volume=2197,
+            expected_density=0.7469019389358941,
         ),
     ]
 


### PR DESCRIPTION
Use the guessed density if no n_atoms and no n_molecules specified (but if there are box_bounds).

Particularly useful when doing packmol_around on a slab, then there is no need to explicitly think about the density but one can just use the guessed one.