### PR TITLE
Rosa Bulo (REB) SCMSUITE-- SO107: Fixed bug RKFHistoryFile nob-block …

### DIFF
--- a/src/scm/plams/trajectories/rkffile.py
+++ b/src/scm/plams/trajectories/rkffile.py
@@ -320,6 +320,9 @@ class RKFTrajectoryFile(TrajectoryFile):
             self.mdblocksize = 100
             return
         blocksize = self.file_object.read(section, "blockSize")
+        nblocks = 0
+        if (section, "nBlocks") in self.file_object:
+            nblocks = self.file_object.read(section, "nBlocks")
         item_keys = [kn for kn in sections[section] if "ItemName" in kn]
         items = [self.file_object.read(section, kn) for kn in item_keys]
         blockitems = []
@@ -329,6 +332,12 @@ class RKFTrajectoryFile(TrajectoryFile):
                 is_blockitem = True
                 if (section, "%s(1)" % (item)) in self.file_object:
                     if isinstance(self.file_object.read(section, "%s(1)" % (item)), str):
+                        is_blockitem = False
+                    # If this is a block item, the correct amount of blocks need to be there
+                    # Still not full proof. Should check that the number of items is correct.
+                    elif not (section, "%s(%i)" % (item, nblocks)) in self.file_object:
+                        is_blockitem = False
+                    elif (section, "%s(%i)" % (item, nblocks + 1)) in self.file_object:
                         is_blockitem = False
                 else:
                     is_blockitem = False
@@ -857,6 +866,11 @@ class RKFTrajectoryFile(TrajectoryFile):
                         old_values = self.file_object.read(section, "%s(%i)" % (key, iblock))
                         if not isinstance(old_values, list):
                             old_values = [old_values]
+                if len(old_values) != step % self.mdblocksize - 1:
+                    # This will mess up the RKF, so should throw an error
+                    msg = "Introducing new block value '%s' at step %i." % (key, step - 1)
+                    msg += " Block values should be written every step!"
+                    raise PlamsError(msg)
                 values = old_values + [values]  # Values is a scalar
             else:
                 self.file_object.write(section, "nBlocks", iblock)

--- a/src/scm/plams/trajectories/rkfhistoryfile.py
+++ b/src/scm/plams/trajectories/rkfhistoryfile.py
@@ -190,36 +190,36 @@ class RKFHistoryFile(RKFTrajectoryFile):
         version = 1
         self._set_system_version_elements()
         for i in range(self.get_length()):
-            if not ("History", "SystemVersion(%i)" % (i + 1)) in self.file_object:
+            if not ("History", f"SystemVersion({i + 1})") in self.file_object:
                 continue
-            new_version = self.file_object.read("History", "SystemVersion(%i)" % (i + 1))
+            new_version = self.file_object.read("History", f"SystemVersion({i + 1})")
             if new_version == version:
                 continue
             self.added_atoms[i] = {}
             self.removed_atoms[i] = {}
             # Now look for the added and removed atoms
             removed_atoms = []
-            if ("SystemVersionHistory", "RemovedAtoms(%i)" % (new_version)) in self.file_object:
-                removed_atoms = self.file_object.read("SystemVersionHistory", "RemovedAtoms(%i)" % (new_version))
+            if ("SystemVersionHistory", f"RemovedAtoms({new_version})") in self.file_object:
+                removed_atoms = self.file_object.read("SystemVersionHistory", f"RemovedAtoms({new_version})")
             if not isinstance(removed_atoms, list):
                 removed_atoms = [removed_atoms]
             added_atoms = []
-            if ("SystemVersionHistory", "AddedAtoms(%i)" % (new_version)) in self.file_object:
-                added_atoms = self.file_object.read("SystemVersionHistory", "AddedAtoms(%i)" % (new_version))
+            if ("SystemVersionHistory", f"AddedAtoms({new_version})") in self.file_object:
+                added_atoms = self.file_object.read("SystemVersionHistory", f"AddedAtoms({new_version})")
             if not isinstance(added_atoms, list):
                 added_atoms = [added_atoms]
             # Now find the corresponding elements
-            chemSysNum = self.file_object.read("SystemVersionHistory", "SectionNum(%i)" % (new_version))
+            chemSysNum = self.file_object.read("SystemVersionHistory", f"SectionNum({new_version})")
             # Compare to the previous chemical system
             # prev_version = new_version - 1
             # prevChemSysNum = self.file_object.read('SystemVersionHistory','SectionNum(%i)'%(prev_version))
             prevChemSysNum = self.chemical_systems[max(self.chemical_systems.keys())]
-            sectionname = "ChemicalSystem(%i)" % (prevChemSysNum)
+            sectionname = f"ChemicalSystem({prevChemSysNum})"
             atnums = self.file_object.read(sectionname, "AtomicNumbers")
             if isinstance(atnums, int):
                 atnums = [atnums]
             prev_elements = [PT.get_symbol(atnum) for atnum in atnums]
-            sectionname = "ChemicalSystem(%i)" % (chemSysNum)
+            sectionname = f"ChemicalSystem({chemSysNum})"
             atnums = self.file_object.read(sectionname, "AtomicNumbers")
             if isinstance(atnums, int):
                 atnums = [atnums]
@@ -259,7 +259,7 @@ class RKFHistoryFile(RKFTrajectoryFile):
             chemSysNum = self._check_for_chemical_system(new_elements, compare_elements=False)
             if chemSysNum is None:
                 raise Exception("Chemical system with this number of atoms does not exist")
-        sectionname = "ChemicalSystem(%i)" % (chemSysNum)
+        sectionname = f"ChemicalSystem({chemSysNum})"
         elements = [PT.get_symbol(atnum) for atnum in self.file_object.read(sectionname, "AtomicNumbers")]
         ###################
         # Check the regions
@@ -334,7 +334,7 @@ class RKFHistoryFile(RKFTrajectoryFile):
             # Rebuild the molecule (bonds will disappear for now)
             if isinstance(molecule, Molecule):
                 # self.props = props
-                secname = "ChemicalSystem(%i)" % (self.chemical_systems[ifr])
+                secname = f"ChemicalSystem({self.chemical_systems[ifr]})"
                 if not "SystemVersionHistory" in self.file_object.sections():
                     secname = "InputMolecule"
                 section_dict = self.file_object.read_section(secname)
@@ -359,7 +359,7 @@ class RKFHistoryFile(RKFTrajectoryFile):
                     for iat, atnum in enumerate(atnums):
                         molecule.atoms[iat].atnum = atnum
 
-        coords[:] = self.file_object.read("History", "Coords(%i)" % (i + 1))
+        coords[:] = self.file_object.read("History", f"Coords({i + 1})")
         coords *= bohr_to_angstrom
         # This changes self.coords behind the scenes
 
@@ -475,7 +475,7 @@ class RKFHistoryFile(RKFTrajectoryFile):
             if chemsysversion is None:
                 chemsysversion = len(self.system_version_elements)
                 self._write_molecule_section(
-                    coords, cell, section="ChemicalSystem(%i)" % (chemsysversion), molecule=molecule
+                    coords, cell, section=f"ChemicalSystem({chemsysversion})", molecule=molecule
                 )
             self.chemical_systems[self.position] = chemsysversion
         counter = self._write_system_version_history_entry(counter)

--- a/unit_tests/test_trajectories.py
+++ b/unit_tests/test_trajectories.py
@@ -10,6 +10,8 @@ from scm.plams.trajectories.rkffile import RKFTrajectoryFile
 from scm.plams.trajectories.xyzfile import XYZTrajectoryFile
 from scm.plams.trajectories.sdffile import SDFTrajectoryFile
 
+from test_helpers import skip_if_no_ams_installation
+
 
 @pytest.fixture
 def conformers_rkf(rkf_folder):
@@ -88,6 +90,7 @@ class TestRKFHistoryFile:
         """
         Test reading of properties from the RKFHistoryFile
         """
+        skip_if_no_ams_installation()
         assert os.path.isfile(rkffilename)
 
         rkf = RKFHistoryFile(rkffilename)

--- a/unit_tests/test_trajectories.py
+++ b/unit_tests/test_trajectories.py
@@ -92,6 +92,7 @@ class TestRKFHistoryFile:
         Test reading of properties from the RKFHistoryFile
         """
         assert os.path.isfile(rkffilename)
+        print("Temporary file: ", rkffilename)
 
         rkf = RKFHistoryFile(rkffilename)
         rkf.store_mddata()

--- a/unit_tests/test_trajectories.py
+++ b/unit_tests/test_trajectories.py
@@ -1,4 +1,6 @@
 import pytest
+import os
+import random
 from pathlib import Path
 import numpy as np
 
@@ -19,7 +21,48 @@ def trajectory_xyz(xyz_folder):
     return str(Path(xyz_folder) / "water_box_traj.xyz")
 
 
+@pytest.fixture
+def molecules(xyz_folder):
+    """
+    Return set of single molecules
+    """
+    path = str(Path(xyz_folder))
+    filenames = [os.path.join(path, fn) for fn in os.listdir(path)]
+
+    molecules = []
+    for i, fn in enumerate(filenames):
+        mol = Molecule(fn)
+        mol.guess_bonds()
+        if len(mol.lattice) > 0:
+            continue
+        nmols = len(mol.separate())
+        if nmols > 1:
+            continue
+        molecules.append(mol)
+    return molecules
+
+
 class TestRKFHistoryFile:
+
+    @pytest.fixture
+    def rkffilename(self, tmp_path_factory, molecules):
+        """
+        Write RKFHistoryFile with properties NOT stored as blocks
+        """
+        rkfname = (tmp_path_factory.mktemp("data") / "molecules.rkf").as_posix()
+        rkf = RKFHistoryFile(rkfname, mode="wb")
+        rkf.store_historydata()
+        rkf.store_mddata()
+
+        # Store iframe as a list of integers, but not every step
+        for iframe, mol in enumerate(molecules):
+            historydata = {"Step": iframe, "Energy": 0.0}
+            mddata = {}
+            if iframe % 2 != 0:
+                mddata = {"ListOfInts": [iframe]}
+            rkf.write_next(molecule=mol, historydata=historydata, mddata=mddata)
+        rkf.close()
+        return rkfname
 
     def test_frames(self, conformers_rkf):
         # Given rkf file with multiple conformers
@@ -40,6 +83,27 @@ class TestRKFHistoryFile:
             # But the labels still match considering bond connectivity
             assert not np.allclose(crds, input_mol.as_array())
             assert mol.label(3) == input_mol.label(3)
+
+    def test_property_reading(self, rkffilename):
+        """
+        Test reading of properties from the RKFHistoryFile
+        """
+        assert os.path.isfile(rkffilename)
+
+        rkf = RKFHistoryFile(rkffilename)
+        rkf.store_mddata()
+        assert len(rkf) >= 23
+
+        indices = [i for i in range(len(rkf))]
+        indices = random.sample(indices, len(rkf))
+        results = []
+        for iframe in indices:
+            crd, cell = rkf.read_frame(iframe)
+            if "ListOfInts" in rkf.mddata:
+                results.append(rkf.mddata["ListOfInts"])
+                assert rkf.mddata["ListOfInts"] == iframe
+        assert len(results) > 0
+        assert len(results) < len(rkf)
 
 
 class TestTrajectoryFileFormats:

--- a/unit_tests/test_trajectories.py
+++ b/unit_tests/test_trajectories.py
@@ -51,6 +51,7 @@ class TestRKFHistoryFile:
         """
         Write RKFHistoryFile with properties NOT stored as blocks
         """
+        skip_if_no_ams_installation()
         rkfname = (tmp_path_factory.mktemp("data") / "molecules.rkf").as_posix()
         rkf = RKFHistoryFile(rkfname, mode="wb")
         rkf.store_historydata()
@@ -90,7 +91,6 @@ class TestRKFHistoryFile:
         """
         Test reading of properties from the RKFHistoryFile
         """
-        skip_if_no_ams_installation()
         assert os.path.isfile(rkffilename)
 
         rkf = RKFHistoryFile(rkffilename)


### PR DESCRIPTION
…property reading

- Fixed a bug where properties that were not stored as block items (because they were stored as lists) would be interpreted as block items if the first encountered list had length 1. This bug was present in both RKFTrajectoryFile and RKFHistoryFile.
- Added a test for this property reading.