### PR TITLE
Rosa Bulo (REB) SCMSUITE-- SO107: Fixed bug in Molecule.reorder

### DIFF
--- a/src/scm/plams/mol/identify.py
+++ b/src/scm/plams/mol/identify.py
@@ -242,7 +242,7 @@ def get_graph(mol: "Molecule", dic: Dict[str, Any], level: int = 1) -> Optional[
     if len(mol.bonds) == 0:
         mol.guess_bonds()
     if not hasattr(mol.atoms[0], "IDname"):
-        mol.label(level=1, keep_labels=True)
+        mol.label(level=level, keep_labels=True)
 
     # Get the connectivity matrix (remove bond orders)
     matrix = mol.bond_matrix()
@@ -256,6 +256,7 @@ def get_graph(mol: "Molecule", dic: Dict[str, Any], level: int = 1) -> Optional[
     identifiers = identifiers.astype(np.int32)
     matrix *= identifiers.reshape((1, nats))
     matrix *= identifiers.reshape((nats, 1))
+    np.fill_diagonal(matrix, identifiers)
 
     # Create the graph
     graph = networkx.from_numpy_array(matrix)

--- a/src/scm/plams/mol/molecule.py
+++ b/src/scm/plams/mol/molecule.py
@@ -3998,7 +3998,7 @@ class Molecule:
         if len(self.bonds) == 0:
             self.guess_bonds()
         if not hasattr(self.atoms[0], "IDname"):
-            self.label(level=1, keep_labels=True)
+            self.label(level=level, keep_labels=True)
 
         # Link atom IDs to integers
         dic: Dict[str, int] = {}
@@ -4007,8 +4007,8 @@ class Molecule:
                 dic[at.IDname] = max([v for v in dic.values()]) + 1 if len(dic) > 0 else 1  # type: ignore[attr-defined]
 
         # Create the graphs
-        graph = get_graph(self, dic, level=1)
-        graph2 = get_graph(other, dic, level=1)
+        graph = get_graph(self, dic, level=level)
+        graph2 = get_graph(other, dic, level=level)
         if graph2 is None:
             return None
 

--- a/unit_tests/test_identify.py
+++ b/unit_tests/test_identify.py
@@ -1,5 +1,6 @@
 import pytest
 
+from scm.plams.mol.molecule import Atom
 from scm.plams.mol.molecule import Molecule
 
 
@@ -48,3 +49,14 @@ class TestIdentify:
         chl3 = chl1.reorder(chl2)
         assert chl3.label(4) == chl1.label(4) != chl2.label(4)
         assert [at.symbol for at in chl3] == [at.symbol for at in chl2] != [at.symbol for at in chl1]
+
+        # Try with the simplest molecule (OH)
+        o = Atom(symbol="O", coords=(0.0, 0.0, 0.0))
+        h = Atom(symbol="H", coords=(1.0, 0.0, 0.0))
+        oh = Molecule()
+        oh.add_atom(o)
+        oh.add_atom(h)
+        oh.add_bond(o, h)
+        ho = oh.get_fragment([1, 0])
+        mol = ho.reorder(oh)
+        assert [at.symbol for at in mol] == [at.symbol for at in oh] != [at.symbol for at in ho]


### PR DESCRIPTION
- The reorder method failed for very simple cases, because it only compares edges (bonds) and not the nodes. The graph passed to NetworkX now contains edges between each node and itself, containing identifying data for the node.
- I also changed the code so that in creating unique identifiers for the atoms, which are used to map the graphs, the depth of the dfs can be adjusted. The argument was already there, but it was unused, which I expect was a bug.