### PR TITLE
Rosa Bulo (REB) SCMSUITE-- SO107: input_to_dict now recursive over su…

### DIFF
--- a/src/scm/plams/interfaces/adfsuite/inputparser.py
+++ b/src/scm/plams/interfaces/adfsuite/inputparser.py
@@ -178,32 +178,57 @@ def input_to_settings(
     :param parser: use specific parser or defaults to internal parser if ``None``
     :return: |Settings| object with the structure of the parsed AMS input
     """
+
+    def _separate_engine_settings(lines: List[str], depth: int = 0) -> Tuple[Settings, List[str]]:
+        """
+        Recursively resolve the engine settings and add them to the rest
+        """
+        input_settings = Settings()
+
+        # Find the lines corresponding to the engine block.
+        # This should be recursive, to handle the hybrid engine.
+        while True:
+            lines, engine_lines = _separate_engine_lines(lines)
+            if engine_lines is None:
+                break
+            # We have found a separate engine block.
+            engine_words = engine_lines[0].split()
+            engine_name = engine_words[1]
+            if depth == 0:
+                key = engine_name
+            else:
+                key = " ".join(engine_words[:2])
+            engine_header = None if len(engine_words) == 2 else engine_words[2]
+            if not key in input_settings:
+                input_settings[key] = []
+            if len(engine_lines) == 2:
+                # If it's empty we already know the result of parsing it.
+                engine_settings = Settings()
+                if engine_header is not None:
+                    engine_settings["_h"] = engine_header
+                input_settings[key].append(engine_settings)
+            else:
+                engine_settings, rest_lines = _separate_engine_settings(engine_lines[1:-1], depth + 1)
+                if engine_header is not None:
+                    engine_settings["_h"] = engine_header
+                rest_settings = Settings(input_parser.to_dict(engine_name.lower(), "\n".join(rest_lines), string_leafs))
+                engine_settings.update(rest_settings)
+                input_settings[key].append(engine_settings)
+        for key in input_settings.keys():
+            if len(input_settings[key]) == 1:
+                input_settings[key] = input_settings[key][0]
+
+        return input_settings, lines
+
     input_parser = parser or InputParserFacade()
     if program in ["ams", "acerxn"]:
         # Settings for the program are special:
         # * Root level input needs to go under settings.input.ams.
         # * Engine block needs to go  to settings.input.%engine% where
         #   %engine% is the name of the engine, e.g. adf.
-        input_settings = Settings()
         lines = text_input.splitlines()
-
-        # Find the lines corresponding to the engine block.
-        while True:
-            lines, engine_lines = _separate_engine_lines(lines)
-            if engine_lines is None:
-                break
-            # We have found a separate engine block.
-            engine_name = engine_lines[0].split()[1]
-            if len(engine_lines) == 2:
-                # If it's empty we already know the result of parsing it.
-                input_settings[engine_name] = Settings()
-            else:
-                input_settings[engine_name] = Settings(
-                    input_parser.to_dict(engine_name.lower(), "\n".join(engine_lines[1:-1]), string_leafs)
-                )
-
+        input_settings, lines = _separate_engine_settings(lines)
         input_settings["ams"] = Settings(input_parser.to_dict(program, "\n".join(lines), string_leafs))
-
     else:
         input_settings = Settings(input_parser.to_dict(program, text_input, string_leafs))
 

--- a/unit_tests/test_interfaces.py
+++ b/unit_tests/test_interfaces.py
@@ -49,6 +49,7 @@ Engine Hybrid
   End
   Engine ADF ADF-1
   EndEngine
+
   Engine DFTB DFTB-1
   EndEngine
 
@@ -90,19 +91,20 @@ Engine Hybrid
     End
   End
   Engine ADF ADF-1
-     Save TAPE10
-     Save TAPE11
-     Basis
-     PerAtomType
-     Symbol H
-     End
-     PerAtomType
-     Symbol O
-     End
-     End
+    Basis
+      PerAtomType
+        Symbol H
+      End
+      PerAtomType
+        Symbol O
+      End
+    End
+    Save TAPE10
+    Save TAPE11
   EndEngine
   Engine ADF ADF-2
   EndEngine
+
   Engine DFTB DFTB-1
   EndEngine
 


### PR DESCRIPTION
…bengines

- input_to_dict of AMS input now recursively converts subengines to dictionaries This behavior is different from libbase.InputFile.to_dict(), but the behavior was already different before.
- The reason for this change is a future change I am making in the libbase.InputFile, which keeps the Engine block unchanged upon first processing of the input text. This messes up a PLAMS unittest, which creates an AMSJob from input, and then recreates the input. This job counted on the engine text lines being stripped, which will no longer be the case with the coming changes. Adding new spaces at the start of non-stripped lines makes no sense, so as a work around I made sure the engine block is no longer read as lines, but as a dictionary.