### PR TITLE
Some typing fixes

### DIFF
--- a/src/scm/plams/core/basejob.py
+++ b/src/scm/plams/core/basejob.py
@@ -252,6 +252,13 @@ class Job(ABC):
             else "Could not determine error message. Please check the output manually."
         )
 
+    def get_path(self) -> Path:
+        if self.path is None:
+            raise JobError(
+                f"'path' attribute of job '{self.name} is not yet initialized, typically because the job has not yet ran."
+            )
+        return Path(self.path)
+
     @abstractmethod
     def hash(self) -> Optional[str]:
         """Calculate the hash of this instance."""

--- a/src/scm/plams/core/results.py
+++ b/src/scm/plams/core/results.py
@@ -214,7 +214,7 @@ class Results(ApplyRestrict):
             old = old.replace("$JN", self.job.name)
             new = new.replace("$JN", self.job.name)
             if old in self.files:
-                os.rename(opj(self.job.path, old), opj(self.job.path, new))
+                os.rename(self.job.get_path() / old, self.job.get_path() / new)
                 self.files[self.files.index(old)] = new
         self.refresh()
 
@@ -265,7 +265,7 @@ class Results(ApplyRestrict):
         filename = filename.replace("$JN", self.job.name)
         if filename not in self.files:
             raise ResultsError(f"No `{filename}` associated with job `{self.job.name}`")
-        with open(opj(self.job.path, filename)) as f:
+        with open(self.job.get_path() / filename) as f:
             return f.read()
 
     def regex_file(self, filename: str, regex: str) -> List:
@@ -321,10 +321,10 @@ class Results(ApplyRestrict):
         new = new.replace("$JN", self.job.name)
         self.refresh()
         if old in self.files:
-            os.rename(opj(self.job.path, old), opj(self.job.path, new))
+            os.rename(self.job.get_path() / old, self.job.get_path() / new)
             self.files[self.files.index(old)] = new
         else:
-            raise FileError(f"File {old} not present in {self.job.path}")
+            raise FileError(f"File {old} not present in {str(self.job.get_path())}")
 
     def get_file_chunk(
         self,
@@ -408,8 +408,8 @@ class Results(ApplyRestrict):
         if arg == "all":
             return
 
-        path = self.job.path
-        absfiles = [opj(path, f) for f in self.files]
+        path = self.job.get_path()
+        absfiles = [path / f for f in self.files]
         childnames = [child.name for child in self.job] if hasattr(self.job, "children") else []
         if arg in ["none", [], None]:
             for f in absfiles:
@@ -436,7 +436,7 @@ class Results(ApplyRestrict):
             for f in absfiles:
                 if (f in absarg) == rev and os.path.isfile(f):
                     os.remove(f)
-                    log("Deleting file " + f, 5)
+                    log(f"Deleting file {str(f)}", 5)
 
         else:
             log(f"WARNING: {arg} is not a valid keep/save argument", 3)
@@ -452,8 +452,8 @@ class Results(ApplyRestrict):
         """
         for name in self.files:
             newname = Results._replace_job_name(name, self.job.name, newresults.job.name)
-            oldpath = opj(self.job.path, name)
-            newpath = opj(newresults.job.path, newname)
+            oldpath = self.job.get_path() / name
+            newpath = newresults.job.get_path() / newname
             os.makedirs(os.path.dirname(newpath), exist_ok=True)
             if os.name == "posix" and self.job.settings.link_files is True:
                 os.link(oldpath, newpath)
@@ -484,9 +484,9 @@ class Results(ApplyRestrict):
         """Magic method to enable bracket notation. Elements from ``files`` can be used to get absolute paths."""
         name = name.replace("$JN", self.job.name)
         if name in self.files:
-            return opj(self.job.path, name)
+            return str(self.job.get_path() / name)
         else:
-            raise FileError(f"File {name} not present in {self.job.path}")
+            raise FileError(f"File {name} not present in {str(self.job.get_path())}")
 
     def __contains__(self, name: str) -> bool:
         """Magic method to enable the Python ``in`` operator notation for checking if a filename with a particular name is present."""
@@ -499,10 +499,10 @@ class Results(ApplyRestrict):
         """
         filename = filename.replace("$JN", self.job.name)
         if filename in self.files:
-            process = saferun(command + [filename], cwd=self.job.path, stdout=PIPE)
+            process = saferun(command + [filename], cwd=str(self.job.get_path()), stdout=PIPE)
             if process.returncode != 0:
                 return []
             ret: List[str] = process.stdout.decode().splitlines()
             return ret
         else:
-            raise FileError(f"File {filename} not present in {self.job.path}")
+            raise FileError(f"File {filename} not present in {str(self.job.get_path())}")

--- a/src/scm/plams/interfaces/adfsuite/ams.py
+++ b/src/scm/plams/interfaces/adfsuite/ams.py
@@ -666,8 +666,8 @@ class AMSResults(Results):
             else:
                 x.append(my_x)
 
-            A = cast(List[float], self.readrkf("band_curves", f"Edge_{i+1}_bands", file="engine"))
-            A = np.array(A).reshape(-1, nBands * nSpin)
+            tA = cast(List[float], self.readrkf("band_curves", f"Edge_{i+1}_bands", file="engine"))
+            A = np.array(tA).reshape(-1, nBands * nSpin)
             spinup_data = A[:, bands]
             spindown_data = A[:, spindown_bands]
 
@@ -689,7 +689,7 @@ class AMSResults(Results):
         fermi_energy = cast(float, self.readrkf("BandStructure", "FermiEnergy", file="engine"))
         fermi_energy = Units.convert(fermi_energy, "hartree", unit)
 
-        return x, complete_spinup_data, complete_spindown_data, labels, fermi_energy
+        return x, complete_spinup_data, complete_spindown_data, labels, fermi_energy  # type: ignore[return-value]
 
     def get_phonons_dos(
         self, unit: str = "hartree"
@@ -745,7 +745,7 @@ class AMSResults(Results):
         if nSpecies:
 
             nAtoms = cast(int, self.readrkf("DOS_Phonons", "nAtoms", file="engine"))
-
+            assert self.job.molecule is not None
             assert nAtoms == len(self.job.molecule)
 
             DOSperSpecies = np.array(
@@ -829,8 +829,8 @@ class AMSResults(Results):
             else:
                 x.append(my_x)
 
-            A = cast(List[float], self.readrkf("phonon_curves", f"Edge_{i+1}_bands", file="engine"))
-            A = np.array(A).reshape(-1, nBands)
+            tA = cast(List[float], self.readrkf("phonon_curves", f"Edge_{i+1}_bands", file="engine"))
+            A = np.array(tA).reshape(-1, nBands)
             spinup_data = A[:, bands]
 
             if only_high_symmetry_points:

--- a/src/scm/plams/interfaces/adfsuite/ams.py
+++ b/src/scm/plams/interfaces/adfsuite/ams.py
@@ -17,6 +17,7 @@ from typing import (
     TypeVar,
     Iterator,
     Type,
+    cast,
 )
 
 import numpy as np
@@ -218,7 +219,7 @@ class AMSResults(Results):
         Example: job.results.read_hybrid_term_rkf("AMSResults", "Energy", file="engine", term=1)
         """
 
-        kf_file = self.readrkf("EngineResults", f"Files({term})", file=file)
+        kf_file = cast(str, self.readrkf("EngineResults", f"Files({term})", file=file))
         kf = KFReader(os.path.join(self.job.path, kf_file))
         return kf.read(section, variable)
 
@@ -291,7 +292,7 @@ class AMSResults(Results):
 
         sectiondict = self.read_rkf_section(section, file)
         bohr2angstrom = Units.conversion_ratio("bohr", "angstrom")
-        nLatticeVectors: int = sectiondict.get("nLatticeVectors", 0)
+        nLatticeVectors = cast(int, sectiondict.get("nLatticeVectors", 0))
         pbc = [True] * nLatticeVectors + [False] * (3 - nLatticeVectors)
         if nLatticeVectors > 0:
             cell = np.zeros((3, 3))
@@ -299,7 +300,7 @@ class AMSResults(Results):
             cell[: lattice.shape[0], : lattice.shape[1]] = lattice * bohr2angstrom
         else:
             cell = None
-        atomsymbols = sectiondict["AtomSymbols"].split()
+        atomsymbols = cast(str, sectiondict["AtomSymbols"]).split()
         positions = np.array(sectiondict["Coords"]).reshape(-1, 3) * bohr2angstrom
         return Atoms(symbols=atomsymbols, positions=positions, pbc=pbc, cell=cell)
 
@@ -333,9 +334,11 @@ class AMSResults(Results):
         if "InputMolecule" in skel:
             mols[""] = self.get_molecule("InputMolecule")
         if "InputMolecules" in skel:
-            num_named_molecules: int = self.readrkf("InputMolecules", "numNamedMolecules")
+            num_named_molecules = cast(int, self.readrkf("InputMolecules", "numNamedMolecules"))
             for imol in range(1, num_named_molecules + 1):
-                mols[self.readrkf("InputMolecules", f"Name({imol})")] = self.get_molecule(f"InputMolecule({imol})")
+                mols[cast(str, self.readrkf("InputMolecules", f"Name({imol})"))] = self.get_molecule(
+                    f"InputMolecule({imol})"
+                )
         return mols
 
     def get_main_molecule(self) -> Molecule:
@@ -500,7 +503,7 @@ class AMSResults(Results):
 
     def get_history_length(self, history_section: str = "History") -> int:
         """Returns the number of entries (nEntries) in the history section on the ams.rkf file."""
-        return self.readrkf(history_section, "nEntries")
+        return cast(int, self.readrkf(history_section, "nEntries"))
 
     def get_history_property(self, varname: str, history_section: str = "History") -> Optional[List]:
         """Return the values of *varname* in the history section *history_section*."""
@@ -523,9 +526,9 @@ class AMSResults(Results):
                 main.read(history_section, f"{varname}({iblock})", return_as_list=True)
                 for iblock in range(1, nblocks + 1)
             ]
-            values = [val for blockvals in values for val in blockvals if isinstance(blockvals, list)]
+            values = [val for blockvals in values for val in blockvals if isinstance(blockvals, list)]  # type: ignore[union-attr]
         else:
-            values = [main.read(history_section, f"{varname}({step})") for step in range(1, nentries + 1)]
+            values = [main.read(history_section, f"{varname}({step})") for step in range(1, nentries + 1)]  # type: ignore[misc]
         return values
 
     def get_property_at_step(self, step: int, varname: str, history_section: str = "History") -> Optional["TRead"]:
@@ -541,7 +544,7 @@ class AMSResults(Results):
                 history_section, f"{varname}({iblock})"
             )  # this can return something that isn't a list, for example an int
             try:
-                value = value[(step % blocksize) - 1]
+                value = value[(step % blocksize) - 1]  # type: ignore[index]
             except TypeError:  # TypeError: 'int' object is not subscriptable
                 pass
         else:
@@ -625,11 +628,11 @@ class AMSResults(Results):
 
         read_labels = True
 
-        nBands: int = self.readrkf("band_curves", "nBands", file="engine")
+        nBands = cast(int, self.readrkf("band_curves", "nBands", file="engine"))
 
-        nEdges: int = self.readrkf("band_curves", "nEdges", file="engine")
+        nEdges = cast(int, self.readrkf("band_curves", "nEdges", file="engine"))
         try:
-            nSpin: int = self.readrkf("band_curves", "nSpin", file="engine")
+            nSpin = cast(int, self.readrkf("band_curves", "nSpin", file="engine"))
         except KeyError:
             nSpin = 1
 
@@ -652,7 +655,7 @@ class AMSResults(Results):
             prevmaxx = np.max(my_x)
 
             if read_labels:
-                my_labels = self.readrkf("band_curves", f"Edge_{i+1}_labels", file="engine").split()
+                my_labels = cast(str, self.readrkf("band_curves", f"Edge_{i+1}_labels", file="engine")).split()
                 if len(my_labels) == 2:
                     if only_high_symmetry_points:
                         labels += [my_labels[0]]  # only the first point of the curve
@@ -664,7 +667,7 @@ class AMSResults(Results):
             else:
                 x.append(my_x)
 
-            A = self.readrkf("band_curves", f"Edge_{i+1}_bands", file="engine")
+            A = cast(List[float], self.readrkf("band_curves", f"Edge_{i+1}_bands", file="engine"))
             A = np.array(A).reshape(-1, nBands * nSpin)
             spinup_data = A[:, bands]
             spindown_data = A[:, spindown_bands]
@@ -684,10 +687,10 @@ class AMSResults(Results):
 
         x = np.concatenate(x).ravel()
 
-        fermi_energy = self.readrkf("BandStructure", "FermiEnergy", file="engine")
+        fermi_energy = cast(float, self.readrkf("BandStructure", "FermiEnergy", file="engine"))
         fermi_energy = Units.convert(fermi_energy, "hartree", unit)
 
-        return x, complete_spinup_data, complete_spindown_data, labels, fermi_energy  # type: ignore
+        return x, complete_spinup_data, complete_spindown_data, labels, fermi_energy
 
     def get_phonons_dos(
         self, unit: str = "hartree"
@@ -713,16 +716,16 @@ class AMSResults(Results):
         """
         energyConv = Units.convert(1.0, "Hartree", unit)
 
-        nEnergies = self.readrkf("DOS_Phonons", "nEnergies", file="engine")
+        nEnergies = cast(int, self.readrkf("DOS_Phonons", "nEnergies", file="engine"))
 
-        integrateDeltaE = self.readrkf("DOS_Phonons", "IntegrateDeltaE", file="engine")
+        integrateDeltaE = cast(float, self.readrkf("DOS_Phonons", "IntegrateDeltaE", file="engine"))
 
         assert integrateDeltaE
 
-        energy = np.array(self.readrkf("DOS_Phonons", "Energies", file="engine")) * energyConv
+        energy = np.array(cast(List[float], self.readrkf("DOS_Phonons", "Energies", file="engine"))) * energyConv
         dE = energy[1] - energy[0]
 
-        total_dos = np.array(self.readrkf("DOS_Phonons", "Total DOS", file="engine")) / dE
+        total_dos = np.array(cast(List[float], self.readrkf("DOS_Phonons", "Total DOS", file="engine"))) / dE
 
         assert len(energy) == nEnergies
         assert len(total_dos) == nEnergies
@@ -732,7 +735,7 @@ class AMSResults(Results):
 
         nSpecies = None
         try:
-            nSpecies = self.readrkf("DOS_Phonons", "nSpecies", file="engine")
+            nSpecies = cast(int, self.readrkf("DOS_Phonons", "nSpecies", file="engine"))
         except KeyError:
             print(
                 "Warning! The density of states (DOS) per atom and species is currently only supported by the Quantum Espresso engine."
@@ -742,20 +745,22 @@ class AMSResults(Results):
 
         if nSpecies:
 
-            nAtoms = self.readrkf("DOS_Phonons", "nAtoms", file="engine")
+            nAtoms = cast(int, self.readrkf("DOS_Phonons", "nAtoms", file="engine"))
 
             assert nAtoms == len(self.job.molecule)
 
-            DOSperSpecies = np.array(self.readrkf("DOS_Phonons", "DOS per species", file="engine")).reshape(
-                nSpecies, -1
-            )
-            species = self.readrkf("DOS_Phonons", "Species", file="engine").split("\0")
+            DOSperSpecies = np.array(
+                cast(List[int], self.readrkf("DOS_Phonons", "DOS per species", file="engine"))
+            ).reshape(nSpecies, -1)
+            species = cast(str, self.readrkf("DOS_Phonons", "Species", file="engine")).split("\0")
 
             for i, s in enumerate(species):
                 dos_per_species[s] = DOSperSpecies[i] / dE
 
-            DOSperAtom = np.array(self.readrkf("DOS_Phonons", "DOS per atom", file="engine")).reshape(nAtoms, -1)
-            atomToSpecies = np.array(self.readrkf("DOS_Phonons", "Atom to Species", file="engine")) - 1
+            DOSperAtom = np.array(cast(List[int], self.readrkf("DOS_Phonons", "DOS per atom", file="engine"))).reshape(
+                nAtoms, -1
+            )
+            atomToSpecies = np.array(cast(List[int], self.readrkf("DOS_Phonons", "Atom to Species", file="engine"))) - 1
             if isinstance(atomToSpecies, np.int64):
                 atomToSpecies = atomToSpecies.reshape(1)
 
@@ -794,8 +799,8 @@ class AMSResults(Results):
 
         read_labels = True
 
-        nBands: int = self.readrkf("phonon_curves", "nBands", file="engine")
-        nEdges: int = self.readrkf("phonon_curves", "nEdges", file="engine")
+        nBands = cast(int, self.readrkf("phonon_curves", "nBands", file="engine"))
+        nEdges = cast(int, self.readrkf("phonon_curves", "nEdges", file="engine"))
 
         if bands is None:
             bands = np.arange(nBands).tolist()
@@ -806,12 +811,14 @@ class AMSResults(Results):
 
         prevmaxx = 0
         for i in range(nEdges):
-            my_x = np.array(self.readrkf("phonon_curves", f"Edge_{i+1}_xFor1DPlotting", file="engine"))
+            my_x = np.array(
+                cast(List[float], self.readrkf("phonon_curves", f"Edge_{i+1}_xFor1DPlotting", file="engine"))
+            )
             my_x += prevmaxx
             prevmaxx = np.max(my_x)
 
             if read_labels:
-                my_labels = self.readrkf("phonon_curves", f"Edge_{i+1}_labels", file="engine").split()
+                my_labels = cast(str, self.readrkf("phonon_curves", f"Edge_{i+1}_labels", file="engine")).split()
                 if len(my_labels) == 2:
                     if only_high_symmetry_points:
                         labels += [my_labels[0]]  # only the first point of the curve
@@ -823,7 +830,7 @@ class AMSResults(Results):
             else:
                 x.append(my_x)
 
-            A = self.readrkf("phonon_curves", f"Edge_{i+1}_bands", file="engine")
+            A = cast(List[float], self.readrkf("phonon_curves", f"Edge_{i+1}_bands", file="engine"))
             A = np.array(A).reshape(-1, nBands)
             spinup_data = A[:, bands]
 
@@ -879,24 +886,24 @@ class AMSResults(Results):
                 Units.constants["Boltzmann"] * Units.constants["Avogadro_constant"] / Units.constants["electron_charge"]
             )
 
-        nPlots = self.readrkf("Plot", "numPlots", file="engine")
+        nPlots = cast(int, self.readrkf("Plot", "numPlots", file="engine"))
 
         temperature = np.array(
-            self.readrkf("Plot", "XValues(1)", file="engine")
+            cast(List[float], self.readrkf("Plot", "XValues(1)", file="engine"))
         )  # We assume that temperature is the same for all properties
 
         for iProp in range(nPlots):
-            label = self.readrkf("Plot", f"YLabel({iProp+1})", file="engine").strip()
+            label = cast(str, self.readrkf("Plot", f"YLabel({iProp+1})", file="engine")).strip()
 
             if label not in ["Internal Energy", "Free Energy", "Specific Heat", "Entropy"]:
                 continue
 
-            values = np.array(self.readrkf("Plot", f"YValues({iProp+1})", file="engine"))
+            values = np.array(cast(List[float], self.readrkf("Plot", f"YValues({iProp+1})", file="engine")))
 
-            property_title = self.readrkf("Plot", f"Title({iProp+1})", file="engine").strip()
-            temperature_unit = self.readrkf("Plot", f"XUnit({iProp+1})", file="engine").strip()
-            property_unit = self.readrkf("Plot", f"YUnit({iProp+1})", file="engine").strip()
-            temperature_label = self.readrkf("Plot", f"XLabel({iProp+1})", file="engine").strip()
+            property_title = cast(str, self.readrkf("Plot", f"Title({iProp+1})", file="engine")).strip()
+            temperature_unit = cast(str, self.readrkf("Plot", f"XUnit({iProp+1})", file="engine")).strip()
+            property_unit = cast(str, self.readrkf("Plot", f"YUnit({iProp+1})", file="engine")).strip()
+            temperature_label = cast(str, self.readrkf("Plot", f"XLabel({iProp+1})", file="engine")).strip()
 
             assert property_title == label
             assert temperature_label == "Temperature"
@@ -1454,12 +1461,12 @@ class AMSResults(Results):
 
     def get_timings(self) -> Dict[str, float]:
         """Return a dictionary with timing statistics of the job execution. Returned dictionary contains keys cpu, system and elapsed. The values are corresponding timings, expressed in seconds."""
-        ret = {}
+        ret: Dict[str, float] = {}
         try:
             # new AMS versions store timings on ams.rkf
-            ret["elapsed"] = self.readrkf("General", "ElapsedTime")
-            ret["system"] = self.readrkf("General", "SysTime")
-            ret["cpu"] = self.readrkf("General", "CPUTime")
+            ret["elapsed"] = cast(float, self.readrkf("General", "ElapsedTime"))
+            ret["system"] = cast(float, self.readrkf("General", "SysTime"))
+            ret["cpu"] = cast(float, self.readrkf("General", "CPUTime"))
         except:
             # fall back to reading output, was needed for old AMS versions
             cpu = self.grep_output("Total cpu time:")
@@ -1562,7 +1569,7 @@ class AMSResults(Results):
             else:
                 return [x]
 
-        nScanCoord: int = self.readrkf("PESScan", "nScanCoord")
+        nScanCoord = cast(int, self.readrkf("PESScan", "nScanCoord"))
 
         pes = tolist(self.readrkf("PESScan", "PES"))
 
@@ -1671,15 +1678,15 @@ class AMSResults(Results):
             else:
                 return [x]
 
-        ret = {}
+        ret: Dict[str, Any] = {}
         conversion_ratio = Units.conversion_ratio("au", unit)
         ret["nImages"] = self.readrkf("NEB", "nebImages")
         ret["nIterations"] = self.readrkf("NEB", "nebIterations")
         ret["Climbing"] = bool(self.readrkf("NEB", "climbing"))
         ret["HighestIndex"] = self.readrkf("NEB", "highestIndex")
-        ret["LeftBarrier"] = self.readrkf("NEB", "LeftBarrier") * conversion_ratio
-        ret["RightBarrier"] = self.readrkf("NEB", "RightBarrier") * conversion_ratio
-        ret["ReactionEnergy"] = self.readrkf("NEB", "ReactionEnergy") * conversion_ratio
+        ret["LeftBarrier"] = cast(float, self.readrkf("NEB", "LeftBarrier")) * conversion_ratio
+        ret["RightBarrier"] = cast(float, self.readrkf("NEB", "RightBarrier")) * conversion_ratio
+        ret["ReactionEnergy"] = cast(float, self.readrkf("NEB", "ReactionEnergy")) * conversion_ratio
         history_dim = tolist(self.readrkf("NEB", "historyIndex@dim"))  # nimages, randombign
         history_dim.reverse()  # randombign, nimages
         history_indices_matrix = np.array(
@@ -1690,9 +1697,11 @@ class AMSResults(Results):
         if any(x == -1 for x in history_indices):
             raise ValueError("Found -1 in the 'converged' part of historyIndex. This should not happen!")
         ret["HistoryIndices"] = history_indices
-        ret["Energies"] = [self.get_property_at_step(ind, "Energy") * conversion_ratio for ind in ret["HistoryIndices"]]
+        ret["Energies"] = [
+            cast(float, self.get_property_at_step(ind, "Energy")) * conversion_ratio for ind in ret["HistoryIndices"]
+        ]
         if molecules:
-            ret["Molecules"] = [self.get_history_molecule(ind) for ind in ret["HistoryIndices"]]
+            ret["Molecules"] = [self.get_history_molecule(ind) for ind in cast(Sequence, ret["HistoryIndices"])]
 
         return ret
 
@@ -1802,8 +1811,8 @@ class AMSResults(Results):
 
     def get_time_step(self, history_section: Literal["BinLog", "MDHistory"] = "MDHistory") -> int:
         """Returns the time step between adjacent frames (NOT the TimeStep in the settings, but Timestep*SamplingFreq) in femtoseconds for MD simulation jobs"""
-        time1 = self.get_property_at_step(1, "Time", history_section=history_section)
-        time2 = self.get_property_at_step(2, "Time", history_section=history_section)
+        time1 = cast(Optional[int], self.get_property_at_step(1, "Time", history_section=history_section))
+        time2 = cast(Optional[int], self.get_property_at_step(2, "Time", history_section=history_section))
 
         if time1 is None or time2 is None:
             raise PlamsError(f"Cannot determine time step from 'Time' variable of history section '{history_section}'")
@@ -1872,7 +1881,7 @@ class AMSResults(Results):
         """
         from scm.plams.trajectories.analysis import autocorrelation
 
-        nEntries: int = self.readrkf("MDHistory", "nEntries")
+        nEntries = cast(int, self.readrkf("MDHistory", "nEntries"))
 
         time_step = self.get_time_step()
 
@@ -1959,7 +1968,7 @@ class AMSResults(Results):
         from scm.plams.trajectories.analysis import autocorrelation
 
         # nEntries = self.readrkf('BinLog', 'nEntries')
-        time_step: int = self.get_time_step(history_section="BinLog")
+        time_step = self.get_time_step(history_section="BinLog")
 
         data = self.get_dipole_history()
 
@@ -2218,7 +2227,7 @@ class AMSResults(Results):
             T = np.array(self.get_history_property("Temperature", "MDHistory"))[start_step:end_step:every]
             mean_T = np.mean(T)
         except KeyError:  # might be triggered for currently running trajectories, then just use the first temperature
-            mean_T = self.get_property_at_step(1, "Temperature", "MDHistory")
+            mean_T = cast(float, self.get_property_at_step(1, "Temperature", "MDHistory"))
 
         k_B = Units.constants["k_B"]
 
@@ -2284,7 +2293,7 @@ class AMSResults(Results):
         bohr2ang = Units.convert(1.0, "bohr", "angstrom")
 
         start_step, end_step, every, _ = self._get_integer_start_end_every_max(start_fs, end_fs, every_fs, None)
-        nEntries = self.readrkf("History", "nEntries")
+        nEntries = cast(int, self.readrkf("History", "nEntries"))
         history_coords = np.array(self.get_history_property("Coords")).reshape(nEntries, -1, 3)
         coords = history_coords[start_step:end_step:every]
         nEntries = len(coords)
@@ -2406,12 +2415,12 @@ class AMSResults(Results):
         coordinate = np.array(self.readrkf("WorkFunction", "coordinate", file="engine")) * to_dunit
         planarAverage = np.array(self.readrkf("WorkFunction", "planarAverage", file="engine")) * to_eunit
         macroscopicAverage = np.array(self.readrkf("WorkFunction", "macroscopicAverage", file="engine")) * to_eunit
-        Efermi = self.readrkf("WorkFunction", "fermiEnergy", file="engine") * to_eunit
-        Vbulk = self.readrkf("WorkFunction", "minMacroscopicAverPotential", file="engine") * to_eunit
-        leftVvacuum = self.readrkf("WorkFunction", "leftVacuumPotential", file="engine") * to_eunit
-        rightVvacuum = self.readrkf("WorkFunction", "rightVacuumPotential", file="engine") * to_eunit
-        leftWF = self.readrkf("WorkFunction", "leftWorkFunction", file="engine") * to_eunit
-        rightWF = self.readrkf("WorkFunction", "rightWorkFunction", file="engine") * to_eunit
+        Efermi = cast(float, self.readrkf("WorkFunction", "fermiEnergy", file="engine")) * to_eunit
+        Vbulk = cast(float, self.readrkf("WorkFunction", "minMacroscopicAverPotential", file="engine")) * to_eunit
+        leftVvacuum = cast(float, self.readrkf("WorkFunction", "leftVacuumPotential", file="engine")) * to_eunit
+        rightVvacuum = cast(float, self.readrkf("WorkFunction", "rightVacuumPotential", file="engine")) * to_eunit
+        leftWF = cast(float, self.readrkf("WorkFunction", "leftWorkFunction", file="engine")) * to_eunit
+        rightWF = cast(float, self.readrkf("WorkFunction", "rightWorkFunction", file="engine")) * to_eunit
 
         return (
             coordinate,
@@ -2445,7 +2454,7 @@ class AMSResults(Results):
         If ``ams.rkf`` is present in the job folder, extract user input and parse it back to a |Settings| instance using ``scm.libbase`` module. Remove the ``system`` branch from that instance.
         """
         if "ams" in self.rkfs:
-            user_input = self.readrkf("General", "user input")
+            user_input = cast(str, self.readrkf("General", "user input"))
             try:
                 from scm.plams.interfaces.adfsuite.inputparser import input_to_settings
 
@@ -2623,26 +2632,39 @@ class AMSResults(Results):
             # If there is only 1 state in the 'EnergyLandscape' section, some variables that are normally lists are insted be build-in types (e.g. a 'float' instead of a 'list of floats').
             # For convenience here we make sure that the following variables are always 'lists':
             for var in ["energies", "counts", "isTS", "reactants", "products"]:
+                tmp = sec[var]
                 if not isinstance(sec[var], list):
-                    sec[var] = [sec[var]]
+                    sec[var] = [sec[var]]  # type: ignore[list-item]
 
-            nStates: int = sec["nStates"]
+            nStates = cast(int, sec["nStates"])
 
             for iState in range(nStates):
-                energy: float = sec["energies"][iState]
-                resfile = os.path.splitext(sec["fileNames"].split("\0")[iState])[0]
+                energy = cast(List[float], sec["energies"])[iState]
+                resfile = os.path.splitext(cast(str, sec["fileNames"]).split("\0")[iState])[0]
                 mol = results.get_molecule("Molecule", file=resfile)
-                count: int = sec["counts"][iState]
-                if not sec["isTS"][iState]:
+                count = cast(List[int], sec["counts"])[iState]
+                if not cast(List[bool], sec["isTS"])[iState]:
                     self._states.append(AMSResults.EnergyLandscape.State(self, resfile, energy, mol, count, False))
                 else:
-                    reactantsID = sec["reactants"][iState] if sec["reactants"][iState] > 0 else None
-                    productsID = sec["products"][iState] if sec["products"][iState] > 0 else None
+                    reactantsID = (
+                        cast(List[int], sec["reactants"])[iState]
+                        if cast(List[int], sec["reactants"])[iState] > 0
+                        else None
+                    )
+                    productsID = (
+                        cast(List[int], sec["products"])[iState]
+                        if cast(List[int], sec["products"])[iState] > 0
+                        else None
+                    )
                     prefactorsFromReactant = (
-                        sec["prefactorsFromReactant"][iState] if sec["products"][iState] > 0 else None
+                        cast(List[int], sec["prefactorsFromReactant"])[iState]
+                        if cast(List[int], sec["products"])[iState] > 0
+                        else None
                     )
                     prefactorsFromProduct = (
-                        sec["prefactorsFromProduct"][iState] if sec["products"][iState] > 0 else None
+                        cast(List[float], sec["prefactorsFromProduct"])[iState]
+                        if cast(List[bool], sec["products"])[iState] > 0
+                        else None
                     )
                     self._states.append(
                         AMSResults.EnergyLandscape.State(
@@ -2662,32 +2684,32 @@ class AMSResults(Results):
             if "nFragments" not in sec:
                 return
 
-            nFragments = sec["nFragments"]
+            nFragments = cast(int, sec["nFragments"])
 
             for iFragment in range(nFragments):
-                energy = sec["fragmentsEnergies"][iFragment]
-                resfile = os.path.splitext(sec["fragmentsFileNames"].split("\0")[iFragment])[0]
+                energy = cast(List[float], sec["fragmentsEnergies"])[iFragment]
+                resfile = os.path.splitext(cast(str, sec["fragmentsFileNames"]).split("\0")[iFragment])[0]
                 mol = results.get_molecule("Molecule", file=resfile)
                 self._fragments.append(AMSResults.EnergyLandscape.Fragment(self, resfile, energy, mol))
 
             if "nFStates" not in sec:
                 return
 
-            nFragmentedStates = sec["nFStates"]
+            nFragmentedStates = cast(int, sec["nFStates"])
 
             for iFState in range(nFragmentedStates):
-                iEnergy = sec["fStatesEnergy(" + str(iFState + 1) + ")"]
+                iEnergy = cast(float, sec["fStatesEnergy(" + str(iFState + 1) + ")"])
 
-                value = sec["fStatesComposition(" + str(iFState + 1) + ")"]
+                value = cast(Union[List[int], int], sec["fStatesComposition(" + str(iFState + 1) + ")"])
                 iComposition = [i - 1 for i in value] if isinstance(value, list) else [value - 1]
 
-                value = sec["fStatesConnections(" + str(iFState + 1) + ")"]
+                value = cast(Union[List[int], int], sec["fStatesConnections(" + str(iFState + 1) + ")"])
                 iConnections = [i - 1 for i in value] if isinstance(value, list) else [value - 1]
 
-                value = sec["fStatesAdsorptionPrefactors(" + str(iFState + 1) + ")"]
+                value = cast(Union[List[int], int], sec["fStatesAdsorptionPrefactors(" + str(iFState + 1) + ")"])
                 iAdsorptionPrefactors = value if isinstance(value, list) else [value]
 
-                value = sec["fStatesDesorptionPrefactors(" + str(iFState + 1) + ")"]
+                value = cast(Union[List[int], int], sec["fStatesDesorptionPrefactors(" + str(iFState + 1) + ")"])
                 iDesorptionPrefactors = value if isinstance(value, list) else [value]
 
                 self._fstates.append(
@@ -2945,7 +2967,7 @@ class AMSJob(SingleJob):
     def check(self) -> bool:
         """Check if ``termination status`` variable from ``General`` section of main KF file equals ``NORMAL TERMINATION``."""
         try:
-            status = self.results.readrkf("General", "termination status")
+            status = cast(str, self.results.readrkf("General", "termination status"))
         except (FileError, KeyError) as e:
             log(str(e), 1)
             return False
@@ -2987,7 +3009,7 @@ class AMSJob(SingleJob):
                 #                find the last error from the stderr
                 # Note AMS can crash before even creating an rkf, then can just check the output and error files.
                 try:
-                    termination_status = self.results.readrkf("General", "termination status")
+                    termination_status = cast(str, self.results.readrkf("General", "termination status"))
                 except FileError:
                     termination_status = None
 

--- a/src/scm/plams/interfaces/adfsuite/ams.py
+++ b/src/scm/plams/interfaces/adfsuite/ams.py
@@ -1,6 +1,5 @@
 import os
 import re
-from os.path import join as opj
 
 from typing import (
     Dict,
@@ -130,17 +129,17 @@ class AMSResults(Results):
     def collect_rkfs(self) -> None:
         rkfname = "ams.rkf"
         if rkfname in self.files:
-            main = KFFile(opj(self.job.path, rkfname))
+            main = KFFile(str(self.job.get_path() / rkfname))
             n = main.read_int("EngineResults", "nEntries")
             for i in range(1, n + 1):
                 files = main.read_string("EngineResults", "Files({})".format(i)).split("\x00")
                 if files[0].endswith(".rkf"):
                     key = files[0][:-4]
-                    self.rkfs[key] = KFFile(opj(self.job.path, files[0]))
+                    self.rkfs[key] = KFFile(str(self.job.get_path() / files[0]))
             self.rkfs["ams"] = main
 
         else:
-            log("WARNING: Main KF file {} not present in {}".format(rkfname, self.job.path), 1)
+            log("WARNING: Main KF file {} not present in {}".format(rkfname, str(self.job.get_path())), 1)
 
     def _copy_to(self, newresults: "AMSResults") -> None:
         super()._copy_to(newresults)
@@ -157,7 +156,7 @@ class AMSResults(Results):
         for key, val in self.rkfs.items():
             if not os.path.isfile(val.path):
                 if os.path.dirname(val.path) != self.job.path:
-                    guessnewpath = opj(self.job.path, os.path.basename(val.path))
+                    guessnewpath = str(self.job.get_path() / os.path.basename(val.path))
                     if os.path.isfile(guessnewpath):
                         self.rkfs[key] = KFFile(guessnewpath)
                     else:
@@ -220,7 +219,7 @@ class AMSResults(Results):
         """
 
         kf_file = cast(str, self.readrkf("EngineResults", f"Files({term})", file=file))
-        kf = KFReader(os.path.join(self.job.path, kf_file))
+        kf = KFReader(str(self.job.get_path() / kf_file))
         return kf.read(section, variable)
 
     def rkfpath(self, file: str = "ams") -> str:
@@ -2801,11 +2800,11 @@ class AMSResults(Results):
         filename = file + ".rkf"
         self.refresh()
         if filename in self.files:
-            self.rkfs[file] = KFFile(opj(self.job.path, filename))
+            self.rkfs[file] = KFFile(str(self.job.get_path() / filename))
             return func(self.rkfs[file])
 
         # Surrender:
-        raise FileError("File {} not present in {}".format(filename, self.job.path))
+        raise FileError("File {} not present in {}".format(filename, self.job.get_path()))
 
     def _process_engine_results(self, func: Callable[[KFFile], T], engine: Optional[str] = None) -> T:
         """A generic method skeleton for processing any engine results ``.rkf`` file. *func* should be a function that takes one argument (an instance of |KFFile|) and returns arbitrary data.
@@ -2817,12 +2816,14 @@ class AMSResults(Results):
             if engine in names:
                 return func(self.rkfs[engine])
             else:
-                raise FileError(f"File {engine}.rkf not present in {self.job.path}\n engine names found are: {names}")
+                raise FileError(
+                    f"File {engine}.rkf not present in {self.job.get_path()}\n engine names found are: {names}"
+                )
         else:
             if len(names) == 1:
                 return func(self.rkfs[names[0]])
             elif len(names) == 0:
-                raise FileError("There is no engine .rkf present in {}".format(self.job.path))
+                raise FileError("There is no engine .rkf present in {}".format(self.job.get_path()))
             else:
                 raise ValueError(
                     "You need to specify the 'engine' argument when there are multiple engine result files present in the job folder"

--- a/src/scm/plams/interfaces/adfsuite/ams.py
+++ b/src/scm/plams/interfaces/adfsuite/ams.py
@@ -2631,7 +2631,6 @@ class AMSResults(Results):
             # If there is only 1 state in the 'EnergyLandscape' section, some variables that are normally lists are insted be build-in types (e.g. a 'float' instead of a 'list of floats').
             # For convenience here we make sure that the following variables are always 'lists':
             for var in ["energies", "counts", "isTS", "reactants", "products"]:
-                tmp = sec[var]
                 if not isinstance(sec[var], list):
                     sec[var] = [sec[var]]  # type: ignore[list-item]
 

--- a/src/scm/plams/interfaces/adfsuite/ams.py
+++ b/src/scm/plams/interfaces/adfsuite/ams.py
@@ -110,6 +110,8 @@ __all__ = ["AMSJob", "AMSResults"]
 class AMSResults(Results):
     """A specialized |Results| subclass for accessing the results of |AMSJob|."""
 
+    job: "AMSJob"
+
     def __init__(self, *args: Any, **kwargs: Any):
         Results.__init__(self, *args, **kwargs)
         self.rkfs: Dict[str, KFFile] = {}

--- a/src/scm/plams/interfaces/adfsuite/amsanalysis.py
+++ b/src/scm/plams/interfaces/adfsuite/amsanalysis.py
@@ -1,4 +1,3 @@
-import os
 from typing import Dict, Union, Optional, KeysView, List, Any, Tuple, NoReturn, TYPE_CHECKING, cast
 from typing_extensions import LiteralString
 

--- a/src/scm/plams/interfaces/adfsuite/amsanalysis.py
+++ b/src/scm/plams/interfaces/adfsuite/amsanalysis.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict, Union, Optional, KeysView, List, Any, Tuple, NoReturn, TYPE_CHECKING
+from typing import Dict, Union, Optional, KeysView, List, Any, Tuple, NoReturn, TYPE_CHECKING, cast
 from typing_extensions import LiteralString
 
 if TYPE_CHECKING:
@@ -103,7 +103,7 @@ class AMSAnalysisPlot:
         # Now set the instance variables
         self.properties = properties
         if "Legend" in properties:
-            self.name = properties["Legend"]
+            self.name = cast(str, properties["Legend"])
 
     def get_dimensions(self) -> int:
         """
@@ -186,8 +186,8 @@ class AMSAnalysisResults(SCMResults):
         """
         if not self._kfpresent():
             raise FileError("File {} not present in {}".format(self.job.name + self.__class__._kfext, self.job.path))
-        if self._kf.reader._sections is None:
-            self._kf.reader._create_index()
+        if self._kf.reader._sections is None:  # type: ignore
+            self._kf.reader._create_index()  # type: ignore
         return self._kf.reader._sections.keys()  # type: ignore
 
     def get_xy(self, section: str = "", i: int = 1) -> AMSAnalysisPlot:
@@ -243,7 +243,7 @@ class AMSAnalysisResults(SCMResults):
         if not plot.properties or "DiffusionCoefficient" not in plot.properties.keys():
             return None, None
 
-        D = plot.properties["DiffusionCoefficient"]
+        D = cast(float, plot.properties["DiffusionCoefficient"])
         D_units = plot.y_units
         return D, D_units
 

--- a/src/scm/plams/interfaces/adfsuite/amsanalysis.py
+++ b/src/scm/plams/interfaces/adfsuite/amsanalysis.py
@@ -287,6 +287,7 @@ class AMSAnalysisResults(SCMResults):
 class AMSAnalysisJob(SCMJob):
     """A class for analyzing molecular dynamics trajectories using the ``analysis`` program."""
 
+    results: AMSAnalysisResults
     _result_type = AMSAnalysisResults
     _command = "analysis"
     _subblock_end = "end"

--- a/src/scm/plams/interfaces/adfsuite/amsanalysis.py
+++ b/src/scm/plams/interfaces/adfsuite/amsanalysis.py
@@ -258,7 +258,7 @@ class AMSAnalysisResults(SCMResults):
         except:
             log(
                 "Failed to recreate input settings from {}".format(
-                    os.path.join(self.job.path, "".join([self.job.name, self.__class__._kfext]))
+                    str(self.job.get_path() / (self.job.name + self.__class__._kfext))
                 )
             )
             return None

--- a/src/scm/plams/interfaces/adfsuite/crs.py
+++ b/src/scm/plams/interfaces/adfsuite/crs.py
@@ -2,7 +2,7 @@ import inspect
 import os
 import subprocess
 from itertools import cycle
-from typing import Optional, List, Dict, TYPE_CHECKING, Set, Union, Any, Tuple
+from typing import Optional, List, Dict, TYPE_CHECKING, Set, Union, Any, Tuple, cast
 
 import numpy as np
 
@@ -37,12 +37,12 @@ class CRSResults(SCMResults):
 
     def get_energy(self, energy_type: str = "deltag", compound_idx: int = 0, unit: str = "kcal/mol") -> float:
         """Returns the solute solvation energy from an Activity Coefficients calculation."""
-        E: float = self.readkf(self.section, energy_type)[compound_idx]
+        E = cast(List[float], self.readkf(self.section, energy_type))[compound_idx]
         return Units.convert(E, "kcal/mol", unit)
 
     def get_activity_coefficient(self, compound_idx: int = 0) -> float:
         """Return the solute activity coefficient from an Activity Coefficients calculation."""
-        return self.readkf(self.section, "gamma")[compound_idx]
+        return cast(List[float], self.readkf(self.section, "gamma"))[compound_idx]
 
     def get_sigma_profile(self, subsection: str = "profil", as_df: bool = False) -> dict:
         r"""Grab all sigma profiles, returning a dictionary of Numpy Arrays.
@@ -113,10 +113,10 @@ class CRSResults(SCMResults):
             raise ValueError("Results object is missing or incomplete.")
 
         # first get the two ranges for the indices
-        ncomp = self.readkf(section, "ncomp")
-        nitems = self.readkf(section, "nitems")
+        ncomp = cast(int, self.readkf(section, "ncomp"))
+        nitems = cast(int, self.readkf(section, "nitems"))
         try:
-            nstruct = self.readkf(section, "nstruct")
+            nstruct = cast(int, self.readkf(section, "nstruct"))
         except:
             nstruct = ncomp
 
@@ -126,6 +126,7 @@ class CRSResults(SCMResults):
         for prop in props:
             tmp = self.readkf(section, prop)
             if prop in ["filename", "name", "SMILES", "mol_filenames"]:
+                tmp = cast(str, tmp)
                 if len(tmp) / ncomp == chunk_length:
                     np_dict[prop] = [tmp[i : i + chunk_length].strip() for i in range(0, len(tmp), chunk_length)]
                     continue
@@ -133,6 +134,7 @@ class CRSResults(SCMResults):
                     np_dict[prop] = tmp.split("\x00")
                     continue
             if prop == "struct names":
+                tmp = cast(str, tmp)
                 if len(tmp) / nstruct == chunk_length:
                     np_dict[prop] = [tmp[i : i + chunk_length].strip() for i in range(0, len(tmp), chunk_length)]
                     continue
@@ -162,9 +164,9 @@ class CRSResults(SCMResults):
         else:
             nPhase = 1
 
-        ncomp: int = self.readkf(self.section, "ncomp")
+        ncomp = cast(int, self.readkf(self.section, "ncomp"))
         struct_names = res["struct names"]
-        num_points: int = self.readkf(self.section, "nitems")
+        num_points = cast(int, self.readkf(self.section, "nitems"))
         valid_structs: List[List[str]] = [[] for _ in range(ncomp)]
         comp_dist = res["comp distribution"].flatten()
         for i in range(len(struct_names)):
@@ -226,28 +228,26 @@ class CRSResults(SCMResults):
 
         section = "EnegyComponent"
         try:
-            nspecies = self.readkf(section, "nspecies")
+            nspecies = cast(int, self.readkf(section, "nspecies"))
         except:
             log("The section of EnergyComponent is not found in the crskf file.")
             return None, None
 
-        ms_index = self.readkf(section, "ms_index")
-        ms_index = np.array(ms_index)
+        ms_index = np.array(self.readkf(section, "ms_index"))
         ms_index = ms_index.reshape(nspecies, 4)
 
-        mu_component = self.readkf(section, "mu_component")
-        mu_component = np.array(mu_component)
+        mu_component = np.array(self.readkf(section, "mu_component"))
         mu_component = mu_component.reshape(nspecies, int(len(mu_component) / nspecies))
 
         species_molfrac = self.readkf(section, "species_molfrac")
-        species_coskf = self.readkf(section, "species_coskf").split("\x00")
+        species_coskf = cast(str, self.readkf(section, "species_coskf")).split("\x00")
         species_coskf = [os.path.basename(x.rstrip()) for x in species_coskf]
 
         Assoc = self.readkf(section, "Assoc")
         NumRepMonmer = self.readkf(section, "NumRepMonmer")
         NumStrucPerComp = self.readkf(section, "NumStrucPerComp")
 
-        dict_species = {}
+        dict_species: Dict[str, Any] = {}
         dict_species["s_idx"] = [i + 1 for i in range(nspecies)]
         dict_species["CompIdx"] = ms_index[:, 0]
         dict_species["FormIdx"] = ms_index[:, 1]
@@ -271,9 +271,9 @@ class CRSResults(SCMResults):
             Assoc_s_idx = self.readkf(section, "Assoc_s_idx")
             ReqCompIdxAssoc = self.readkf(section, "ReqCompIdxAssoc")
             NumReqCompAssoc = self.readkf(section, "NumReqCompAssoc")
-            ReqCompNameAssoc = self.readkf(section, "ReqCompNameAssoc").split("\x00")
+            ReqCompNameAssoc = cast(str, self.readkf(section, "ReqCompNameAssoc")).split("\x00")
 
-            dict_Asson = {}
+            dict_Asson: Dict[str, Any] = {}
             dict_Asson["Assoc_s_idx"] = Assoc_s_idx
             dict_Asson["ReqCompIdxAssoc"] = ReqCompIdxAssoc
             dict_Asson["NumReqCompAssoc"] = NumReqCompAssoc
@@ -456,12 +456,12 @@ class CRSResults(SCMResults):
     def _construct_array_dict(self, section: str, subsection: str, unit: str = "kcal/mol") -> dict:
         """Construct dictionary containing all values in *section*/*subsection*."""
         # Use filenames as keys
-        _filenames: Union[List[str], str] = self.readkf(section, "filename").split()
+        _filenames = cast(str, self.readkf(section, "filename")).split()
         filenames = [_filenames] if not isinstance(_filenames, list) else _filenames
 
         # Grab the keys and the number of items per key
         keys = [os.path.basename(key) for key in filenames] + ["Total"]
-        nitems: int = self.readkf(section, "nitems")
+        nitems = cast(int, self.readkf(section, "nitems"))
 
         # Use sigma profiles/potentials as values
         ratio = Units.conversion_ratio("kcal/mol", unit)

--- a/src/scm/plams/interfaces/adfsuite/crs.py
+++ b/src/scm/plams/interfaces/adfsuite/crs.py
@@ -279,7 +279,7 @@ class CRSResults(SCMResults):
             dict_Asson["NumReqCompAssoc"] = NumReqCompAssoc
             dict_Asson["ReqCompNameAssoc"] = ReqCompNameAssoc
         else:
-            dict_Asson = None
+            dict_Asson = None  # type: ignore
 
         if as_df:
             try:
@@ -457,7 +457,7 @@ class CRSResults(SCMResults):
         """Construct dictionary containing all values in *section*/*subsection*."""
         # Use filenames as keys
         _filenames = cast(str, self.readkf(section, "filename")).split()
-        filenames = [_filenames] if not isinstance(_filenames, list) else _filenames
+        filenames = [_filenames] if not isinstance(_filenames, list) else _filenames  # type: ignore[list-item]
 
         # Grab the keys and the number of items per key
         keys = [os.path.basename(key) for key in filenames] + ["Total"]

--- a/src/scm/plams/interfaces/adfsuite/scmjob.py
+++ b/src/scm/plams/interfaces/adfsuite/scmjob.py
@@ -1,6 +1,20 @@
 import os
 from os.path import join as opj
-from typing import Union, TYPE_CHECKING, Dict, Any, TypeVar, NoReturn, Optional, Sequence, Type, Callable, List, Mapping
+from typing import (
+    Union,
+    TYPE_CHECKING,
+    Dict,
+    Any,
+    TypeVar,
+    NoReturn,
+    Optional,
+    Sequence,
+    Type,
+    Callable,
+    List,
+    Mapping,
+    cast,
+)
 
 import numpy as np
 
@@ -90,11 +104,11 @@ class SCMResults(Results):
         """get_properties()
         Return a dictionary with all the entries from ``Properties`` section in the main KF file.
         """
-        n = self.readkf("Properties", "nEntries")
+        n = cast(int, self.readkf("Properties", "nEntries"))
         ret: Dict[str, Any] = {}
         for i in range(1, n + 1):
-            tp = self.readkf("Properties", "Type({})".format(i)).strip()
-            stp = self.readkf("Properties", "Subtype({})".format(i)).strip()
+            tp = cast(str, self.readkf("Properties", "Type({})".format(i))).strip()
+            stp = cast(str, self.readkf("Properties", "Subtype({})".format(i))).strip()
             val = self.readkf("Properties", "Value({})".format(i))
             key = stp if stp.endswith(tp) else ("{} {}".format(stp, tp) if stp else tp)
             ret[key] = val
@@ -242,7 +256,7 @@ class SCMJob(SingleJob):
     def check(self) -> bool:
         """Check if ``termination status`` variable from ``General`` section of main KF file equals ``NORMAL TERMINATION``."""
         try:
-            status = self.results.readkf("General", "termination status")
+            status = cast(str, self.results.readkf("General", "termination status"))
         except:
             return False
         if "NORMAL TERMINATION" in status:

--- a/src/scm/plams/interfaces/adfsuite/scmjob.py
+++ b/src/scm/plams/interfaces/adfsuite/scmjob.py
@@ -32,6 +32,7 @@ TSelf = TypeVar("TSelf", bound="SCMResults")
 class SCMResults(Results):
     """Abstract class gathering common mechanisms for results of ADF Suite programs."""
 
+    job: "SCMJob"
     _kfext = ""
 
     def collect(self) -> None:
@@ -203,6 +204,7 @@ class SCMResults(Results):
 class SCMJob(SingleJob):
     """Abstract class gathering common mechanisms for jobs with ADF Suite programs."""
 
+    results: SCMResults
     _result_type = SCMResults
     _top = ["title", "units", "define"]
     _command = ""

--- a/src/scm/plams/interfaces/adfsuite/scmjob.py
+++ b/src/scm/plams/interfaces/adfsuite/scmjob.py
@@ -1,5 +1,4 @@
 import os
-from os.path import join as opj
 from typing import (
     Union,
     TYPE_CHECKING,
@@ -54,7 +53,7 @@ class SCMResults(Results):
         Results.collect(self)
         kfname = self.job.name + self.__class__._kfext
         if kfname in self.files:
-            self._kf = KFFile(opj(self.job.path, kfname))
+            self._kf = KFFile(str(self.job.get_path() / kfname))
         else:
             log("WARNING: Main KF file {} not present in {}".format(kfname, self.job.path), 1)
 
@@ -64,9 +63,9 @@ class SCMResults(Results):
         to_remove = []
         for attr, val in self.__dict__.items():
             if isinstance(val, KFFile) and os.path.dirname(val.path) != self.job.path:
-                guessnewpath = opj(self.job.path, os.path.basename(val.path))
+                guessnewpath = self.job.get_path() / os.path.basename(val.path)
                 if os.path.isfile(guessnewpath):
-                    self.__dict__[attr] = KFFile(guessnewpath)
+                    self.__dict__[attr] = KFFile(str(guessnewpath))
                 else:
                     to_remove.append(attr)
         for i in to_remove:
@@ -80,7 +79,7 @@ class SCMResults(Results):
         """
         if self._kfpresent():
             return self._kf.read(section, variable)
-        raise FileError("File {} not present in {}".format(self.job.name + self.__class__._kfext, self.job.path))
+        raise FileError("File {} not present in {}".format(self.job.name + self.__class__._kfext, self.job.get_path()))
 
     def newkf(self, filename: str) -> KFFile:
         """newkf(filename)
@@ -96,9 +95,9 @@ class SCMResults(Results):
         self.refresh()
         filename = filename.replace("$JN", self.job.name)
         if filename in self.files:
-            return KFFile(opj(self.job.path, filename))
+            return KFFile(str(self.job.get_path() / filename))
         else:
-            raise FileError("File {} not present in {}".format(filename, self.job.path))
+            raise FileError("File {} not present in {}".format(filename, self.job.get_path()))
 
     def get_properties(self) -> Dict[str, Any]:
         """get_properties()
@@ -167,7 +166,7 @@ class SCMResults(Results):
         """_kfpath()
         Return the absolute path to the main KF file.
         """
-        return opj(self.job.path, self.job.name + self.__class__._kfext)
+        return str(self.job.get_path() / (self.job.name + self.__class__._kfext))
 
     def _kfpresent(self) -> bool:
         """_kfpresent()
@@ -182,7 +181,7 @@ class SCMResults(Results):
         if isinstance(attr, KFFile):
             oldname = os.path.basename(attr.path)
             newname = Results._replace_job_name(oldname, self.job.name, other.job.name)
-            newpath = opj(other.job.path, newname)
+            newpath = str(other.job.get_path() / newname)
             return KFFile(newpath) if os.path.isfile(newpath) else None
         else:
             return Results._export_attribute(self, attr, other)

--- a/src/scm/plams/interfaces/adfsuite/unifac.py
+++ b/src/scm/plams/interfaces/adfsuite/unifac.py
@@ -2,7 +2,6 @@ import os
 import stat
 from collections.abc import Iterable
 from itertools import chain
-from os.path import join as opj
 from typing import List, Optional, Union, Any
 
 from scm.plams.core.basejob import SingleJob
@@ -163,7 +162,7 @@ class UnifacJob(SingleJob):
 
     def _get_ready(self) -> None:
         """Create the runfile."""
-        runfile = opj(self.path, self._filename("run"))
+        runfile = self.get_path() / self._filename("run")
         with open(runfile, "w") as f:
             f.write(self.full_runscript())
         os.chmod(runfile, os.stat(runfile).st_mode | stat.S_IEXEC)

--- a/src/scm/plams/interfaces/molecule/rdkit.py
+++ b/src/scm/plams/interfaces/molecule/rdkit.py
@@ -960,9 +960,9 @@ def gen_coords(plamsmol: Molecule) -> List[int]:
     for a in range(len(plamsmol.atoms)):
         pos = conf.GetAtomPosition(a)
         atom = plamsmol.atoms[a]
-        atom._setx(pos.x)
-        atom._sety(pos.y)
-        atom._setz(pos.z)
+        atom._setx(pos.x)  # type: ignore[attr-defined]
+        atom._sety(pos.y)  # type: ignore[attr-defined]
+        atom._setz(pos.z)  # type: ignore[attr-defined]
     return [a + 1 for a in unchanged]
 
 

--- a/src/scm/plams/mol/identify.py
+++ b/src/scm/plams/mol/identify.py
@@ -57,26 +57,26 @@ def unique_atoms(atomlist: Sequence["Atom"]) -> List["Atom"]:
     """Filter *atomlist* (list or |Molecule|) for atoms with unique ``IDname``."""
     d = {}
     for atom in atomlist:
-        if atom.IDname not in d:
-            d[atom.IDname] = 0
-        d[atom.IDname] += 1
-    return [atom for atom in atomlist if d[atom.IDname] == 1]
+        if atom.IDname not in d:  # type: ignore[attr-defined]
+            d[atom.IDname] = 0  # type: ignore[attr-defined]
+        d[atom.IDname] += 1  # type: ignore[attr-defined]
+    return [atom for atom in atomlist if d[atom.IDname] == 1]  # type: ignore[attr-defined]
 
 
 def initialize(molecule: "Molecule") -> None:
     """Initialize atom labeling algorithm by setting ``IDname`` and ``IDdone`` attributes for all atoms in *molecule*."""
     for at in molecule:
-        at.IDname = at.symbol
-        at.IDdone = False
+        at.IDname = at.symbol  # type: ignore[attr-defined]
+        at.IDdone = False  # type: ignore[attr-defined]
 
 
 def clear(molecule: "Molecule") -> None:
     """Remove ``IDname`` and ``IDdone`` attributes from all atoms in *molecule*."""
     for at in molecule:
         if hasattr(at, "IDname"):
-            del at.IDname
+            del at.IDname  # type: ignore[attr-defined]
         if hasattr(at, "IDdone"):
-            del at.IDdone
+            del at.IDdone  # type: ignore[attr-defined]
 
 
 def iterate(molecule: "Molecule", flags: Dict[str, Any]) -> bool:
@@ -84,20 +84,20 @@ def iterate(molecule: "Molecule", flags: Dict[str, Any]) -> bool:
 
     First, mark all atoms that are unique and have only unique neighbors as "done". Then calculate new label for each atom that is not done. Return True if the number of different atom labels increased during this iteration.
     """
-    names = len(set(at.IDname for at in molecule))
+    names = len(set(at.IDname for at in molecule))  # type: ignore[attr-defined]
     unique = set(unique_atoms(molecule))
 
     for atom in molecule:
         if atom in unique and all(N in unique for N in atom.neighbors()):
-            atom.IDdone = True
-        if not atom.IDdone:
-            atom.IDnew = new_name(atom, flags)
+            atom.IDdone = True  # type: ignore[attr-defined]
+        if not atom.IDdone:  # type: ignore[attr-defined]
+            atom.IDnew = new_name(atom, flags)  # type: ignore[attr-defined]
 
     for atom in molecule:
-        if not atom.IDdone:
-            atom.IDname = atom.IDnew
+        if not atom.IDdone:  # type: ignore[attr-defined]
+            atom.IDname = atom.IDnew  # type: ignore[attr-defined]
 
-    new_names = len(set(atom.IDname for atom in molecule))
+    new_names = len(set(atom.IDname for atom in molecule))  # type: ignore[attr-defined]
     return new_names > names  # True means this iteration increased the number of distinct names
 
 
@@ -139,7 +139,7 @@ def new_name(atom: "Atom", flags: Dict[str, Any]) -> str:
                         angles.append(sorted(bend(v1, atom.vector_to(a), flags.get("bend_tol")) for a in d[k]))  # type: ignore
             more.append("CO" + str(angles))
 
-    return sha256("|".join([atom.IDname] + [i[0] for i in knocks] + more))
+    return sha256("|".join([atom.IDname] + [i[0] for i in knocks] + more))  # type: ignore[attr-defined]
 
 
 def knock(A: "Atom", bond: "Bond", flags: Dict[str, Any]) -> Tuple[str, "Atom"]:
@@ -149,7 +149,7 @@ def knock(A: "Atom", bond: "Bond", flags: Dict[str, Any]) -> Tuple[str, "Atom"]:
     """
 
     S = bond.other_end(A)
-    ret: str = S.IDname
+    ret: str = S.IDname  # type: ignore[attr-defined]
 
     if flags["BO"] and bond.order != 1:
         ret += "BO" + str(bond.order)
@@ -158,7 +158,7 @@ def knock(A: "Atom", bond: "Bond", flags: Dict[str, Any]) -> Tuple[str, "Atom"]:
         S_nbors = S.neighbors()
         S_nbors.remove(A)
         if len(S_nbors) == 3 and len(unique_atoms(S_nbors)) == 3:
-            S_nbors.sort(key=lambda x: x.IDname)
+            S_nbors.sort(key=lambda x: x.IDname)  # type: ignore[attr-defined]
             v1, v2, v3 = [S.vector_to(i) for i in S_nbors]
             t = twist(v1, v2, v3, flags.get("twist_tol"))
             ret += "H2" + str(t)
@@ -167,14 +167,14 @@ def knock(A: "Atom", bond: "Bond", flags: Dict[str, Any]) -> Tuple[str, "Atom"]:
         S_unique = unique_atoms(S.neighbors())
         if A in S_unique:  # *A* is a unique neighbor of *S*
             S_unique.remove(A)
-            S_unique.sort(key=lambda x: x.IDname)
+            S_unique.sort(key=lambda x: x.IDname)  # type: ignore[attr-defined]
             for b in S.bonds:
                 N = b.other_end(S)
                 if N in S_unique:
                     N_unique = unique_atoms(N.neighbors())
                     if S in N_unique:
                         N_unique.remove(S)
-                    N_unique.sort(key=lambda x: x.IDname)
+                    N_unique.sort(key=lambda x: x.IDname)  # type: ignore[attr-defined]
                     if N_unique:
                         F = N_unique[0]
                         v1 = A.vector_to(S)
@@ -219,7 +219,7 @@ def label_atoms(molecule: "Molecule", **kwargs: Any) -> "Molecule":
 
 def molecule_name(molecule: "Molecule") -> str:
     """Compute the label of the whole *molecule* based on ``IDname`` attributes of all the atoms."""
-    names = [atom.IDname for atom in molecule]
+    names = [atom.IDname for atom in molecule]  # type: ignore[attr-defined]
     names.sort()
     return sha256(" ".join(names))
 
@@ -244,7 +244,7 @@ def get_graph(mol: "Molecule", dic: Dict[str, Any], level: int = 1) -> Optional[
     matrix = matrix.astype(np.int32)
 
     # Multiply the graph entries with the unique labels for each atom
-    identifiers = np.array([dic[at.IDname] if at.IDname in dic.keys() else None for at in mol.atoms])
+    identifiers = np.array([dic[at.IDname] if at.IDname in dic.keys() else None for at in mol.atoms])  # type: ignore[attr-defined]
     if None in identifiers:
         return None
     identifiers = identifiers.astype(np.int32)

--- a/src/scm/plams/mol/molecule.py
+++ b/src/scm/plams/mol/molecule.py
@@ -502,13 +502,13 @@ class Molecule:
         The starting value of the numbering can be set with *start* (starts at 1 by default).
         """
         for i, at in enumerate(self.atoms, start):
-            at.id = i
+            at.id = i  # type: ignore[attr-defined]
 
     def unset_atoms_id(self) -> None:
         """Delete ``id`` attributes of all atoms."""
         for at in self.atoms:
             try:
-                del at.id
+                del at.id  # type: ignore[attr-defined]
             except AttributeError:
                 pass
 
@@ -525,7 +525,7 @@ class Molecule:
         ret = np.zeros((len(self), len(self)))
         self.set_atoms_id(start=0)
         for b in self.bonds:
-            i, j = b.atom1.id, b.atom2.id
+            i, j = b.atom1.id, b.atom2.id  # type: ignore[attr-defined]
             ret[i, j] = ret[j, i] = b.order
         self.unset_atoms_id()
         return ret
@@ -578,31 +578,31 @@ class Molecule:
         frags = []
         clone = self.copy()
         for at in clone:
-            at._visited = False
+            at._visited = False  # type: ignore[attr-defined]
 
         def dfs(start_v: Atom, mol: "Molecule") -> None:
             stack = [start_v]
 
             while stack:
                 v = stack.pop()
-                if not v._visited:
-                    v._visited = True
+                if not v._visited:  # type: ignore[attr-defined]
+                    v._visited = True  # type: ignore[attr-defined]
                     v.mol = mol
                     for e in v.bonds:
                         e.mol = mol
                         u = e.other_end(v)
-                        if not u._visited:
+                        if not u._visited:  # type: ignore[attr-defined]
                             stack.append(u)
 
         for src in clone.atoms:
-            if not src._visited:
+            if not src._visited:  # type: ignore[attr-defined]
                 m = Molecule()
                 dfs(src, m)
                 frags.append(m)
                 frags[-1].lattice = self.lattice
 
         for at in clone.atoms:
-            del at._visited
+            del at._visited  # type: ignore[attr-defined]
             at.mol.atoms.append(at)
         for b in clone.bonds:
             b.mol.bonds.append(b)
@@ -679,13 +679,13 @@ class Molecule:
 
             cubes: Dict[Tuple[int, ...], List[Atom]] = {}
             for i, at in enumerate(atom_list, 1):
-                at._id = i
-                at.free = at.connectors
-                at.cube = tuple(map(lambda x: int(math.floor(x / cubesize)), at.coords))
-                if at.cube in cubes:
-                    cubes[at.cube].append(at)
+                at._id = i  # type: ignore[attr-defined]
+                at.free = at.connectors  # type: ignore[attr-defined]
+                at.cube = tuple(map(lambda x: int(math.floor(x / cubesize)), at.coords))  # type: ignore[attr-defined]
+                if at.cube in cubes:  # type: ignore[attr-defined]
+                    cubes[at.cube].append(at)  # type: ignore[attr-defined]
                 else:
-                    cubes[at.cube] = [at]
+                    cubes[at.cube] = [at]  # type: ignore[attr-defined]
 
             neighbors: Dict[Tuple[int, ...], List[Atom]] = {}
             for cube in cubes:
@@ -717,16 +717,16 @@ class Molecule:
 
             heap = []
             for at1 in from_atoms_subset:
-                if at1.free > 0 or ignore_free:
-                    for at2 in neighbors[at1.cube]:
+                if at1.free > 0 or ignore_free:  # type: ignore[attr-defined]
+                    for at2 in neighbors[at1.cube]:  # type: ignore[attr-defined]
                         if not at2 in to_atoms_subset:
                             continue
                         if ignore_free:
                             if at2 in from_atoms_subset:
-                                if at2._id <= at1._id:
+                                if at2._id <= at1._id:  # type: ignore[attr-defined]
                                     continue
                         else:
-                            if at2.free <= 0 or at2._id <= at1._id:
+                            if at2.free <= 0 or at2._id <= at1._id:  # type: ignore[attr-defined]
                                 continue
                         # the bond guessing is more accurate with smaller metallic radii
                         ratio = at1.distance_to(at2) / (
@@ -739,30 +739,30 @@ class Molecule:
                                 heap.append(HeapElement(0, ratio, at1, at2))
                                 # I hate to do this, but I guess there's no other way :/ [MiHa]
                                 if at1.atnum == 16 and at2.atnum == 8:
-                                    at1.free = 6
+                                    at1.free = 6  # type: ignore[attr-defined]
                                 elif at2.atnum == 16 and at1.atnum == 8:
-                                    at2.free = 6
+                                    at2.free = 6  # type: ignore[attr-defined]
                                 elif at1.atnum == 7:
-                                    at1.free += 1
+                                    at1.free += 1  # type: ignore[attr-defined]
                                 elif at2.atnum == 7:
-                                    at2.free += 1
+                                    at2.free += 1  # type: ignore[attr-defined]
             if not ignore_free:
                 heapq.heapify(heap)
 
                 for at in atom_list:
                     if at.atnum == 7:
-                        if at.free > 6:
-                            at.free = 4
+                        if at.free > 6:  # type: ignore[attr-defined]
+                            at.free = 4  # type: ignore[attr-defined]
                         else:
-                            at.free = 3
+                            at.free = 3  # type: ignore[attr-defined]
 
                 while heap:
                     val, o, r, at1, at2 = heapq.heappop(heap).unpack()
                     step = 1 if o in [0, 2] else 0.5
-                    if at1.free >= step and at2.free >= step:
+                    if at1.free >= step and at2.free >= step:  # type: ignore[attr-defined]
                         o += step
-                        at1.free -= step
-                        at2.free -= step
+                        at1.free -= step  # type: ignore[attr-defined]
+                        at2.free -= step  # type: ignore[attr-defined]
                         if o < 3:
                             heapq.heappush(heap, HeapElement(o, r, at1, at2))
                         else:
@@ -773,13 +773,13 @@ class Molecule:
                         self.add_bond(at1, at2, o)
 
                 def dfs(atom: Atom, par: int) -> Optional[bool]:
-                    atom.arom += 1000
+                    atom.arom += 1000  # type: ignore[attr-defined]
                     for b in atom.bonds:
                         oe = b.other_end(atom)
-                        if b.is_aromatic() and oe.arom < 1000:
-                            if oe.arom > 2:
+                        if b.is_aromatic() and oe.arom < 1000:  # type: ignore[attr-defined]
+                            if oe.arom > 2:  # type: ignore[attr-defined]
                                 return False
-                            if par and oe.arom == 1:
+                            if par and oe.arom == 1:  # type: ignore[attr-defined]
                                 b.order = 2
                                 return True
                             if dfs(oe, 1 - par):
@@ -788,21 +788,21 @@ class Molecule:
                     return None
 
                 for at in atom_list:
-                    at.arom = len(list(filter(Bond.is_aromatic, at.bonds)))
+                    at.arom = len(list(filter(Bond.is_aromatic, at.bonds)))  # type: ignore[attr-defined]
 
                 for at in atom_list:
-                    if at.arom == 1:
+                    if at.arom == 1:  # type: ignore[attr-defined]
                         dfs(at, 1)
 
         def cleanup_atom_list(atom_list: Sequence[Atom]) -> None:
             for at in atom_list:
-                del at.cube, at.free, at._id
+                del at.cube, at.free, at._id  # type: ignore[attr-defined]
                 if hasattr(at, "arom"):
-                    del at.arom
+                    del at.arom  # type: ignore[attr-defined]
                 if hasattr(at, "_metalbondcounter"):
-                    del at._metalbondcounter
+                    del at._metalbondcounter  # type: ignore[attr-defined]
                 if hasattr(at, "_electronegativebondcounter"):
-                    del at._electronegativebondcounter
+                    del at._electronegativebondcounter  # type: ignore[attr-defined]
 
         self.delete_all_bonds()
         atom_list = atom_subset or self.atoms
@@ -851,12 +851,12 @@ class Molecule:
             # delete metal-metal bonds and metal-hydrogen bonds if the metal is bonded to enough electronegative atoms and not enough metal atoms
             # (this means that the metal is a cation, so bonds should almost never be drawn unless it's a dimetal complex or a hydride/H2 ligand, but that should be rare)
             for at in metallic:
-                at._metalbondcounter = len([x for x in at.bonds if x.other_end(at).is_metallic])
-                at._electronegativebondcounter = len([x for x in at.bonds if x.other_end(at).is_electronegative])
+                at._metalbondcounter = len([x for x in at.bonds if x.other_end(at).is_metallic])  # type: ignore[attr-defined]
+                at._electronegativebondcounter = len([x for x in at.bonds if x.other_end(at).is_electronegative])  # type: ignore[attr-defined]
                 if (
-                    at._electronegativebondcounter >= 3
-                    or (at._electronegativebondcounter >= 2 >= at._metalbondcounter)
-                    or (at._electronegativebondcounter >= 1 and at._metalbondcounter <= 0)
+                    at._electronegativebondcounter >= 3  # type: ignore[attr-defined]
+                    or (at._electronegativebondcounter >= 2 >= at._metalbondcounter)  # type: ignore[attr-defined]
+                    or (at._electronegativebondcounter >= 1 and at._metalbondcounter <= 0)  # type: ignore[attr-defined]
                 ):
                     bonds_to_delete = [b for b in at.bonds if b.other_end(at).is_metallic or b.other_end(at).atnum == 1]
                     for b in bonds_to_delete:
@@ -1045,27 +1045,27 @@ class Molecule:
             self._validate_bond(arg, msg="Cannot check whether in ring.")
 
         def dfs(v: Atom, depth: int = 0) -> None:
-            v._visited = True
+            v._visited = True  # type: ignore[attr-defined]
             for bond in v.bonds:
                 if bond is not arg:
                     u = bond.other_end(v)
                     if u is arg and depth > 1:
-                        u._visited = "cycle"
-                    if not u._visited:
+                        u._visited = "cycle"  # type: ignore[attr-defined]
+                    if not u._visited:  # type: ignore[attr-defined]
                         dfs(u, depth + 1)
 
         for at in self:
-            at._visited = False
+            at._visited = False  # type: ignore[attr-defined]
 
         if isinstance(arg, Atom):
             dfs(arg)
-            ret = arg._visited == "cycle"
+            ret = arg._visited == "cycle"  # type: ignore[attr-defined]
         else:
             dfs(arg.atom1)
-            ret = arg.atom2._visited
+            ret = arg.atom2._visited  # type: ignore[attr-defined]
 
         for at in self:
-            del at._visited
+            del at._visited  # type: ignore[attr-defined]
         return ret
 
     def supercell(self, *args: Any) -> "Molecule":
@@ -1343,10 +1343,10 @@ class Molecule:
         def dfs(atom: Atom, func: Callable[["_SupportsFloatOrIndex"], int]) -> None:
             """Depth-first search algorithm for integer-ifying the bond orders."""
             for b2 in atom.bonds:
-                if b2._visited:
+                if b2._visited:  # type: ignore[attr-defined]
                     continue
 
-                b2._visited = True
+                b2._visited = True  # type: ignore[attr-defined]
                 b2.order = func(b2.order)  # func = ``math.ceil()`` or ``math.floor()``
                 del bond_dict[b2]
 
@@ -1368,10 +1368,10 @@ class Molecule:
                 if (
                     hasattr(bond.order, "is_integer") and not bond.order.is_integer()
                 ):  # Checking for ``is_integer()`` catches both float and np.float
-                    bond._visited = False
+                    bond._visited = False  # type: ignore[attr-defined]
                     bond_dict[bond] = None
                 else:
-                    bond._visited = True
+                    bond._visited = True  # type: ignore[attr-defined]
             return bond_dict, order_before
 
         bond_dict, order_before = collect_and_mark_bonds(self)
@@ -1386,7 +1386,7 @@ class Molecule:
             func = ceil if abs(delta_ceil) < abs(delta_floor) else floor
 
             b1.order = func(order)
-            b1._visited = True
+            b1._visited = True  # type: ignore[attr-defined]
             dfs(b1.atom1, func=func_invert[func])
             dfs(b1.atom2, func=func_invert[func])
 
@@ -1394,7 +1394,7 @@ class Molecule:
         order_after_sum = 0.0
         for bond in self.bonds:
             order_after_sum += bond.order
-            del bond._visited
+            del bond._visited  # type: ignore[attr-defined]
 
         # Check that the total (summed) bond order has not changed
         order_before_sum = sum(order_before)
@@ -1521,16 +1521,16 @@ class Molecule:
         """
         molecule_indices: List[List[int]] = []
         for at in self:
-            at._visited = False
+            at._visited = False  # type: ignore[attr-defined]
 
         def dfs(v: Atom, indices: List[int]) -> None:
             """
             Depth first search of self starting at atom v, extending the list of connected atoms (indices)
             """
-            v._visited = True
+            v._visited = True  # type: ignore[attr-defined]
             for e in v.bonds:
                 u = e.other_end(v)
-                if not u._visited:
+                if not u._visited:  # type: ignore[attr-defined]
                     indices.append(self.index(u, start=indices[0] + 1) - 1)
                     dfs(u, indices)
 
@@ -1542,12 +1542,12 @@ class Molecule:
             atoms = [v]
             while len(atoms) > 0:
                 for v in atoms:
-                    v._visited = True
+                    v._visited = True  # type: ignore[attr-defined]
                 res = []
                 for v in atoms:
                     for e in v.bonds:
                         other_end = e.other_end(v)
-                        if not other_end._visited and other_end not in res:
+                        if not other_end._visited and other_end not in res:  # type: ignore[attr-defined]
                             res.append(other_end)
                 atoms = res
                 # atoms = [e.other_end(v) for v in atoms for e in v.bonds if not e.other_end(v)._visited]
@@ -1555,14 +1555,14 @@ class Molecule:
                     indices.append(self.index(u, start=indices[0] + 1) - 1)
 
         for iatom, src in enumerate(self.atoms):
-            if not src._visited:
+            if not src._visited:  # type: ignore[attr-defined]
                 indices = [iatom]
                 # dfs(src, indices)
                 bfs(src, indices)
                 molecule_indices.append(sorted(indices))
 
         for at in self:
-            del at._visited
+            del at._visited  # type: ignore[attr-defined]
 
         return molecule_indices
 
@@ -2704,12 +2704,12 @@ class Molecule:
             s += ("%5i" % (i)) + atom.str(decimal=decimal) + "\n"
         if len(self.bonds) > 0:
             for j, atom in enumerate(self.atoms, 1):
-                atom._tmpid = j
+                atom._tmpid = j  # type: ignore[attr-defined]
             s += "  Bonds: \n"
             for bond in self.bonds:
-                s += "   (%d)--%1.1f--(%d)\n" % (bond.atom1._tmpid, bond.order, bond.atom2._tmpid)
+                s += "   (%d)--%1.1f--(%d)\n" % (bond.atom1._tmpid, bond.order, bond.atom2._tmpid)  # type: ignore[attr-defined]
             for atom in self.atoms:
-                del atom._tmpid
+                del atom._tmpid  # type: ignore[attr-defined]
         if self.lattice:
             s += "  Lattice:\n"
             for vec in self.lattice:
@@ -3116,7 +3116,7 @@ class Molecule:
             order = bo.order
             if order == Bond.AR:
                 order = 4
-            f.write("%3i %2i %2i  0  0  0  0\n" % (bo.atom1.id, bo.atom2.id, round(order)))
+            f.write("%3i %2i %2i  0  0  0  0\n" % (bo.atom1.id, bo.atom2.id, round(order)))  # type: ignore[attr-defined]
         self.unset_atoms_id()
         f.write("M  END\n")
 
@@ -3215,11 +3215,11 @@ class Molecule:
             write_prop("subst_name", at, " ", 7)
             write_prop("charge", at, " ", 6)
             write_prop("flags", at, "\n")
-            at.id = i
+            at.id = i  # type: ignore[attr-defined]
 
         f.write("\n@<TRIPOS>BOND\n")
         for i, bo in enumerate(self.bonds, 1):
-            f.write("%5i %5i %5i %4s" % (i, bo.atom1.id, bo.atom2.id, "ar" if bo.is_aromatic() else bo.order))
+            f.write("%5i %5i %5i %4s" % (i, bo.atom1.id, bo.atom2.id, "ar" if bo.is_aromatic() else bo.order))  # type: ignore[attr-defined]
             write_prop("flags", bo, "\n")
 
         self.unset_atoms_id()
@@ -3993,8 +3993,8 @@ class Molecule:
         # Link atom IDs to integers
         dic: Dict[str, int] = {}
         for at in self.atoms:
-            if not at.IDname in dic.keys():
-                dic[at.IDname] = max([v for v in dic.values()]) + 1 if len(dic) > 0 else 1
+            if not at.IDname in dic.keys():  # type: ignore[attr-defined]
+                dic[at.IDname] = max([v for v in dic.values()]) + 1 if len(dic) > 0 else 1  # type: ignore[attr-defined]
 
         # Create the graphs
         graph = get_graph(self, dic, level=1)

--- a/src/scm/plams/recipes/md/trajectoryanalysis.py
+++ b/src/scm/plams/recipes/md/trajectoryanalysis.py
@@ -190,6 +190,7 @@ class AMSMSDResults(AMSAnalysisResults):
 class AMSMSDJob(AMSConvenientAnalysisJob):
     """A convenient class wrapping around the trajectory analysis MSD tool"""
 
+    results: AMSMSDResults
     _result_type = AMSMSDResults
     _parent_write_atoms = True
     _task = "MeanSquareDisplacement"
@@ -323,6 +324,7 @@ class AMSViscosityFromBinLogResults(AMSAnalysisResults):
 class AMSViscosityFromBinLogJob(AMSConvenientAnalysisJob):
     """A convenient class wrapping around the trajectory analysis ViscosityFromBinLog tool. Only runs with default input options (max correlation time 10% of the total trajectory)."""
 
+    results: AMSViscosityFromBinLogResults
     _result_type = AMSViscosityFromBinLogResults
     _parent_write_atoms = False
     _task = "AutoCorrelation"

--- a/src/scm/plams/tools/plot.py
+++ b/src/scm/plams/tools/plot.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple, Union, TYPE_CHECKING, Dict, Any, Literal
+from typing import List, Optional, Tuple, Union, TYPE_CHECKING, Dict, Any, Literal, cast
 import numpy as np
 
 from scm.plams.core.errors import MissingOptionalPackageError
@@ -426,15 +426,17 @@ def get_correlation_xy(
     data2 = []
     for j1, j2 in zip(job1, job2):
         try:
-            d1 = j1.results.readrkf(section, variable, file=file)
+            d1 = cast(Union[List[float], float], j1.results.readrkf(section, variable, file=file))
         except KeyError:
-            d1 = j1.results.get_history_property(variable, history_section=section)
+            d1 = cast(Union[List[float], float], j1.results.get_history_property(variable, history_section=section))
         d1 = np.ravel(d1) * multiplier
 
         try:
-            d2 = j2.results.readrkf(alt_section, alt_variable, file=file)
+            d2 = cast(Union[List[float], float], j2.results.readrkf(alt_section, alt_variable, file=file))
         except KeyError:
-            d2 = j2.results.get_history_property(alt_variable, history_section=alt_section)
+            d2 = cast(
+                Union[List[float], float], j2.results.get_history_property(alt_variable, history_section=alt_section)
+            )
         d2 = np.ravel(d2) * multiplier
 
         data1.extend(list(d1))

--- a/src/scm/plams/tools/plot.py
+++ b/src/scm/plams/tools/plot.py
@@ -429,7 +429,7 @@ def get_correlation_xy(
             d1 = cast(Union[List[float], float], j1.results.readrkf(section, variable, file=file))
         except KeyError:
             d1 = cast(Union[List[float], float], j1.results.get_history_property(variable, history_section=section))
-        d1 = np.ravel(d1) * multiplier
+        d1a = np.ravel(d1) * multiplier
 
         try:
             d2 = cast(Union[List[float], float], j2.results.readrkf(alt_section, alt_variable, file=file))
@@ -437,10 +437,10 @@ def get_correlation_xy(
             d2 = cast(
                 Union[List[float], float], j2.results.get_history_property(alt_variable, history_section=alt_section)
             )
-        d2 = np.ravel(d2) * multiplier
+        d2a = np.ravel(d2) * multiplier
 
-        data1.extend(list(d1))
-        data2.extend(list(d2))
+        data1.extend(list(d1a))
+        data2.extend(list(d2a))
 
     return np.array(data1), np.array(data2)
 

--- a/unit_tests/test_amsresults.py
+++ b/unit_tests/test_amsresults.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, Mock
 import numpy as np
 import pytest
 from ase import Atoms as AseAtoms
@@ -22,6 +22,7 @@ class TestWaterOptimizationAMSResults:
         job = MagicMock(spec=AMSJob)
         job.status = "successful"
         job.path = str(rkf_folder / "water_optimization")
+        job.get_path = Mock(return_value=rkf_folder / "water_optimization")
         results = AMSResults(job=job)
         return results
 
@@ -794,6 +795,7 @@ class TestPropaneNitrileOptimizationAMSResults:
         job = MagicMock(spec=AMSJob)
         job.status = "successful"
         job.path = str(rkf_folder / "propanenitrile")
+        job.get_path = Mock(return_value=rkf_folder / "propanenitrile")
         results = AMSResults(job=job)
         return results
 


### PR DESCRIPTION
- type ignore Atom.things - Some algorithms add temporary attributes to the Atom class, this can't be typed as is
- add casts for readrkf/readkf - Some `cast(Type, variable)` added to add type hints to structured data read from IO
- add `Job.get_path` - convenient compared to `Job.path` attribute that can be `None` in some cases.
- add specific subclasses to results/job attributes - `Job`/`Results` pairs need their `results` and `job` attributes typed to their pair so that it can be known what methods/attributes are available