### PR TITLE
Rename scm.libbase references to scm.base

### DIFF
--- a/doc/source/examples/H-NMRSpinSpinCoupling/H-NMRSpinSpinCoupling.ipynb.rst
+++ b/doc/source/examples/H-NMRSpinSpinCoupling/H-NMRSpinSpinCoupling.ipynb.rst
@@ -6,7 +6,7 @@ Initial imports
 
 .. code:: ipython3
 
-   from scm.libbase import ChemicalSystem
+   from scm.base import ChemicalSystem
    from scm.plams import AMSJob, Settings, view
 
 System

--- a/doc/source/examples/JobAnalysis/job_analysis.ipynb.rst
+++ b/doc/source/examples/JobAnalysis/job_analysis.ipynb.rst
@@ -9,7 +9,7 @@ To begin with, create a variety of AMS jobs with different settings, engines and
 .. code:: ipython3
 
    from scm.plams import from_smiles, AMSJob, PlamsError, Settings, Molecule, Atom
-   from scm.libbase import ChemicalSystem
+   from scm.base import ChemicalSystem
    from scm.input_classes.drivers import AMS
    from scm.input_classes.engines import DFTB
    from scm.utils.conversions import plams_molecule_to_chemsys

--- a/doc/source/examples/MoleculeFormats/MoleculeFormats.ipynb.rst
+++ b/doc/source/examples/MoleculeFormats/MoleculeFormats.ipynb.rst
@@ -384,7 +384,7 @@ The problem can be fixed by passing the argument ``presanitize`` to the ``to_rdm
 
 .. figure:: MoleculeFormats_files/MoleculeFormats_42_1.svg
 
-SCM libbase ChemicalSystem Python class
+SCM Base ChemicalSystem Python class
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Convert PLAMS Molecule to ChemicalSystem
@@ -394,7 +394,7 @@ Convert PLAMS Molecule to ChemicalSystem
 
    from scm.utils.conversions import plams_molecule_to_chemsys, chemsys_to_plams_molecule
    from scm.plams import Molecule
-   from scm.libbase import ChemicalSystem
+   from scm.base import ChemicalSystem
 
    mol = Molecule(xyz_file)
    chemsys = plams_molecule_to_chemsys(mol)
@@ -403,7 +403,7 @@ Convert PLAMS Molecule to ChemicalSystem
 
 ::
 
-   type(chemsys)=<class 'scm.libbase._internal.ChemicalSystem'>
+   type(chemsys)=<class 'scm.base._internal.ChemicalSystem'>
    System
       Atoms
          C -1.47627 -1.15316 -0.292796
@@ -442,7 +442,7 @@ Convert ChemicalSystem to PLAMS Molecule
 
    from scm.utils.conversions import plams_molecule_to_chemsys, chemsys_to_plams_molecule
    from scm.plams import Molecule
-   from scm.libbase import ChemicalSystem
+   from scm.base import ChemicalSystem
 
    mol = chemsys_to_plams_molecule(chemsys)
    print(f"{type(chemsys)=}")
@@ -451,7 +451,7 @@ Convert ChemicalSystem to PLAMS Molecule
 
 ::
 
-   type(chemsys)=<class 'scm.libbase._internal.ChemicalSystem'>
+   type(chemsys)=<class 'scm.base._internal.ChemicalSystem'>
    type(mol)=<class 'scm.plams.mol.molecule.Molecule'>
 
 .. figure:: MoleculeFormats_files/MoleculeFormats_46_1.png

--- a/doc/source/examples/ZieglerNattaCatalyst/ZieglerNattaCatalyst.ipynb.rst
+++ b/doc/source/examples/ZieglerNattaCatalyst/ZieglerNattaCatalyst.ipynb.rst
@@ -18,7 +18,7 @@ Initial imports
 
 .. code:: ipython3
 
-   from scm.libbase import ChemicalSystem
+   from scm.base import ChemicalSystem
    from scm.plams import view, Settings, AMSJob, Units
 
 Initial system

--- a/examples/H-NMRSpinSpinCoupling/H-NMRSpinSpinCoupling.ipynb
+++ b/examples/H-NMRSpinSpinCoupling/H-NMRSpinSpinCoupling.ipynb
@@ -15,7 +15,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from scm.libbase import ChemicalSystem\n",
+    "from scm.base import ChemicalSystem\n",
     "from scm.plams import AMSJob, Settings, view"
    ]
   },

--- a/examples/H-NMRSpinSpinCoupling/H-NMRSpinSpinCoupling.py
+++ b/examples/H-NMRSpinSpinCoupling/H-NMRSpinSpinCoupling.py
@@ -3,7 +3,7 @@
 
 # ## Initial imports
 
-from scm.libbase import ChemicalSystem
+from scm.base import ChemicalSystem
 from scm.plams import AMSJob, Settings, view
 
 

--- a/examples/JobAnalysis/job_analysis.ipynb
+++ b/examples/JobAnalysis/job_analysis.ipynb
@@ -24,7 +24,7 @@
    "outputs": [],
    "source": [
     "from scm.plams import from_smiles, AMSJob, PlamsError, Settings, Molecule, Atom\n",
-    "from scm.libbase import ChemicalSystem\n",
+    "from scm.base import ChemicalSystem\n",
     "from scm.input_classes.drivers import AMS\n",
     "from scm.input_classes.engines import DFTB\n",
     "from scm.utils.conversions import plams_molecule_to_chemsys\n",

--- a/examples/JobAnalysis/job_analysis.py
+++ b/examples/JobAnalysis/job_analysis.py
@@ -6,7 +6,7 @@
 # To begin with, create a variety of AMS jobs with different settings, engines and calculation types.
 
 from scm.plams import from_smiles, AMSJob, PlamsError, Settings, Molecule, Atom
-from scm.libbase import ChemicalSystem
+from scm.base import ChemicalSystem
 from scm.input_classes.drivers import AMS
 from scm.input_classes.engines import DFTB
 from scm.utils.conversions import plams_molecule_to_chemsys

--- a/examples/MoleculeFormats/MoleculeFormats.ipynb
+++ b/examples/MoleculeFormats/MoleculeFormats.ipynb
@@ -907,7 +907,7 @@
    "id": "3d18c8c5-a1f6-4ef7-bb63-44d14faa3333",
    "metadata": {},
    "source": [
-    "### SCM libbase ChemicalSystem Python class\n",
+    "### SCM Base ChemicalSystem Python class\n",
     "\n",
     "#### Convert PLAMS Molecule to ChemicalSystem"
    ]
@@ -922,7 +922,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "type(chemsys)=<class 'scm.libbase._internal.ChemicalSystem'>\n",
+      "type(chemsys)=<class 'scm.base._internal.ChemicalSystem'>\n",
       "System\n",
       "   Atoms\n",
       "      C -1.47627 -1.15316 -0.292796\n",
@@ -959,7 +959,7 @@
    "source": [
     "from scm.utils.conversions import plams_molecule_to_chemsys, chemsys_to_plams_molecule\n",
     "from scm.plams import Molecule\n",
-    "from scm.libbase import ChemicalSystem\n",
+    "from scm.base import ChemicalSystem\n",
     "\n",
     "mol = Molecule(xyz_file)\n",
     "chemsys = plams_molecule_to_chemsys(mol)\n",
@@ -985,7 +985,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "type(chemsys)=<class 'scm.libbase._internal.ChemicalSystem'>\n",
+      "type(chemsys)=<class 'scm.base._internal.ChemicalSystem'>\n",
       "type(mol)=<class 'scm.plams.mol.molecule.Molecule'>\n"
      ]
     },
@@ -1004,7 +1004,7 @@
    "source": [
     "from scm.utils.conversions import plams_molecule_to_chemsys, chemsys_to_plams_molecule\n",
     "from scm.plams import Molecule\n",
-    "from scm.libbase import ChemicalSystem\n",
+    "from scm.base import ChemicalSystem\n",
     "\n",
     "mol = chemsys_to_plams_molecule(chemsys)\n",
     "print(f\"{type(chemsys)=}\")\n",

--- a/examples/MoleculeFormats/MoleculeFormats.py
+++ b/examples/MoleculeFormats/MoleculeFormats.py
@@ -223,13 +223,13 @@ rdkit_mol = to_rdmol(mol, presanitize=True)
 rdkit_mol
 
 
-# ### SCM libbase ChemicalSystem Python class
+# ### SCM base ChemicalSystem Python class
 #
 # #### Convert PLAMS Molecule to ChemicalSystem
 
 from scm.utils.conversions import plams_molecule_to_chemsys, chemsys_to_plams_molecule
 from scm.plams import Molecule
-from scm.libbase import ChemicalSystem
+from scm.base import ChemicalSystem
 
 mol = Molecule(xyz_file)
 chemsys = plams_molecule_to_chemsys(mol)
@@ -241,7 +241,7 @@ print(chemsys)
 
 from scm.utils.conversions import plams_molecule_to_chemsys, chemsys_to_plams_molecule
 from scm.plams import Molecule
-from scm.libbase import ChemicalSystem
+from scm.base import ChemicalSystem
 
 mol = chemsys_to_plams_molecule(chemsys)
 print(f"{type(chemsys)=}")

--- a/examples/ZieglerNattaCatalyst/ZieglerNattaCatalyst.ipynb
+++ b/examples/ZieglerNattaCatalyst/ZieglerNattaCatalyst.ipynb
@@ -32,7 +32,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from scm.libbase import ChemicalSystem\n",
+    "from scm.base import ChemicalSystem\n",
     "from scm.plams import view, Settings, AMSJob, Units"
    ]
   },

--- a/examples/ZieglerNattaCatalyst/ZieglerNattaCatalyst.py
+++ b/examples/ZieglerNattaCatalyst/ZieglerNattaCatalyst.py
@@ -14,7 +14,7 @@
 
 # ## Initial imports
 
-from scm.libbase import ChemicalSystem
+from scm.base import ChemicalSystem
 from scm.plams import view, Settings, AMSJob, Units
 
 

--- a/src/scm/plams/core/basejob.py
+++ b/src/scm/plams/core/basejob.py
@@ -38,7 +38,7 @@ from scm.plams.core.settings import Settings, JobSettings
 from scm.plams.mol.molecule import Molecule
 
 try:
-    from scm.libbase import ChemicalSystem
+    from scm.base import ChemicalSystem
 
     _has_scm_chemsys = True
 except ImportError:

--- a/src/scm/plams/interfaces/adfsuite/ams.py
+++ b/src/scm/plams/interfaces/adfsuite/ams.py
@@ -42,7 +42,7 @@ except ImportError:
     _has_scm_pisa = False
 
 try:
-    from scm.libbase import ChemicalSystem
+    from scm.base import ChemicalSystem
 
     _has_scm_chemsys = True
 except ImportError:
@@ -275,7 +275,7 @@ class AMSResults(Results):
         else:
             raise ValueError(f"Could not retrieve molecule from rkf section '{section}' for file '{file}.rkf'")
 
-    @requires_optional_package("scm.libbase")
+    @requires_optional_package("scm.base")
     def get_system(self, section: str, file: str = "ams") -> "ChemicalSystem":
         """Return a ``ChemicalSystem`` instance stored in a given *section* of a chosen ``.rkf`` file.
 
@@ -2448,7 +2448,7 @@ class AMSResults(Results):
     def recreate_settings(self) -> Optional[Settings]:
         """Recreate the input |Settings| instance for the corresponding job based on files present in the job folder. This method is used by |load_external|.
 
-        If ``ams.rkf`` is present in the job folder, extract user input and parse it back to a |Settings| instance using ``scm.libbase`` module. Remove the ``system`` branch from that instance.
+        If ``ams.rkf`` is present in the job folder, extract user input and parse it back to a |Settings| instance using ``scm.base`` module. Remove the ``system`` branch from that instance.
         """
         if "ams" in self.rkfs:
             user_input = cast(str, self.readrkf("General", "user input"))
@@ -3392,7 +3392,7 @@ class AMSJob(SingleJob):
         keyval_dict = {}
 
         if _has_scm_chemsys:
-            from scm.libbase import AtomAttributes
+            from scm.base import AtomAttributes
 
             allowed_attributes = AtomAttributes.Groups + ["mass", "region"]
 

--- a/src/scm/plams/interfaces/adfsuite/amsanalysis.py
+++ b/src/scm/plams/interfaces/adfsuite/amsanalysis.py
@@ -249,7 +249,7 @@ class AMSAnalysisResults(SCMResults):
     def recreate_settings(self) -> Optional[Settings]:
         """Recreate the input |Settings| instance for the corresponding job based on files present in the job folder. This method is used by |load_external|.
 
-        Extract user input from the kf file and parse it back to a |Settings| instance using ``scm.libbase`` module. Remove the ``system`` branch from that instance.
+        Extract user input from the kf file and parse it back to a |Settings| instance using ``scm.base`` module. Remove the ``system`` branch from that instance.
         """
         user_input = self._kf.read_string("General", "user input")
         try:

--- a/src/scm/plams/interfaces/adfsuite/inputparser.py
+++ b/src/scm/plams/interfaces/adfsuite/inputparser.py
@@ -11,8 +11,8 @@ from scm.plams.interfaces.adfsuite.amsworker import AMSWorker, AMSWorkerError
 from scm.plams.interfaces.adfsuite.ams import AMSJob
 
 if TYPE_CHECKING:
-    from scm.libbase import InputParser as InputParserLibbase
-    from scm.libbase import InputFile as InputFileLibbase
+    from scm.base import InputParser as InputParserLibbase
+    from scm.base import InputFile as InputFileLibbase
 
 TSelf = TypeVar("TSelf", bound="InputParser")
 
@@ -23,15 +23,15 @@ class InputParser:
     """
     A utility class for converting text input into JSON dictionaries and plams.Settings.
 
-    This is a legacy implementation for environments without access to scm.libbase.
+    This is a legacy implementation for environments without access to scm.base.
     """
 
     # !!!!!!!  DEPRECATED  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-    # This class has been deprecated. The equivalent in scm.libbase
-    # should be used instead where possible. The scm.libbase version does the input
+    # This class has been deprecated. The equivalent in scm.base
+    # should be used instead where possible. The scm.base version does the input
     # parsing via direct calls into libscm_base, instead of spawning an AMSWorker
     # and then pushing the input through the pipe. This implementation exists here
-    # only to remove the dependency on scm.libbase when running in python
+    # only to remove the dependency on scm.base when running in python
     # environments without access to the base library.
     # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
@@ -79,28 +79,28 @@ class InputParserFacade:
     """
     A utility class for converting text input into JSON dictionaries and plams.Settings.
 
-    Uses the scm.libbase implementation of InputParser if available, and otherwise the legacy implementation
+    Uses the scm.base implementation of InputParser if available, and otherwise the legacy implementation
     of the parser which spawns an AMSWorker instance.
     """
 
     try:
-        from scm.libbase import InputParser as InputParserLibbase
+        from scm.base import InputParser as InputParserLibbase
 
         # Cache a single instance of the parser to avoid having to repeatedly reload input file definition JSON
         # But for this need to make access to the parser thread-safe
-        input_parser_scm_libbase = InputParserLibbase()
+        input_parser_scm_base = InputParserLibbase()
         input_parser_lock = threading.Lock()
-        _has_scm_libbase = True
+        _has_scm_base = True
     except ImportError:
-        _has_scm_libbase = False
+        _has_scm_base = False
 
     @property
     def parser(self) -> Union[InputParser, "InputParserLibbase"]:
         """
         Get instance of a parser used to convert text input.
         """
-        if self._has_scm_libbase:
-            return self.input_parser_scm_libbase
+        if self._has_scm_base:
+            return self.input_parser_scm_base
         else:
             return InputParser()
 
@@ -108,7 +108,7 @@ class InputParserFacade:
         """
         Run a string of text input through the input parser and produce a Python dictionary representing the JSONified input.
         """
-        if self._has_scm_libbase:
+        if self._has_scm_base:
             with self.input_parser_lock:
                 return self.parser.to_dict(program, text_input, string_leafs)
         else:
@@ -116,7 +116,7 @@ class InputParserFacade:
                 return parser.to_dict(program, text_input, string_leafs)
 
 
-@requires_optional_package("scm.libbase")
+@requires_optional_package("scm.base")
 def get_system_blocks_as_molecules_from_input(input_file: "InputFileLibbase") -> Dict[str, Molecule]:
     """
     Get a dictionary of mappings between the System blocks in the input to |Molecule| instances.

--- a/src/scm/plams/interfaces/molecule/packmol.py
+++ b/src/scm/plams/interfaces/molecule/packmol.py
@@ -18,7 +18,7 @@ from scm.plams.core.jobmanager import JobManager
 
 if TYPE_CHECKING:
     try:
-        from scm.libbase import ChemicalSystem
+        from scm.base import ChemicalSystem
     except ImportError:
         pass
 
@@ -1111,7 +1111,7 @@ def _run_uff_md(
     return my_packed
 
 
-@requires_optional_package("scm.libbase")
+@requires_optional_package("scm.base")
 def packmol_around(
     current: Union[Molecule, "ChemicalSystem"],
     molecules: Union[List[Molecule], Molecule],
@@ -1162,7 +1162,7 @@ def packmol_around(
         the density will be lower than what you request.
 
     """
-    from scm.libbase import ChemicalSystem
+    from scm.base import ChemicalSystem
     from scm.utils.conversions import plams_molecule_to_chemsys, chemsys_to_plams_molecule
 
     if isinstance(current, Molecule):
@@ -1455,7 +1455,7 @@ def packmol_microsolvation(
 
 
 @overload
-@requires_optional_package("scm.libbase")
+@requires_optional_package("scm.base")
 def packmol_around_md(
     current: Union[Molecule, "ChemicalSystem"],
     molecules: Union[Molecule, List[Molecule]],
@@ -1464,7 +1464,7 @@ def packmol_around_md(
     **kwargs: Any,
 ) -> Molecule: ...
 @overload
-@requires_optional_package("scm.libbase")
+@requires_optional_package("scm.base")
 def packmol_around_md(
     current: Union[Molecule, "ChemicalSystem"],
     molecules: Union[Molecule, List[Molecule]],
@@ -1473,7 +1473,7 @@ def packmol_around_md(
     **kwargs: Any,
 ) -> Tuple[Molecule, Dict[str, Any]]: ...
 @overload
-@requires_optional_package("scm.libbase")
+@requires_optional_package("scm.base")
 def packmol_around_md(
     current: Union[Molecule, "ChemicalSystem"],
     molecules: Union[Molecule, List[Molecule]],
@@ -1481,7 +1481,7 @@ def packmol_around_md(
     always_run_md: bool = False,
     **kwargs: Any,
 ) -> Union[Molecule, Tuple[Molecule, Dict[str, Any]]]: ...
-@requires_optional_package("scm.libbase")
+@requires_optional_package("scm.base")
 def packmol_around_md(
     current: Union[Molecule, "ChemicalSystem"],
     molecules: Union[Molecule, List[Molecule]],
@@ -1503,7 +1503,7 @@ def packmol_around_md(
 
     In the returned ``Molecule``, the system will be mapped to ``[0..1]``. It has the same lattice has ``current``.
     """
-    from scm.libbase import ChemicalSystem, Lattice
+    from scm.base import ChemicalSystem, Lattice
     from scm.utils.conversions import plams_molecule_to_chemsys, chemsys_to_plams_molecule
 
     loglevel = 7

--- a/src/scm/plams/recipes/adfcosmorscompound.py
+++ b/src/scm/plams/recipes/adfcosmorscompound.py
@@ -452,7 +452,7 @@ class ADFCOSMORSCompoundJob(MultiJob):
         return s
 
     @staticmethod
-    @requires_optional_package("scm.libbase")
+    @requires_optional_package("scm.base")
     def convert_to_coskf(
         rkf_path: str,
         coskf_name: str,
@@ -472,7 +472,7 @@ class ADFCOSMORSCompoundJob(MultiJob):
             mol_info (Optional[Dict[str, Union[float, int, str]]]) : Optional information to write out in the "Compound Data" section of the .coskf file
             densf_path (Optional[str]) : path to the densf output .t41 file
         """
-        from scm.libbase import KFFile
+        from scm.base import KFFile
 
         with KFFile(rkf_path) as rkf:
             cosmo = rkf.read_section("COSMO")

--- a/src/scm/plams/tools/hbc_utilities.py
+++ b/src/scm/plams/tools/hbc_utilities.py
@@ -7,7 +7,7 @@ import numpy as np
 import os
 
 
-@requires_optional_package("scm.libbase")
+@requires_optional_package("scm.base")
 def view_HBC(rkf_path: str, xyz_file: Optional[str] = None) -> None:
     """
     visulize the hydrogen bond centers (HBC)
@@ -16,7 +16,7 @@ def view_HBC(rkf_path: str, xyz_file: Optional[str] = None) -> None:
         rkf_path (str) : A COSKF file used to visulize the HBC.
         xyz_file (optional str) : The name of the XYZ file to write the visualization to. If not provided, a temporary file "tmp-HBC.xyz" will be used.
     """
-    from scm.libbase import KFFile
+    from scm.base import KFFile
 
     if not isinstance(rkf_path, str):
         raise TypeError(f"Expected `rkf_path` to be a string but got {type(rkf_path).__name__}")
@@ -55,14 +55,14 @@ def view_HBC(rkf_path: str, xyz_file: Optional[str] = None) -> None:
     os.system(f"$AMSBIN/amsview {xyz_filename}")
 
 
-@requires_optional_package("scm.libbase")
+@requires_optional_package("scm.base")
 def write_HBC_to_COSKF(
     rkf_path: str, HBC_xyz: List[np.ndarray], HBC_atom: List[int], HBC_angle: List[float], HBC_info: Dict[str, Any]
 ) -> None:
     """
     Write the hydrogen bond centers (HBC) information into the COSKF file
     """
-    from scm.libbase import KFFile
+    from scm.base import KFFile
 
     if not isinstance(rkf_path, str):
         raise TypeError(f"Expected `rkf_path` to be a string but got {type(rkf_path).__name__}")
@@ -80,7 +80,7 @@ def write_HBC_to_COSKF(
             rkf.write("HBC", "HBC angles", HBC_angle)
 
 
-@requires_optional_package("scm.libbase")
+@requires_optional_package("scm.base")
 def parse_mesp(
     densf_path: str,
     rkf_path: str,
@@ -104,7 +104,7 @@ def parse_mesp(
         HBC_info (Dict[str, Any]) : A dictionary containing metadata, including the ADF version, density grid type, and HBC script version.
 
     """
-    from scm.libbase import KFFile
+    from scm.base import KFFile
 
     rkf = KFFile(rkf_path)
     densf = KFFile(densf_path)

--- a/src/scm/plams/tools/job_analysis.py
+++ b/src/scm/plams/tools/job_analysis.py
@@ -19,12 +19,12 @@ from scm.plams.mol.molecule import Molecule
 from scm.plams.interfaces.adfsuite.inputparser import input_to_settings
 
 try:
-    from scm.libbase import ChemicalSystem
+    from scm.base import ChemicalSystem
     from scm.utils.conversions import chemsys_to_plams_molecule
 
-    _has_scm_libbase = True
+    _has_scm_base = True
 except ImportError:
-    _has_scm_libbase = False
+    _has_scm_base = False
 
 try:
     from scm.pisa.block import DriverBlock
@@ -129,7 +129,7 @@ class JobAnalysis:
             return ", ".join([f"{n}: {JobAnalysis._mol_formula_extractor(m)}" for n, m in mol.items()])
         elif isinstance(mol, Molecule):
             return mol.get_formula()
-        elif _has_scm_libbase and isinstance(mol, ChemicalSystem):
+        elif _has_scm_base and isinstance(mol, ChemicalSystem):
             return mol.formula()
         return None
 
@@ -141,7 +141,7 @@ class JobAnalysis:
             return ", ".join([f"{n}: {JobAnalysis._mol_smiles_extractor(m)}" for n, m in mol.items()])
         elif isinstance(mol, Molecule):
             return to_smiles(mol)
-        elif _has_scm_libbase and isinstance(mol, ChemicalSystem):
+        elif _has_scm_base and isinstance(mol, ChemicalSystem):
             return JobAnalysis._mol_smiles_extractor(chemsys_to_plams_molecule(mol))
         return None
 
@@ -153,7 +153,7 @@ class JobAnalysis:
             return ", ".join([f"{n}: {JobAnalysis._mol_gyration_radius_extractor(m)}" for n, m in mol.items()])
         elif isinstance(mol, Molecule):
             return mol.get_gyration_radius()
-        elif _has_scm_libbase and isinstance(mol, ChemicalSystem):
+        elif _has_scm_base and isinstance(mol, ChemicalSystem):
             return JobAnalysis._mol_gyration_radius_extractor(chemsys_to_plams_molecule(mol))
         return None
 

--- a/src/scm/plams/tools/view.py
+++ b/src/scm/plams/tools/view.py
@@ -37,7 +37,7 @@ from scm.plams.core.private import run_with_timeout
 from scm.plams.tools.units import Units
 
 try:
-    from scm.libbase import ChemicalSystem
+    from scm.base import ChemicalSystem
 
     _has_scm_chemsys = True
 except ImportError:

--- a/src/scm/plams/trajectories/rkffile.py
+++ b/src/scm/plams/trajectories/rkffile.py
@@ -11,7 +11,7 @@ from scm.plams.tools.units import Units
 from scm.plams.trajectories.trajectoryfile import TrajectoryFile
 
 try:
-    from scm.libbase import KFFile
+    from scm.base import KFFile
 
     _has_libbase = True
 

--- a/src/scm/plams/trajectories/rkffile.py
+++ b/src/scm/plams/trajectories/rkffile.py
@@ -496,7 +496,7 @@ class RKFTrajectoryFile(TrajectoryFile):
             step_txt = ""
             if step is not None:
                 step_txt = "(%i)" % (step + 1)
-            if not ("History", "Bonds.Index%s" % (step_txt)) in self.file_object:
+            if not (section, "Bonds.Index%s" % (step_txt)) in self.file_object:
                 return conect
             indices = self.file_object.read(section, "Bonds.Index%s" % (step_txt))
             connection_table = self.file_object.read(section, "Bonds.Atoms%s" % (step_txt))

--- a/unit_tests/test_amsjob.py
+++ b/unit_tests/test_amsjob.py
@@ -11,7 +11,7 @@ import threading
 from scm.plams.interfaces.adfsuite.ams import AMSJob, AMSResults
 from scm.plams.core.settings import Settings
 from scm.plams.mol.molecule import Atom, Molecule
-from test_helpers import skip_if_no_scm_pisa, skip_if_no_scm_libbase
+from test_helpers import skip_if_no_scm_pisa, skip_if_no_scm_base
 
 
 class TestAMSJob:
@@ -308,8 +308,8 @@ class TestAMSJobWithChemicalSystem(TestAMSJob):
         """
         Instance of the Molecule class passed to the AMSJob
         """
-        skip_if_no_scm_libbase()
-        from scm.libbase import ChemicalSystem
+        skip_if_no_scm_base()
+        from scm.base import ChemicalSystem
 
         molecule = ChemicalSystem()
         molecule.add_atom("O", coords=[0, 0, 0])
@@ -354,8 +354,8 @@ class TestAMSJobWithChemicalSystemAndPisa(TestAMSJobWithPisa):
         """
         Instance of the Molecule class passed to the AMSJob
         """
-        skip_if_no_scm_libbase()
-        from scm.libbase import ChemicalSystem
+        skip_if_no_scm_base()
+        from scm.base import ChemicalSystem
 
         molecule = ChemicalSystem()
         molecule.add_atom("O", coords=[0, 0, 0])
@@ -614,8 +614,8 @@ class TestAMSJobWithMultipleChemicalSystems(TestAMSJobWithMultipleMolecules):
         """
         Instance of the Molecule class passed to the AMSJob
         """
-        skip_if_no_scm_libbase()
-        from scm.libbase import ChemicalSystem
+        skip_if_no_scm_base()
+        from scm.base import ChemicalSystem
 
         main_molecule = ChemicalSystem()
         main_molecule.add_atom("C", coords=(0, 0, 0))
@@ -675,8 +675,8 @@ class TestAMSJobWithMultipleChemicalSystemsAndPisa(TestAMSJobWithMultipleMolecul
         """
         Instance of the Molecule class passed to the AMSJob
         """
-        skip_if_no_scm_libbase()
-        from scm.libbase import ChemicalSystem
+        skip_if_no_scm_base()
+        from scm.base import ChemicalSystem
 
         main_molecule = ChemicalSystem()
         main_molecule.add_atom("C", coords=(0, 0, 0))
@@ -975,8 +975,8 @@ class TestAMSJobWithSystemBlockSettingsAndChemicalSystem(TestAMSJobWithSystemBlo
         """
         Get instance of the Molecule class passed to the AMSJob
         """
-        skip_if_no_scm_libbase()
-        from scm.libbase import ChemicalSystem, Lattice
+        skip_if_no_scm_base()
+        from scm.base import ChemicalSystem, Lattice
 
         molecule = ChemicalSystem()
         molecule.add_atom("Ar", coords=(0, 0, 0))
@@ -1038,8 +1038,8 @@ class TestAMSJobWithSystemBlockSettingsAndChemicalSystemAndPisa(TestAMSJobWithSy
         """
         Get instance of the Molecule class passed to the AMSJob
         """
-        skip_if_no_scm_libbase()
-        from scm.libbase import ChemicalSystem, Lattice
+        skip_if_no_scm_base()
+        from scm.base import ChemicalSystem, Lattice
 
         molecule = ChemicalSystem()
         molecule.add_atom("Ar", coords=(0, 0, 0))
@@ -1415,8 +1415,8 @@ class TestAMSJobWithSystemBlockSettingsAndMultipleChemicalSystems(
         """
         Get instance of the Molecule class passed to the AMSJob
         """
-        skip_if_no_scm_libbase()
-        from scm.libbase import ChemicalSystem
+        skip_if_no_scm_base()
+        from scm.base import ChemicalSystem
 
         main_molecule = ChemicalSystem()
         main_molecule.add_atom("C", coords=(-0.13949723, -0.08053322, -0.12698191))
@@ -1688,7 +1688,7 @@ class TestAMSJobWithAtomAttributes(TestAMSJob):
         """
         Get instance of the Molecule class passed to the AMSJob
         """
-        skip_if_no_scm_libbase()
+        skip_if_no_scm_base()
 
         molecule = Molecule()
         o = Atom(symbol="O", coords=(0, 0, 0))
@@ -1757,8 +1757,8 @@ class TestAMSJobWithAtomAttributesAndChemicalSystem(TestAMSJobWithAtomAttributes
         """
         Get instance of the Molecule class passed to the AMSJob
         """
-        skip_if_no_scm_libbase()
-        from scm.libbase import ChemicalSystem
+        skip_if_no_scm_base()
+        from scm.base import ChemicalSystem
 
         molecule = ChemicalSystem()
         molecule.add_atom("O", coords=[0, 0, 0])

--- a/unit_tests/test_amsresults.py
+++ b/unit_tests/test_amsresults.py
@@ -247,7 +247,7 @@ class TestWaterOptimizationAMSResults:
 
         # When get molecule from given file section
         try:
-            from scm.libbase import ChemicalSystem
+            from scm.base import ChemicalSystem
 
             # Then molecule as expected when chemical system present
             molecule = water_opt_results.get_system(section, file)
@@ -288,7 +288,7 @@ class TestWaterOptimizationAMSResults:
 
         # When get input molecule
         try:
-            from scm.libbase import ChemicalSystem
+            from scm.base import ChemicalSystem
 
             # Then molecule as expected when chemical system present
             molecule = water_opt_results.get_input_system()
@@ -323,7 +323,7 @@ class TestWaterOptimizationAMSResults:
 
         # Then molecule as expected (post optimization)
         try:
-            from scm.libbase import ChemicalSystem
+            from scm.base import ChemicalSystem
 
             # Then molecule as expected when chemical system present
             molecule = water_opt_results.get_main_system()

--- a/unit_tests/test_helpers.py
+++ b/unit_tests/test_helpers.py
@@ -139,14 +139,14 @@ def skip_if_no_scm_pisa():
         pytest.skip("Skipping test as cannot find scm.pisa package.")
 
 
-def skip_if_no_scm_libbase():
+def skip_if_no_scm_base():
     """
-    Check whether SCM libbase is available, and skip the test with a warning if it is not available.
+    Check whether SCM base is available, and skip the test with a warning if it is not available.
     """
     try:
-        import scm.libbase  # noqa F401
+        import scm.base  # noqa F401
     except ImportError:
-        pytest.skip("Skipping test as cannot find scm.libbase package.")
+        pytest.skip("Skipping test as cannot find scm.base package.")
 
 
 def skip_if_windows():

--- a/unit_tests/test_inputparser.py
+++ b/unit_tests/test_inputparser.py
@@ -6,7 +6,7 @@ import pytest
 from test_helpers import (
     get_mock_import_function,
     skip_if_no_ams_installation,
-    skip_if_no_scm_libbase,
+    skip_if_no_scm_base,
 )
 
 from scm.plams.core.settings import Settings
@@ -216,9 +216,9 @@ def test_to_dict_with_scmlibbase_succeeds(system_text_inputs):
 def test_get_system_blocks_from_input_as_molecules(system_text_inputs):
     # If there is no AMS installation the input file will not be present so skip test with a warning
     skip_if_no_ams_installation()
-    skip_if_no_scm_libbase()
+    skip_if_no_scm_base()
 
-    from scm.libbase import InputFile
+    from scm.base import InputFile
 
     from scm.plams.interfaces.adfsuite.inputparser import (
         get_system_blocks_as_molecules_from_input,
@@ -246,11 +246,11 @@ def get_monkeypatched_input_parser(monkeypatch):
     # If there is no AMS installation the input parser will not run so skip test with a warning
     skip_if_no_ams_installation()
 
-    # Mock scm.libbase import failing (even when present in the env)
-    mock_import_function = get_mock_import_function("scm.libbase")
+    # Mock scm.base import failing (even when present in the env)
+    mock_import_function = get_mock_import_function("scm.base")
     monkeypatch.setattr(builtins, "__import__", mock_import_function)
 
-    # Reload the module without scm.libbase
+    # Reload the module without scm.base
     import scm.plams.interfaces.adfsuite.inputparser as inputparser
 
     reload(inputparser)
@@ -269,17 +269,17 @@ def get_input_parser_or_skip():
 
     from scm.plams.interfaces.adfsuite.inputparser import InputParser, InputParserFacade
 
-    # Get an instance of the input parser facade using the scm.libbase parser
+    # Get an instance of the input parser facade using the scm.base parser
     # otherwise skip the test if the package is not loaded
     input_parser = InputParserFacade()
-    if input_parser._has_scm_libbase:
-        from scm.libbase import InputParser as InputParserScmLibbase
+    if input_parser._has_scm_base:
+        from scm.base import InputParser as InputParserScmBase
 
-        assert isinstance(input_parser.parser, InputParserScmLibbase)
+        assert isinstance(input_parser.parser, InputParserScmBase)
         return input_parser
     else:
         assert isinstance(input_parser.parser, InputParser)
-        pytest.skip("Skipping test because optional 'scm.libbase' package is not available")
+        pytest.skip("Skipping test because optional 'scm.base' package is not available")
 
 
 def input_to_settings_succeeds(input_texts, input_parser):

--- a/unit_tests/test_job_analysis.py
+++ b/unit_tests/test_job_analysis.py
@@ -13,7 +13,7 @@ from scm.plams.core.enums import JobStatus
 from scm.plams.tools.job_analysis import JobAnalysis
 from scm.plams.core.settings import Settings, JobManagerSettings
 from test_basejob import DummySingleJob
-from test_helpers import temp_file_path, skip_if_no_scm_pisa, skip_if_no_scm_libbase
+from test_helpers import temp_file_path, skip_if_no_scm_pisa, skip_if_no_scm_base
 
 
 class TestJobAnalysis:
@@ -1636,7 +1636,7 @@ class TestJobAnalysisWithChemicalSystem(TestJobAnalysis):
     @pytest.fixture(scope="class")
     def dummy_single_jobs(self):
         # Generate dummy jobs for a selection of molecules and input settings
-        skip_if_no_scm_libbase()
+        skip_if_no_scm_base()
         from scm.utils.conversions import plams_molecule_to_chemsys
 
         smiles = ["CC", "C", "O", "CO", "CCC", "CCCC", "CCCO", "CCCCCC", "CCCOC", "Sys"]

--- a/unit_tests/test_packmol.py
+++ b/unit_tests/test_packmol.py
@@ -4,7 +4,7 @@ from typing import List, Optional, Union
 
 import numpy as np
 import pytest
-from test_helpers import skip_if_no_ams_installation, skip_if_no_scm_libbase
+from test_helpers import skip_if_no_ams_installation, skip_if_no_scm_base
 
 from scm.plams.interfaces.molecule.packmol import (
     PackMolStructure,
@@ -969,7 +969,7 @@ class TestGuessDensity:
 
         mols = [mol]
         try:
-            import scm.libbase  # noqa F401
+            import scm.base  # noqa F401
             from scm.utils.conversions import plams_molecule_to_chemsys
 
             mols.append(plams_molecule_to_chemsys(mols[0]))
@@ -994,7 +994,7 @@ class TestPackMolAround:
 
     def test_pack_water_iteratively(self):
         skip_if_no_ams_installation()
-        skip_if_no_scm_libbase()
+        skip_if_no_scm_base()
 
         water = from_smiles("O")
 

--- a/unit_tests/test_tools_view.py
+++ b/unit_tests/test_tools_view.py
@@ -11,7 +11,7 @@ from scm.plams.mol.molecule import Molecule
 from test_helpers import skip_if_windows
 
 try:
-    from scm.libbase import ChemicalSystem, Lattice
+    from scm.base import ChemicalSystem, Lattice
 
     _has_scm_chemsys = True
 except ImportError:


### PR DESCRIPTION
Rename `scm.libbase` to `scm.base` to reflect changes in internal naming