### PR TITLE
Rosa Bulo (REB) SCMSUITE-- SO107: Fixed bug writing Molecule section …

### DIFF
--- a/src/scm/plams/trajectories/rkffile.py
+++ b/src/scm/plams/trajectories/rkffile.py
@@ -375,6 +375,7 @@ class RKFTrajectoryFile(TrajectoryFile):
 
         # Now make sure that it is possible to read from the file as well
         self._read_header()
+        self.firsttime = False
 
     def _update_celldata(self, cell):
         """
@@ -634,9 +635,8 @@ class RKFTrajectoryFile(TrajectoryFile):
             raise PlamsError("The coordinates do not match the rest of the trajectory")
 
         # If this is the first step, write the header
-        if self.position == 0:
+        if self.firsttime:
             self._write_header(coords, cell, molecule)
-            self.firsttime = False
 
         # Define some local variables
         step = self.position


### PR DESCRIPTION
…RKFTrajectoryFile

- Once the header (Molecule sections etc) is written, it will not be written again when position==0
This fixes a bug, but the bug only had impact when the class was used in a very expert way. Usually the header is written only at the first write call, when position==0.

However, in the conformers tool I tried to be clever, so I first wrote the header and passed it all the molecule information. Then I wrote each trajectory entry, but passed only the coordinate and lattice information. I did this to be faster. Unfortunately, the Molecule section was overwritten with the later incomplete molecule information, resulting in an incorrect charge.