### PR TITLE
Rosa Bulo (REB) SCMSUITE-- SO107 (Zoho-AT1-I138): Removed sympy example

### DIFF
--- a/doc/source/examples/BalanceReactionEquations/BalanceReactionEquations.ipynb.rst
+++ b/doc/source/examples/BalanceReactionEquations/BalanceReactionEquations.ipynb.rst
@@ -137,23 +137,6 @@ Reaction that cannot be balanced
    reaction.coeffs=None
    reaction.message='Empty nullspace'
 
-Sympy method
-~~~~~~~~~~~~
-
-By default, a native method is used to compute the nullspace. Optionally, this can be done with sympy. The result should be the same.
-
-.. code:: ipython3
-
-   reactants = ["C9H8O4", "H2O"]
-   products = ["C2H4O2", "C7H6O3"]
-
-   reaction = balance(reactants, products, method="sympy")
-   print(reaction)
-
-::
-
-   1 C9H8O4 + 1 H2O => 1 C2H4O2 + 1 C7H6O3
-
 Balance reactions with charged species
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/examples/BalanceReactionEquations/BalanceReactionEquations.ipynb
+++ b/examples/BalanceReactionEquations/BalanceReactionEquations.ipynb
@@ -271,38 +271,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "573d002d-c30a-4e11-94f0-86859e363b29",
-   "metadata": {},
-   "source": [
-    "### Sympy method\n",
-    "\n",
-    "By default, a native method is used to compute the nullspace. Optionally, this can be done with sympy. The result should be the same."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "c305929a-4b21-490f-98bb-e0d5d4b2b6c7",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1 C9H8O4 + 1 H2O => 1 C2H4O2 + 1 C7H6O3\n"
-     ]
-    }
-   ],
-   "source": [
-    "reactants = [\"C9H8O4\", \"H2O\"]\n",
-    "products = [\"C2H4O2\", \"C7H6O3\"]\n",
-    "\n",
-    "reaction = balance(reactants, products, method=\"sympy\")\n",
-    "print(reaction)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "581fc1ff-be1d-414e-b01e-6abe85444ef2",
    "metadata": {},
    "source": [
@@ -313,7 +281,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "id": "aa2e24fa-5028-4fba-9d28-f400a5990d1e",
    "metadata": {},
    "outputs": [
@@ -344,7 +312,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "id": "c1adb17e-1793-4806-82e5-20fc9a1aaef8",
    "metadata": {},
    "outputs": [
@@ -375,7 +343,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "id": "99cc4afe-bd89-46cb-8f92-fe916c00971a",
    "metadata": {},
    "outputs": [
@@ -398,7 +366,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "id": "05eb5f30-5094-4060-bfdf-3670dc221608",
    "metadata": {},
    "outputs": [
@@ -426,7 +394,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "id": "e19963b2-b6d6-4e58-9013-fa75de730f09",
    "metadata": {},
    "outputs": [
@@ -463,7 +431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "id": "43994b96-56a1-4e4a-bc85-f0dcc818ebdc",
    "metadata": {},
    "outputs": [
@@ -493,7 +461,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "id": "d82e3433-a6a7-44d9-bdc6-47420fad3827",
    "metadata": {},
    "outputs": [],
@@ -537,7 +505,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "id": "9ed5a578-d06a-4d11-9bff-b782dde2661b",
    "metadata": {},
    "outputs": [
@@ -602,7 +570,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -616,7 +584,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.8.16"
   }
  },
  "nbformat": 4,

--- a/examples/BalanceReactionEquations/BalanceReactionEquations.py
+++ b/examples/BalanceReactionEquations/BalanceReactionEquations.py
@@ -82,17 +82,6 @@ print(f"{reaction.coeffs=}")
 print(f"{reaction.message=}")
 
 
-# ### Sympy method
-#
-# By default, a native method is used to compute the nullspace. Optionally, this can be done with sympy. The result should be the same.
-
-reactants = ["C9H8O4", "H2O"]
-products = ["C2H4O2", "C7H6O3"]
-
-reaction = balance(reactants, products, method="sympy")
-print(reaction)
-
-
 # ## Balance reactions with charged species
 #
 # Charges are printed within square brackets:


### PR DESCRIPTION
Removed sympy example
See Zoho AT1-I138

1. There are some differences between the sympy and the PLAMS eigenvectors.
   They are equally sparse, but Sympy seems to have more integers, so it looks a litle nicer.
2. Computing the eigenvectors with sympy is a little slower always
   (probably due to the conversion to a sympy matrix)
3. With sympy the balancing is sometimes a tiny bit faster
   but this does not outway the loss in the first step.

I now removed the sympy example, but it should stay in the unit tests.
