### PR TITLE
Use stdin mode for amsview through view function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ This changelog is effective from the 2025 releases.
 
 ## [Unreleased]
 
+### Changed
+* `view` function uses stdin mode for AMSview, reducing overhead for image creation
+
+## 2026.102
+
 ### Fixed
 * `view` checks backend availability lazily
 

--- a/src/scm/plams/tools/view.py
+++ b/src/scm/plams/tools/view.py
@@ -642,9 +642,8 @@ class _AMSViewManager:
     """
     Manage a persistent AMSview process that accepts commands over stdin.
 
-    This manager is thread-safe: calls to :meth:`view` are serialized through the
-    single AMSview process, so commands and temporary output files cannot
-    interleave.
+    This manager is thread-safe: render transactions are serialized through the
+    single AMSview process, so commands and temporary output files cannot interleave.
     """
 
     _instance: ClassVar[Optional[Self]] = None
@@ -657,13 +656,10 @@ class _AMSViewManager:
                 cls._instance = super().__new__(cls)
         return cls._instance
 
-    def __init__(self, config: Optional[ViewConfig] = None):
+    def __init__(self) -> None:
         if self._initialized:
-            if config is not None:
-                self.config = config
             return
 
-        self.config = config
         self._lock = RLock()
         self._proc: Optional[subprocess.Popen] = None
         self._initialized = True
@@ -731,14 +727,26 @@ class _AMSViewManager:
         with self._lock:
             input_path = _AmsViewBackend.write_system_input(system)
             img_path, cleanup_image = _AmsViewBackend.get_image_path(config)
+            final_img_path = img_path
+
+            if config.picture_path:
+                final_img_path = str(config.picture_path)
+                target_dir = os.path.dirname(os.path.abspath(final_img_path)) or None
+                fd, img_path = tempfile.mkstemp(suffix=".png", dir=target_dir)
+                os.close(fd)
+                os.remove(img_path)
+                cleanup_image = True
 
             try:
                 command = _AmsViewBackend.get_command(system, config, input_path, img_path)
-                previous_stat = os.stat(img_path) if os.path.exists(img_path) else None
                 self._send_command(command)
-                self._wait_for_image(img_path, config, previous_stat)
+                self._wait_for_image(img_path, config)
 
-                return _AmsViewBackend.load_and_resize_image(img_path, config)
+                img = _AmsViewBackend.load_and_resize_image(img_path, config)
+                if config.picture_path:
+                    os.replace(img_path, final_img_path)
+                    cleanup_image = False
+                return img
             except (BrokenPipeError, OSError, TimeoutError, RuntimeError) as ex:
                 self.close()
                 raise AMSExecutionError("amsview -stdin -batch", str(ex))
@@ -791,7 +799,7 @@ class _AMSViewManager:
             ),
         )
 
-    def _wait_for_image(self, img_path: str, config: ViewConfig, previous_stat: Optional[os.stat_result]) -> None:
+    def _wait_for_image(self, img_path: str, config: ViewConfig) -> None:
         start = time.time()
         poll_interval = 0.05
         while True:
@@ -800,12 +808,7 @@ class _AMSViewManager:
 
             if os.path.exists(img_path):
                 stat = os.stat(img_path)
-                changed = (
-                    previous_stat is None
-                    or stat.st_mtime_ns != previous_stat.st_mtime_ns
-                    or stat.st_size != previous_stat.st_size
-                )
-                if stat.st_size > 0 and changed and self._is_readable_image(img_path):
+                if stat.st_size > 0 and self._is_readable_image(img_path):
                     return
 
             if config.timeout is not None and time.time() - start >= config.timeout:

--- a/src/scm/plams/tools/view.py
+++ b/src/scm/plams/tools/view.py
@@ -1,6 +1,7 @@
 import os
 import re
 import subprocess
+import tempfile
 from typing import (
     Optional,
     Tuple,
@@ -19,7 +20,7 @@ from typing_extensions import Self
 
 import numpy as np
 from dataclasses import dataclass, replace
-from threading import Lock
+from threading import Lock, RLock
 import select
 import time
 from contextlib import contextmanager
@@ -510,7 +511,11 @@ class _AmsViewBackend(_ViewBackend):
 
     @classmethod
     def get_command(
-        cls, system: Union[Molecule, "ChemicalSystem"], config: ViewConfig, input_path: str, img_path: str
+        cls,
+        system: Union[Molecule, "ChemicalSystem"],
+        config: ViewConfig,
+        input_path: str,
+        img_path: str,
     ) -> List[str]:
         """
         Generate command for AMSview
@@ -568,10 +573,10 @@ class _AmsViewBackend(_ViewBackend):
         run_with_timeout(command, timeout=config.timeout)
 
     @classmethod
-    def generate_image(cls, system: Union[Molecule, "ChemicalSystem"], config: ViewConfig) -> "PilImage.Image":
-        from PIL import Image as PilImage
-
-        # Write temporary input file
+    def write_system_input(cls, system: Union[Molecule, "ChemicalSystem"]) -> str:
+        """
+        Write the system to a temporary AMS input file and return the path.
+        """
         with NamedTemporaryFile(mode="w", suffix=".in", delete=False) as input_file:
             input_path = input_file.name
             if isinstance(system, Molecule):
@@ -582,41 +587,245 @@ class _AmsViewBackend(_ViewBackend):
                 raise ValueError(
                     f"System must be a PLAMS Molecule or a ChemicalSystem, but was {type(system).__name__}"
                 )
+        return input_path
 
+    @staticmethod
+    def get_image_path(config: ViewConfig) -> Tuple[str, bool]:
+        """
+        Get the path to write an image to, and whether the caller should delete it.
+        """
         if config.picture_path:
-            img_path = str(config.picture_path)
-        else:
-            with NamedTemporaryFile(mode="wb", suffix=".png", delete=False) as img_file:
-                img_path = img_file.name
+            return str(config.picture_path), False
 
-        # Build and execute command
-        command = cls.get_command(system, config, input_path, img_path)
+        fd, img_path = tempfile.mkstemp(suffix=".png")
+        os.close(fd)
+        os.remove(img_path)
+        return img_path, True
+
+    @staticmethod
+    def load_and_resize_image(img_path: str, config: ViewConfig) -> "PilImage.Image":
+        """
+        Open image file and resize, making sure to maintain aspect ratio as AMSView may not generate with precise dimensions.
+        """
+        from PIL import Image as PilImage
+
+        img = PilImage.open(img_path)
+        img_width, img_height = img.size
+        aspect_ratio = img_width / img_height
+        return img.resize(
+            (config.width, int(np.ceil(config.width / aspect_ratio))),
+            resample=PilImage.Resampling.LANCZOS,
+            reducing_gap=3.0,
+        )
+
+    @classmethod
+    def generate_image(cls, system: Union[Molecule, "ChemicalSystem"], config: ViewConfig) -> "PilImage.Image":
+        if config.open_window:
+            save_config = replace(config, open_window=False, timeout=10)
+            img = _AMSViewManager()._generate_image(system, save_config)
+
+            input_path = cls.write_system_input(system)
+            command = cls.get_command(system, config, input_path, "")
+            try:
+                cls.run_command(command, config)
+            except subprocess.CalledProcessError as ex:
+                raise AMSExecutionError(" ".join(command), ex.stderr)
+            finally:
+                os.remove(input_path)
+
+            return img
+
+        return _AMSViewManager()._generate_image(system, config)
+
+
+class _AMSViewManager:
+    """
+    Manage a persistent AMSview process that accepts commands over stdin.
+
+    This manager is thread-safe: calls to :meth:`view` are serialized through the
+    single AMSview process, so commands and temporary output files cannot
+    interleave.
+    """
+
+    _instance: ClassVar[Optional[Self]] = None
+    _instance_lock: ClassVar[Lock] = Lock()
+    _initialized: bool = False
+
+    def __new__(cls: Type[Self], *args: Any, **kwargs: Any) -> Self:
+        with cls._instance_lock:
+            if cls._instance is None:
+                cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __init__(self, config: Optional[ViewConfig] = None):
+        if self._initialized:
+            if config is not None:
+                self.config = config
+            return
+
+        self.config = config
+        self._lock = RLock()
+        self._proc: Optional[subprocess.Popen] = None
+        self._initialized = True
+
+    def __enter__(self) -> "_AMSViewManager":
+        return self
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        self.close()
+
+    @property
+    def is_running(self) -> bool:
+        """
+        Check whether the managed AMSview process is currently running.
+        """
+        return self._proc is not None and self._proc.poll() is None
+
+    def close(self, timeout: float = 2.0) -> None:
+        """
+        Close the managed AMSview process, if it is running.
+
+        The shutdown is best effort: close stdin first to let AMSview notice EOF,
+        then terminate, and finally kill if it still does not exit.
+        """
+        with self._lock:
+            proc = self._proc
+            self._proc = None
+
+            if proc is None:
+                return
+
+            if proc.stdin is not None and not proc.stdin.closed:
+                try:
+                    proc.stdin.close()
+                except OSError:
+                    pass
+
+            if proc.poll() is not None:
+                return
+
+            try:
+                proc.terminate()
+                proc.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                try:
+                    proc.kill()
+                    proc.wait(timeout=timeout)
+                except (OSError, subprocess.TimeoutExpired):
+                    pass
+            except OSError:
+                pass
+
+    @classmethod
+    def close_instance(cls) -> None:
+        """
+        Close the singleton AMSview process, if it has been created.
+        """
+        with cls._instance_lock:
+            manager = cls._instance
+
+        if manager is not None:
+            manager.close()
+
+    def _generate_image(self, system: Union[Molecule, "ChemicalSystem"], config: ViewConfig) -> "PilImage.Image":
+        with self._lock:
+            input_path = _AmsViewBackend.write_system_input(system)
+            img_path, cleanup_image = _AmsViewBackend.get_image_path(config)
+
+            try:
+                command = _AmsViewBackend.get_command(system, config, input_path, img_path)
+                previous_stat = os.stat(img_path) if os.path.exists(img_path) else None
+                self._send_command(command)
+                self._wait_for_image(img_path, config, previous_stat)
+
+                return _AmsViewBackend.load_and_resize_image(img_path, config)
+            except (BrokenPipeError, OSError, TimeoutError, RuntimeError) as ex:
+                self.close()
+                raise AMSExecutionError("amsview -stdin -batch", str(ex))
+            finally:
+                os.remove(input_path)
+                if cleanup_image and os.path.exists(img_path):
+                    os.remove(img_path)
+
+    def _send_command(self, command: List[str]) -> None:
+        self._ensure_started()
+        if self._proc is None or self._proc.stdin is None:
+            raise RuntimeError("AMSview process has no stdin")
+        if self._proc.poll() is not None:
+            raise RuntimeError("AMSview process is not running")
+
+        replacements = {
+            "\\": "\\\\",
+            '"': '\\"',
+            "$": "\\$",
+            "[": "\\[",
+            "]": "\\]",
+            "\n": "\\n",
+            "\r": "\\r",
+        }
+        quoted_args = []
+        for arg in command[1:]:
+            quoted = '"' + "".join(replacements.get(char, char) for char in str(arg)) + '"'
+            quoted_args.append(quoted)
+        stdin_command = " ".join(quoted_args) + "\n"
+        self._proc.stdin.write(stdin_command)
+        self._proc.stdin.flush()
+
+    def _ensure_started(self) -> None:
+        if self.is_running:
+            return
+
+        if self._proc is not None:
+            self.close()
+
+        self._proc = subprocess.Popen(
+            [os.path.expandvars("$AMSBIN/amsview"), "-stdin", "-batch"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            encoding="utf-8",
+            start_new_session=(os.name == "posix"),
+            creationflags=(
+                subprocess.CREATE_NO_WINDOW | subprocess.CREATE_NEW_PROCESS_GROUP if os.name == "nt" else 0  # type: ignore[attr-defined]
+            ),
+        )
+
+    def _wait_for_image(self, img_path: str, config: ViewConfig, previous_stat: Optional[os.stat_result]) -> None:
+        start = time.time()
+        poll_interval = 0.05
+        while True:
+            if self._proc is not None and self._proc.poll() is not None:
+                raise RuntimeError("AMSview process exited before writing image")
+
+            if os.path.exists(img_path):
+                stat = os.stat(img_path)
+                changed = (
+                    previous_stat is None
+                    or stat.st_mtime_ns != previous_stat.st_mtime_ns
+                    or stat.st_size != previous_stat.st_size
+                )
+                if stat.st_size > 0 and changed and self._is_readable_image(img_path):
+                    return
+
+            if config.timeout is not None and time.time() - start >= config.timeout:
+                raise TimeoutError(f"AMSview did not write image '{img_path}' within {config.timeout} seconds")
+
+            time.sleep(poll_interval)
+
+    @staticmethod
+    def _is_readable_image(img_path: str) -> bool:
+        from PIL import Image as PilImage, UnidentifiedImageError
+
         try:
-            # For open-window, we run command twice, once to generate the image and the second to view
-            # as both cannot be combined without the window auto-closing
-            if config.open_window:
-                save_config = replace(config, open_window=False, timeout=10)
-                save_command = cls.get_command(system, save_config, input_path, img_path)
-                cls.run_command(save_command, save_config)
-            cls.run_command(command, config)
+            with PilImage.open(img_path) as img:
+                img.verify()
+            return True
+        except (OSError, UnidentifiedImageError):
+            return False
 
-            # Open image file and resize, making sure to maintain aspect ratio as AMSView may not generate with precise dimensions
-            img = PilImage.open(img_path)
-            img_width, img_height = img.size
-            aspect_ratio = img_width / img_height
-            resized_img = img.resize(
-                (config.width, int(np.ceil(config.width / aspect_ratio))),
-                resample=PilImage.Resampling.LANCZOS,
-                reducing_gap=3.0,
-            )
-        except subprocess.CalledProcessError as ex:
-            raise AMSExecutionError(" ".join(command), ex.stderr)
-        finally:
-            os.remove(input_path)
-            if not config.picture_path:
-                os.remove(img_path)
 
-        return resized_img
+atexit.register(_AMSViewManager.close_instance)
 
 
 class _AmsViewXvfbBackend(_AmsViewBackend):
@@ -642,7 +851,21 @@ class _AmsViewXvfbBackend(_AmsViewBackend):
         # do not open the AMSview window with xvfb, otherwise it will hang
         if config.open_window:
             config = replace(config, open_window=False, timeout=10)
-        return super().generate_image(system, config)
+
+        input_path = cls.write_system_input(system)
+        img_path, cleanup_image = cls.get_image_path(config)
+
+        command = cls.get_command(system, config, input_path, img_path)
+        try:
+            cls.run_command(command, config)
+
+            return cls.load_and_resize_image(img_path, config)
+        except subprocess.CalledProcessError as ex:
+            raise AMSExecutionError(" ".join(command), ex.stderr)
+        finally:
+            os.remove(input_path)
+            if cleanup_image and os.path.exists(img_path):
+                os.remove(img_path)
 
 
 class _XvfbManager:

--- a/unit_tests/test_basejob.py
+++ b/unit_tests/test_basejob.py
@@ -544,7 +544,8 @@ sleep 0.0 && sed 's/input/output/g' plamsjob.in
         with patch("scm.plams.core.functions._logger", logger):
             with patch("sys.stdout", new_callable=StringIO) as mock_stdout:
                 job1 = DummySingleJob(cmd="not_a_cmd")
-                job2 = DummySingleJob(cmd="x\n" * 50)
+                missing_cmd = "plams_missing_command_for_stdout_test"
+                job2 = DummySingleJob(cmd=f"{missing_cmd}\n" * 50)
 
                 job1.run()
                 job2.run()
@@ -556,7 +557,7 @@ sleep 0.0 && sed 's/input/output/g' plamsjob.in
                     re.DOTALL,
                 )
                 assert re.match(
-                    f".*Error message for job {job2.name} was:.* 3: x: (command ){{0,1}}not found.* 32: x: (command ){{0,1}}not found.*(see output for full error)",
+                    f".*Error message for job {job2.name} was:.* 3: {missing_cmd}: (command ){{0,1}}not found.* 32: {missing_cmd}: (command ){{0,1}}not found.*(see output for full error)",
                     stdout,
                     re.DOTALL,
                 )

--- a/unit_tests/test_tools_view.py
+++ b/unit_tests/test_tools_view.py
@@ -511,17 +511,27 @@ class TestAMSViewManager:
         img_path = tmp_path / "image.png"
         PilImage.new("RGB", (1, 1)).save(img_path)
 
-        manager._wait_for_image(str(img_path), ViewConfig(timeout=1), None)
+        manager._wait_for_image(str(img_path), ViewConfig(timeout=1))
 
-    def test_wait_for_image_rejects_unchanged_existing_picture_path(self, tmp_path):
+    def test_existing_picture_path_is_replaced_from_temp_render(self, water, tmp_path):
         manager = _AMSViewManager()
-        manager._proc = _FakeProcess()
         img_path = tmp_path / "image.png"
-        PilImage.new("RGB", (1, 1)).save(img_path)
-        previous_stat = os.stat(img_path)
+        PilImage.new("RGB", (1, 1), color="red").save(img_path)
+        image = MagicMock()
 
-        with pytest.raises(TimeoutError):
-            manager._wait_for_image(str(img_path), ViewConfig(timeout=0), previous_stat)
+        def write_render(path, config):
+            assert path != str(img_path)
+            PilImage.new("RGB", (1, 1), color="blue").save(path)
+
+        with patch.object(manager, "_send_command") as mock_send_command, patch.object(
+            manager, "_wait_for_image", side_effect=write_render
+        ), patch.object(_AmsViewBackend, "load_and_resize_image", return_value=image):
+            actual = manager._generate_image(water, ViewConfig(timeout=1, picture_path=img_path))
+
+        assert actual is image
+        command = mock_send_command.call_args.args[0]
+        assert command[command.index("-save") + 1] != str(img_path)
+        assert PilImage.open(img_path).getpixel((0, 0)) == (0, 0, 255)
 
     def test_wait_for_image_waits_until_image_is_readable(self, tmp_path):
         manager = _AMSViewManager()
@@ -538,7 +548,7 @@ class TestAMSViewManager:
             return True
 
         with patch.object(manager, "_is_readable_image", side_effect=make_readable):
-            manager._wait_for_image(str(img_path), ViewConfig(timeout=1), None)
+            manager._wait_for_image(str(img_path), ViewConfig(timeout=1))
 
     def test_close_instance_closes_singleton(self):
         manager = _AMSViewManager()

--- a/unit_tests/test_tools_view.py
+++ b/unit_tests/test_tools_view.py
@@ -1,7 +1,11 @@
 import os
+import subprocess
 import pytest
+import threading
+import time
 from unittest.mock import patch, MagicMock
 import numpy as np
+from PIL import Image as PilImage
 
 from scm.plams.interfaces.adfsuite.errors import AMSExecutionError
 from scm.plams.interfaces.adfsuite.ams import AMSJob
@@ -9,6 +13,7 @@ from scm.plams.interfaces.molecule.rdkit import from_smiles
 from scm.plams.tools.view import (
     view,
     ViewConfig,
+    _AMSViewManager,
     _AmsViewBackend,
     _AmsViewXvfbBackend,
     _XvfbManager,
@@ -134,10 +139,7 @@ class TestAmsViewBackend:
 
     def test_check_available(self, monkeypatch):
         monkeypatch.setenv("AMSBIN", "test/ams")
-        with patch("subprocess.run") as mock_run:
-            response = MagicMock()
-            response.stderr = "something went wrong"
-            mock_run.return_value = response
+        with patch.object(_AMSViewManager, "_generate_image", side_effect=RuntimeError("something went wrong")):
             with pytest.raises(AMSExecutionError):
                 self.backend.check_available()
 
@@ -189,6 +191,27 @@ class TestAmsViewBackend:
 
         command = str.join(" ", command[1:])
         assert command == expected
+
+    def test_open_window_saves_with_manager_then_opens_window(self, water, tmp_path):
+        if self.backend is not _AmsViewBackend:
+            pytest.skip("open_window is disabled for this backend")
+
+        input_path = tmp_path / "water.in"
+        input_path.write_text("")
+        image = MagicMock()
+
+        with patch.object(_AMSViewManager, "_generate_image", return_value=image) as mock_generate, patch.object(
+            self.backend, "write_system_input", return_value=str(input_path)
+        ), patch.object(self.backend, "run_command") as mock_run_command:
+            actual = self.backend.generate_image(water, ViewConfig(open_window=True))
+
+        assert actual is image
+        save_config = mock_generate.call_args.args[1]
+        assert not save_config.open_window
+        assert save_config.timeout == 10
+        command, open_config = mock_run_command.call_args.args
+        assert open_config.open_window
+        assert "-save" not in command
 
     @pytest.mark.parametrize(
         "normal_basis, normal, lattice, expected",
@@ -279,6 +302,251 @@ class TestAmsViewBackend:
     def test_get_view_plane_with_unhappy_direction(self, direction, water):
         with pytest.raises(ValueError):
             self.backend.get_view_plane(water, ViewConfig(direction=direction))
+
+
+class _FakeStdin:
+
+    def __init__(self, fail_on_write=False):
+        self.commands = []
+        self.closed = False
+        self.fail_on_write = fail_on_write
+
+    def write(self, data):
+        if self.fail_on_write:
+            raise BrokenPipeError("broken pipe")
+        self.commands.append(data)
+
+    def flush(self):
+        pass
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeProcess:
+
+    def __init__(self, returncode=None, fail_on_write=False, wait_raises=False):
+        self.returncode = returncode
+        self.stdin = _FakeStdin(fail_on_write=fail_on_write)
+        self.terminated = False
+        self.killed = False
+        self.wait_raises = wait_raises
+
+    def poll(self):
+        return self.returncode
+
+    def terminate(self):
+        self.terminated = True
+
+    def kill(self):
+        self.killed = True
+        self.returncode = -9
+
+    def wait(self, timeout=None):
+        if self.wait_raises:
+            raise subprocess.TimeoutExpired("amsview", timeout)
+        self.returncode = 0
+
+
+class TestAMSViewManager:
+
+    @pytest.fixture(autouse=True)
+    def close_singleton(self):
+        _AMSViewManager.close_instance()
+        yield
+        _AMSViewManager.close_instance()
+
+    def test_singleton(self):
+        assert _AMSViewManager() is _AMSViewManager()
+
+    def test_reuses_process(self, water):
+        manager = _AMSViewManager()
+        proc = _FakeProcess()
+        image = MagicMock()
+
+        with patch("subprocess.Popen", return_value=proc) as mock_popen, patch.object(
+            _AMSViewManager, "_wait_for_image"
+        ), patch.object(_AmsViewBackend, "load_and_resize_image", return_value=image):
+            assert manager._generate_image(water, ViewConfig(timeout=1)) is image
+            assert manager._generate_image(water, ViewConfig(timeout=1)) is image
+
+        assert mock_popen.call_count == 1
+        assert proc.stdin.commands[0].startswith('"')
+        assert "-save" in proc.stdin.commands[0]
+        assert len(proc.stdin.commands) == 2
+
+    def test_restarts_dead_process_on_next_call(self, water):
+        manager = _AMSViewManager()
+        dead_proc = _FakeProcess(returncode=1)
+        live_proc = _FakeProcess()
+
+        with patch("subprocess.Popen", side_effect=[dead_proc, live_proc]) as mock_popen, patch.object(
+            _AMSViewManager, "_wait_for_image"
+        ), patch.object(_AmsViewBackend, "load_and_resize_image", return_value=MagicMock()):
+            manager._ensure_started()
+            manager._generate_image(water, ViewConfig(timeout=1))
+
+        assert mock_popen.call_count == 2
+        assert len(live_proc.stdin.commands) == 1
+
+    def test_broken_stdin_closes_and_raises(self, water):
+        manager = _AMSViewManager()
+        broken_proc = _FakeProcess(fail_on_write=True)
+
+        with patch("subprocess.Popen", return_value=broken_proc) as mock_popen, patch.object(
+            _AMSViewManager, "_wait_for_image"
+        ):
+            with pytest.raises(AMSExecutionError):
+                manager._generate_image(water, ViewConfig(timeout=1))
+
+        assert mock_popen.call_count == 1
+        assert broken_proc.terminated
+        assert manager._proc is None
+
+    def test_timeout_closes_and_raises(self, water):
+        manager = _AMSViewManager()
+        proc = _FakeProcess()
+
+        with patch("subprocess.Popen", return_value=proc) as mock_popen, patch.object(
+            _AMSViewManager, "_wait_for_image", side_effect=TimeoutError("timeout")
+        ):
+            with pytest.raises(AMSExecutionError):
+                manager._generate_image(water, ViewConfig(timeout=1))
+
+        assert mock_popen.call_count == 1
+        assert proc.terminated
+        assert manager._proc is None
+
+    def test_close_terminates_then_kills_if_needed(self):
+        manager = _AMSViewManager()
+        proc = _FakeProcess(wait_raises=True)
+        manager._proc = proc
+
+        manager.close(timeout=0.01)
+        manager.close(timeout=0.01)
+
+        assert proc.stdin.closed
+        assert proc.terminated
+        assert proc.killed
+        assert manager._proc is None
+
+    def test_close_allows_later_restart(self, water):
+        manager = _AMSViewManager()
+        first_proc = _FakeProcess()
+        second_proc = _FakeProcess()
+
+        with patch("subprocess.Popen", side_effect=[first_proc, second_proc]) as mock_popen, patch.object(
+            _AMSViewManager, "_wait_for_image"
+        ), patch.object(_AmsViewBackend, "load_and_resize_image", return_value=MagicMock()):
+            manager._generate_image(water, ViewConfig(timeout=1))
+            manager.close()
+            manager._generate_image(water, ViewConfig(timeout=1))
+
+        assert mock_popen.call_count == 2
+        assert first_proc.terminated
+        assert len(second_proc.stdin.commands) == 1
+
+    def test_context_manager_closes(self):
+        proc = _FakeProcess()
+        with patch("subprocess.Popen", return_value=proc):
+            with _AMSViewManager() as manager:
+                manager._ensure_started()
+
+        assert proc.terminated
+
+    def test_thread_safe_generate_image(self, tmp_path):
+        manager = _AMSViewManager()
+        active = 0
+        max_active = 0
+        temp_paths = [tmp_path / f"{idx}.in" for idx in range(3)]
+        for path in temp_paths:
+            path.write_text("")
+
+        def send_command(command):
+            nonlocal active, max_active
+            active += 1
+            max_active = max(max_active, active)
+            time.sleep(0.05)
+            active -= 1
+
+        with patch.object(
+            _AmsViewBackend, "write_system_input", side_effect=[str(path) for path in temp_paths]
+        ), patch.object(
+            _AmsViewBackend, "get_image_path", return_value=(str(tmp_path / "image.png"), False)
+        ), patch.object(
+            manager, "_send_command", side_effect=send_command
+        ), patch.object(
+            manager, "_wait_for_image"
+        ), patch.object(
+            _AmsViewBackend, "load_and_resize_image", return_value=MagicMock()
+        ):
+            threads = [
+                threading.Thread(
+                    target=manager._generate_image,
+                    args=(MagicMock(), ViewConfig(timeout=1, normal=(0.0, 0.0, 1.0))),
+                )
+                for _ in range(3)
+            ]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+
+        assert max_active == 1
+
+    def test_send_command_quotes_arguments(self):
+        manager = _AMSViewManager()
+        proc = _FakeProcess()
+        manager._proc = proc
+
+        manager._send_command(
+            ["/ams/bin/amsview", "path with spaces/file.in", "-viewplane", "0 0 1", "-labelcolor", "#00AAFF"]
+        )
+
+        assert proc.stdin.commands[0] == '"path with spaces/file.in" "-viewplane" "0 0 1" "-labelcolor" "#00AAFF"\n'
+
+    def test_wait_for_image_accepts_fast_completed_render(self, tmp_path):
+        manager = _AMSViewManager()
+        manager._proc = _FakeProcess()
+        img_path = tmp_path / "image.png"
+        PilImage.new("RGB", (1, 1)).save(img_path)
+
+        manager._wait_for_image(str(img_path), ViewConfig(timeout=1), None)
+
+    def test_wait_for_image_rejects_unchanged_existing_picture_path(self, tmp_path):
+        manager = _AMSViewManager()
+        manager._proc = _FakeProcess()
+        img_path = tmp_path / "image.png"
+        PilImage.new("RGB", (1, 1)).save(img_path)
+        previous_stat = os.stat(img_path)
+
+        with pytest.raises(TimeoutError):
+            manager._wait_for_image(str(img_path), ViewConfig(timeout=0), previous_stat)
+
+    def test_wait_for_image_waits_until_image_is_readable(self, tmp_path):
+        manager = _AMSViewManager()
+        manager._proc = _FakeProcess()
+        img_path = tmp_path / "image.png"
+        img_path.write_bytes(b"not yet a png")
+        calls = [0]
+
+        def make_readable(path):
+            calls[0] += 1
+            if calls[0] == 1:
+                return False
+            PilImage.new("RGB", (1, 1)).save(path)
+            return True
+
+        with patch.object(manager, "_is_readable_image", side_effect=make_readable):
+            manager._wait_for_image(str(img_path), ViewConfig(timeout=1), None)
+
+    def test_close_instance_closes_singleton(self):
+        manager = _AMSViewManager()
+
+        with patch.object(manager, "close") as mock_close:
+            _AMSViewManager.close_instance()
+
+        mock_close.assert_called_once()
 
 
 class TestAmsViewXvfbBackend(TestAmsViewBackend):


### PR DESCRIPTION
Add an `_AMSViewManager` class which launches AMSview and manages its lifecycle. 

This allows successive calls to `view` to reuse the same AMSview process, and remove the startup overhead each time this is called.

This speeds up the rendering significantly.