### PR TITLE
docs: fix syntax highlighting for literalincludes of Python code 

### DIFF
--- a/doc/source/examples/ADFFrag/ADFFrag.rst
+++ b/doc/source/examples/ADFFrag/ADFFrag.rst
@@ -21,6 +21,7 @@ It simply redirects the usual |AMSResults| methods to the results of the full sy
 
 
 .. literalinclude:: ../../../../src/scm/plams/recipes/adffragment.py
+   :language: python
 
 .. include:: ADFFrag.common_header.rst
 .. include:: adffrag.ipynb.rst

--- a/doc/source/examples/ADFNBO/ADFNBO.rst
+++ b/doc/source/examples/ADFNBO/ADFNBO.rst
@@ -18,6 +18,7 @@ No specialized |Results| subclass is defined for ``ADFNBOJob``.
 The source code of the whole module:
 
 .. literalinclude:: ../../../../src/scm/plams/recipes/adfnbo.py
+   :language: python
 
 .. include:: ADFNBO.common_header.rst
 .. include:: ADFNBO.ipynb.rst

--- a/doc/source/examples/BandFrag/BandFrag.rst
+++ b/doc/source/examples/BandFrag/BandFrag.rst
@@ -20,6 +20,7 @@ It simply redirects the usual |AMSResults| methods to the results of the full sy
 A derived subclass |NOCVBandFragmentJob| is also provided. It can be usefull for generating NOCV plots after the PEDA-NOCV calculation.
 
 .. literalinclude:: ../../../../src/scm/plams/recipes/bandfragment.py
+   :language: python
 
 .. include:: BandFrag.common_header.rst
 .. include:: bandfrag.ipynb.rst

--- a/doc/source/examples/COSMORSCompound/COSMORSCompound.rst
+++ b/doc/source/examples/COSMORSCompound/COSMORSCompound.rst
@@ -15,6 +15,7 @@ Source code for ``ADFCOSMORSCompound``
 .. dropdown::
 
     .. literalinclude:: ../../../../src/scm/plams/recipes/adfcosmorscompound.py
+       :language: python
 
 Brief API Documentation
 -----------------------

--- a/doc/source/examples/NumGrad/NumGrad.rst
+++ b/doc/source/examples/NumGrad/NumGrad.rst
@@ -18,6 +18,7 @@ Any function that takes results of a single point job and returns a single numbe
 The source code of the whole module with both abovementioned classes:
 
 .. literalinclude:: ../../../../src/scm/plams/recipes/numgrad.py
+   :language: python
 
 .. include:: NumGrad.common_header.rst
 .. include:: NumGrad.ipynb.rst

--- a/doc/source/examples/NumHess/NumHess.rst
+++ b/doc/source/examples/NumHess/NumHess.rst
@@ -18,6 +18,7 @@ The returned Hessian can optionally be mass weighted.
 The source code of the whole module with both aforementioned classes:
 
 .. literalinclude:: ../../../../src/scm/plams/recipes/numhess.py
+   :language: python
 
 .. include:: NumHess.common_header.rst
 .. include:: NumHess.ipynb.rst

--- a/doc/source/examples/ReorganizationEnergy/ReorganizationEnergy.rst
+++ b/doc/source/examples/ReorganizationEnergy/ReorganizationEnergy.rst
@@ -18,6 +18,7 @@ In this recipe we build a job class ``ReorganizationEnergyJob`` by extending |Mu
 In ``ReorganizationEnergyResults``, the reorganization energy is computed by fetching and combining the results from the children jobs.
 
 .. literalinclude:: ../../../../src/scm/plams/recipes/reorganization_energy.py
+   :language: python
 
 
 .. include:: ReorganizationEnergy.common_header.rst

--- a/doc/source/examples/pyAHFCDOS.rst
+++ b/doc/source/examples/pyAHFCDOS.rst
@@ -8,5 +8,6 @@ The ``FCFDOS`` class allows one to easily calculate the density of states for an
 For an example, see :ref:`Vibronic Density of States with ADF<fcf_dos>`.
 
 .. literalinclude:: ../../../src/scm/plams/recipes/fcf_dos.py
+   :language: python
 
 


### PR DESCRIPTION
Without the language specification, there is no syntax hightlighting in the built docs.