### PR TITLE
Rosa Bulo (REB) SCMSUITE-- SO107 (Zoho-AB1-I10): input_to_settings no…

### DIFF
--- a/src/scm/plams/interfaces/adfsuite/inputparser.py
+++ b/src/scm/plams/interfaces/adfsuite/inputparser.py
@@ -221,7 +221,7 @@ def input_to_settings(
         return input_settings, lines
 
     input_parser = parser or InputParserFacade()
-    if program in ["ams", "acerxn"]:
+    if program in ["ams", "acerxn", "conformers"]:
         # Settings for the program are special:
         # * Root level input needs to go under settings.input.ams.
         # * Engine block needs to go  to settings.input.%engine% where


### PR DESCRIPTION
…w works for conformers

- conformers, like acerxn uses the 'ams' key in the input settings, which is why input_to_settings failed before.