### PR TITLE
Disable intersphinx extension in PLAMS docs build

### DIFF
--- a/doc/source/components/settings.rst
+++ b/doc/source/components/settings.rst
@@ -15,7 +15,7 @@ Any derived settings class is interchangeable with the base |Settings| class of 
 Tree-like structure
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The |Settings| class is based on the regular Python dictionary (built-in class :class:`dict`, tutorial can be found :ref:`here<tut-dictionaries>`) and in many aspects works just like it::
+The |Settings| class is based on the regular Python dictionary (built-in class :class:`dict`, tutorial can be found `here <https://docs.python.org/3/tutorial/datastructures.html#tut-dictionaries>`__) and in many aspects works just like it::
 
     >>> s = Settings()
     >>> s['abc'] = 283

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -191,7 +191,6 @@ else:
 
 extensions += [
     "sphinx.ext.autodoc",
-    "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
     "sphinx_copybutton",
@@ -205,9 +204,6 @@ add_module_names = False
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "sphinx"
-
-# configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {"python3": ("http://docs.python.org/3.8", None)}
 
 autodoc_default_options = {"members": True, "private-members": True, "special-members": True}
 autodoc_member_order = "bysource"

--- a/src/scm/plams/core/jobrunner.py
+++ b/src/scm/plams/core/jobrunner.py
@@ -64,7 +64,7 @@ def _in_limited_thread(func: Callable[Concatenate[SelfT, P], None]) -> Callable[
 
 
 def _limit(func: Callable[Concatenate[SelfT, P], None]) -> Callable[Concatenate[SelfT, P], None]:
-    """Decorator for an instance method. If ``_job_limit`` attribute of given instance is not ``None``, use this attribute to wrap decorated method via :ref:`with<with-locks>` statement."""
+    """Decorator for an instance method. If ``_job_limit`` attribute of given instance is not ``None``, use this attribute to wrap decorated method via `with <https://docs.python.org/3/library/threading.html#using-locks-conditions-and-semaphores-in-the-with-statement>`__ statement."""
 
     @functools.wraps(func)
     def wrapper(self: SelfT, /, *args: P.args, **kwargs: P.kwargs) -> None:

--- a/src/scm/plams/mol/atom.py
+++ b/src/scm/plams/mol/atom.py
@@ -116,7 +116,7 @@ class Atom:
 
         If *symbol* is ``True``, atomic symbol is added at the beginning of the line. If *symbol* is a string, this exact string is printed there.
 
-        *suffix* is an arbitrary string that is appended at the end of returned line. It can contain identifiers in curly brackets (like for example ``f={fragment}``) that will be replaced by values of corresponding keys from *suffix_dict* dictionary. See :ref:`formatstrings` for details.
+        *suffix* is an arbitrary string that is appended at the end of returned line. It can contain identifiers in curly brackets (like for example ``f={fragment}``) that will be replaced by values of corresponding keys from *suffix_dict* dictionary. See `Format String Syntax <https://docs.python.org/3/library/string.html#formatstrings>`__ for details.
 
         Example:
 


### PR DESCRIPTION
Enabling intersphinx and configuring it is now done in the global config within the AMS userdoc setup. It is therefore no longer needed in all our individual packages.

This will remove links to python.org for people building the standalone PLAMS docs.