### PR TITLE
Rosa Bulo (REB) SCMSUITE-- SO107: Small bugfix in RKFTrajectory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ For example, 2024.101 is the major release of 2024, and 2024.102 is the first bu
 This changelog is effective from the 2025 releases.
 
 ## [Unreleased]
+* `RKFTrajectoryFile` overwrote existing Molecule section at first write call, causing incorrect charge in Conformers tool
 
 ## 2025.106
 

--- a/trajectories/rkffile.py
+++ b/trajectories/rkffile.py
@@ -353,6 +353,7 @@ class RKFTrajectoryFile(TrajectoryFile):
 
         # Now make sure that it is possible to read from the file as well
         self._read_header()
+        self.firsttime = False
 
     def _update_celldata(self, cell):
         """
@@ -612,9 +613,8 @@ class RKFTrajectoryFile(TrajectoryFile):
             raise PlamsError("The coordinates do not match the rest of the trajectory")
 
         # If this is the first step, write the header
-        if self.position == 0:
+        if self.firsttime:
             self._write_header(coords, cell, molecule)
-            self.firsttime = False
 
         # Define some local variables
         step = self.position


### PR DESCRIPTION
- RKFTrajectory no longer overwrites molecule at first frame if Molecule section is already written This bug only becomes apparent with expert usage, but in the conformers tool it resulted in molecular charges not being written to file.