### PR TITLE
Fix handling of System%GeometryFile in AMSJob::settings_to_mol()

### DIFF
--- a/src/scm/plams/interfaces/adfsuite/ams.py
+++ b/src/scm/plams/interfaces/adfsuite/ams.py
@@ -3736,7 +3736,7 @@ class AMSJob(SingleJob):
             if key in moldict:
                 raise KeyError(f"Duplicate system headers found in s.input.ams.system: {repr(key)}")
             moldict[key] = read_mol(settings_block)
-            used_properties = ["atoms", "bondorders", "lattice", "charge", "region", "supercell"]
+            used_properties = ["atoms", "bondorders", "geometryfile", "lattice", "charge", "region", "supercell"]
             for used_property in used_properties:
                 if used_property in settings_block:
                     settings_block.pop(used_property)


### PR DESCRIPTION
Without this, from_input() leaves system.geometryfile behind after converting it to a Molecule, which tends to confuse callers (e.g. AMSWorker will complain loudly about the leftover system block).