### PR TITLE
Introducing generic typing in MultiJob for self.children

### DIFF
--- a/src/scm/plams/core/basejob.py
+++ b/src/scm/plams/core/basejob.py
@@ -836,9 +836,9 @@ class MultiJob(Job, Generic[J]):
     Private attributes ``_active_children`` and ``_lock`` are essential for proper parallel execution. Please do not modify them.
     """
 
-    def __init__(self, children: Optional[List[J]] = None, childrunner: Optional["JobRunner"] = None, **kwargs: Any):
+    def __init__(self, children: Optional[Union[List[J], Dict[str, J]]] = None, childrunner: Optional["JobRunner"] = None, **kwargs: Any):
         Job.__init__(self, **kwargs)
-        self.children: List[J] = [] if children is None else children
+        self.children: Union[List[J], Dict[str, J]] = [] if children is None else children
         self.childrunner = childrunner
         self._active_children = 0
         self._lock = threading.Lock()

--- a/src/scm/plams/core/basejob.py
+++ b/src/scm/plams/core/basejob.py
@@ -21,6 +21,8 @@ from typing import (
     Any,
     Iterator,
     Set,
+    Generic,
+    cast,
 )
 from typing_extensions import ParamSpec, ParamSpecKwargs, Concatenate
 from abc import ABC, abstractmethod
@@ -810,7 +812,7 @@ class SingleJob(Job):
 # ===========================================================================
 
 
-class MultiJob(Job):
+class MultiJob(Job, Generic[J]):
     """Concrete class representing a job that is a container for other jobs.
 
     In addition to constructor arguments and attributes defined by |Job|, the constructor of this class accepts two keyword arguments:
@@ -834,14 +836,14 @@ class MultiJob(Job):
     Private attributes ``_active_children`` and ``_lock`` are essential for proper parallel execution. Please do not modify them.
     """
 
-    def __init__(self, children: Optional[List[Job]] = None, childrunner: Optional["JobRunner"] = None, **kwargs: Any):
+    def __init__(self, children: Optional[List[J]] = None, childrunner: Optional["JobRunner"] = None, **kwargs: Any):
         Job.__init__(self, **kwargs)
-        self.children: List[Job] = [] if children is None else children
+        self.children: List[J] = [] if children is None else children
         self.childrunner = childrunner
         self._active_children = 0
         self._lock = threading.Lock()
 
-    def new_children(self) -> Optional[Union[List[Job], Dict[str, Job]]]:
+    def new_children(self) -> Optional[Union[List[J], Dict[str, J]]]:
         """Generate new children jobs.
 
         This method is useful when some of children jobs are not known beforehand and need to be generated based on other children jobs, like for example in any kind of self-consistent procedure.
@@ -860,7 +862,7 @@ class MultiJob(Job):
         """Check if the execution of this instance was successful, by calling :meth:`Job.ok` of all the children jobs."""
         return all([child.ok() for child in self])
 
-    def other_jobs(self) -> Generator[Job, None, None]:
+    def other_jobs(self) -> Generator[J, None, None]:
         """Iterate through other jobs that belong to this |MultiJob|, but are not in ``children``.
 
         Sometimes |prerun| or |postrun| methods create and run some small jobs that don't end up in ``children`` collection, but are still considered a part of a |MultiJob| instance (their ``parent`` atribute points to the |MultiJob| and their working folder is inside MultiJob's working folder). This method provides an iterator that goes through all such jobs.
@@ -871,9 +873,9 @@ class MultiJob(Job):
             if isinstance(attr, Job) and (
                 (hasattr(attr, "parent") and attr.parent == self) or not hasattr(attr, "parent")
             ):
-                yield attr
+                yield cast(J, attr)
 
-    def remove_child(self, job: Job) -> None:
+    def remove_child(self, job: J) -> None:
         """Remove *job* from children."""
 
         rm = None
@@ -893,7 +895,7 @@ class MultiJob(Job):
         for child in self:
             child.parent = self
 
-    def __iter__(self) -> Iterator[Job]:
+    def __iter__(self) -> Iterator[J]:
         """Iterate through ``children``. If it is a dictionary, iterate through its values."""
         if isinstance(self.children, dict):
             return iter(self.children.values())
@@ -923,7 +925,7 @@ class MultiJob(Job):
 
             if isinstance(new, dict) and isinstance(self.children, dict):
                 self.children.update(new)
-                it: Iterable[Job] = new.values()
+                it: Iterable[J] = new.values()
             elif isinstance(new, list) and isinstance(self.children, list):
                 self.children += new
                 it = new

--- a/src/scm/plams/core/basejob.py
+++ b/src/scm/plams/core/basejob.py
@@ -160,9 +160,7 @@ class Job(ABC):
 
     _result_type = Results
 
-    def __init__(
-        self, name: str = "plamsjob", settings: Optional[Settings] = None, depend: Optional[List["Job"]] = None
-    ):
+    def __init__(self, name: str = "plamsjob", settings: Optional[Settings] = None, depend: Optional[List["Job"]] = None):
         if os.path.sep in name:
             raise PlamsError(f"Job name cannot contain {os.path.sep}")
         self._status_log: List[Tuple[datetime.datetime, str]] = []
@@ -211,25 +209,18 @@ class Job(ABC):
         self._status_log.append((at, str(value)))
 
         # Send notification via callback if needed
-        on_status_change = (
-            getattr(getattr(self, "settings", JobSettings()), "on_status_change", None)
-            or get_config().job.on_status_change
-        )
+        on_status_change = getattr(getattr(self, "settings", JobSettings()), "on_status_change", None) or get_config().job.on_status_change
         if on_status_change is None:
             return
 
-        def safe_on_status_change(
-            cb: JobSettings.OnStatusChangeCallback, name: str, path: Optional[str], status: str, at: datetime.datetime
-        ) -> None:
+        def safe_on_status_change(cb: JobSettings.OnStatusChangeCallback, name: str, path: Optional[str], status: str, at: datetime.datetime) -> None:
             try:
                 cb(name=name, path=path, status=status, at=at)
             except Exception as e:
                 log(f"on_status_change callback execution raised {e}", 5)
 
         try:
-            future = _status_change_callback_threadpool.submit(
-                safe_on_status_change, on_status_change, self.name, self.path, str(value), at
-            )
+            future = _status_change_callback_threadpool.submit(safe_on_status_change, on_status_change, self.name, self.path, str(value), at)
             with _status_change_callback_lock:
                 _status_change_callback_futures.add(future)
             future.add_done_callback(lambda f: _status_change_callback_futures.discard(f))
@@ -245,9 +236,7 @@ class Job(ABC):
         """
         return self._status_log
 
-    def run(
-        self, jobrunner: Optional["JobRunner"] = None, jobmanager: Optional["JobManager"] = None, **kwargs: Any
-    ) -> Results:
+    def run(self, jobrunner: Optional["JobRunner"] = None, jobmanager: Optional["JobManager"] = None, **kwargs: Any) -> Results:
         """Run the job using *jobmanager* and *jobrunner* (or defaults, if ``None``). Other keyword arguments (*\\*\\*kwargs*) are stored in ``run`` branch of job's settings. Returned value is the |Results| instance associated with this job.
 
         .. warning::
@@ -314,17 +303,11 @@ class Job(ABC):
         if self.check():
             return None
 
-        return (
-            self._error_msg
-            if self._error_msg
-            else "Could not determine error message. Please check the output manually."
-        )
+        return self._error_msg if self._error_msg else "Could not determine error message. Please check the output manually."
 
     def get_path(self) -> Path:
         if self.path is None:
-            raise JobError(
-                f"'path' attribute of job '{self.name} is not yet initialized, typically because the job has not yet ran."
-            )
+            raise JobError(f"'path' attribute of job '{self.name} is not yet initialized, typically because the job has not yet ran.")
         return Path(self.path)
 
     @abstractmethod
@@ -742,9 +725,7 @@ class SingleJob(Job):
                 job.results.collect()
 
         if strict and job.__class__ != cls:
-            raise ValueError(
-                f"The loaded job is an instance of '{job.__class__.__name__}', whereas this method expects it to be a '{cls.__name__}'. Use `strict=False` to ignore this."
-            )
+            raise ValueError(f"The loaded job is an instance of '{job.__class__.__name__}', whereas this method expects it to be a '{cls.__name__}'. Use `strict=False` to ignore this.")
 
         return job
 
@@ -870,9 +851,7 @@ class MultiJob(Job, Generic[J]):
         Each attribute of this |MultiJob| that is of type |Job| and has it's parent pointing to this |MultiJob| is returned, in a random order.
         """
         for attr in self.__dict__.values():
-            if isinstance(attr, Job) and (
-                (hasattr(attr, "parent") and attr.parent == self) or not hasattr(attr, "parent")
-            ):
+            if isinstance(attr, Job) and ((hasattr(attr, "parent") and attr.parent == self) or not hasattr(attr, "parent")):
                 yield cast(J, attr)
 
     def remove_child(self, job: J) -> None:
@@ -930,9 +909,7 @@ class MultiJob(Job, Generic[J]):
                 self.children += new
                 it = new
             else:
-                raise JobError(
-                    f"ERROR in job {self.name}: 'new_children' returned a value incompatible with 'children'"
-                )
+                raise JobError(f"ERROR in job {self.name}: 'new_children' returned a value incompatible with 'children'")
 
             for child in it:
                 child.parent = self
@@ -957,7 +934,7 @@ class MultiJob(Job, Generic[J]):
         if self.status != JobStatus.CREATED:
             self.results.wait()
 
-        for child in [c for c in self.children] if isinstance(self.children, list) else self.children.values():
+        for child in [c for c in self.children] if isinstance(self.children, list) else list(self.children.values()):
             child.delete()
             self.remove_child(child)
 

--- a/src/scm/plams/core/basejob.py
+++ b/src/scm/plams/core/basejob.py
@@ -957,7 +957,7 @@ class MultiJob(Job, Generic[J]):
         if self.status != JobStatus.CREATED:
             self.results.wait()
 
-        for child in [c for c in self.children]:
+        for child in [c for c in self.children] if isinstance(self.children, list) else self.children.values():
             child.delete()
             self.remove_child(child)
 

--- a/src/scm/plams/core/basejob.py
+++ b/src/scm/plams/core/basejob.py
@@ -964,7 +964,7 @@ class MultiJob(Job, Generic[J]):
         super().delete()
 
     @classmethod
-    def apply_to_children(cls, job: Job, func: Callable[[Job], None], recursive: bool = False) -> None:
+    def apply_to_children(cls, job: J, func: Callable[[J], None], recursive: bool = False) -> None:
         """
         Apply the function ``func`` to all children of a |MultiJob| (not the job itself).
         This is a no-op if the job is a |SingleJob|.


### PR DESCRIPTION
Solves #398 about type errors because the self.children attribute in `MultiJob` was not generically typed.

# Changes

- Added Generic Job type to the `MultiJob` class, including the methods `new_children`, `other_jobs`, `remove_child`, and dunder method `__iter__`
- Changed the `self.children` type from `List[J]` to `Union[List[J], Dict[J]]`

No (new) tests have been written since these changes only affect the Python linter and typechecker in the text editor.