### PR TITLE
Fix test_plot_molecule

### DIFF
--- a/src/scm/plams/tools/plot.py
+++ b/src/scm/plams/tools/plot.py
@@ -335,7 +335,6 @@ def plot_molecule(
         ax.axis("on")
     else:
         ax.axis("off")
-        
 
     return ax
 

--- a/src/scm/plams/tools/plot.py
+++ b/src/scm/plams/tools/plot.py
@@ -331,10 +331,11 @@ def plot_molecule(
 
     plot_atoms(molecule, ax=ax, **kwargs)
 
-    if not keep_axis:
-        ax.axis("off")
-    else:
+    if keep_axis:
         ax.axis("on")
+    else:
+        ax.axis("off")
+        
 
     return ax
 

--- a/src/scm/plams/tools/plot.py
+++ b/src/scm/plams/tools/plot.py
@@ -333,6 +333,8 @@ def plot_molecule(
 
     if not keep_axis:
         ax.axis("off")
+    else:
+        ax.axis("on")
 
     return ax
 


### PR DESCRIPTION
Explicitly enable axes in plot_molecule() when keep_axis=True. Since ase.plot_atoms novel version  seems to modify the default value.