### PR TITLE
plams.view xvfb: fix display_number 0 truthiness SO--

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This changelog is effective from the 2025 releases.
 ### Fixed
 * Loading job `.dill` files where the molecule contains a `pathlib.Path` (e.g. `Molecule.properties.source`)
 * Possible recursion errors when pickling a molecule on Windows relating to `_as_array`
+* Xvfb backend for `view` function with 0 display value
 
 ## 2026.102
 

--- a/src/scm/plams/tools/view.py
+++ b/src/scm/plams/tools/view.py
@@ -1053,7 +1053,7 @@ class _XvfbManager:
         """
         Get current display value, if available
         """
-        return f":{self.display_number}" if self.display_number else None
+        return f":{self.display_number}" if self.display_number is not None else None
 
     @contextmanager
     def session(self, env: Optional[Dict[str, str]] = None) -> Generator[Dict[str, str], None, None]:


### PR DESCRIPTION
This fix lets me use amsview_xvfb in a podman container. Also needed on fix2026.