### PR TITLE
Rosa Bulo (REB) SCMSUITE-- SO107: Bugfix. Could only read single forc…

### DIFF
--- a/src/scm/plams/interfaces/adfsuite/ams.py
+++ b/src/scm/plams/interfaces/adfsuite/ams.py
@@ -1215,7 +1215,7 @@ class AMSResults(Results):
                     [p_components[3], p_components[4], p_components[5]],
                 ]
             )
-        elif p_components.shape == (3, 3):
+        elif p_components.shape == (3, 3):  # type: ignore[comparison-overlap]
             polarizability_matrix = p_components
         else:
             raise ValueError(

--- a/src/scm/plams/interfaces/adfsuite/crs.py
+++ b/src/scm/plams/interfaces/adfsuite/crs.py
@@ -267,7 +267,7 @@ class CRSResults(SCMResults):
         dict_species["NumRepMonmer"] = NumRepMonmer
         dict_species["NumStrucPerComp"] = NumStrucPerComp
 
-        if np.sum(Assoc) > 0:
+        if np.sum(Assoc) > 0:  # type: ignore[arg-type]
             Assoc_s_idx = self.readkf(section, "Assoc_s_idx")
             ReqCompIdxAssoc = self.readkf(section, "ReqCompIdxAssoc")
             NumReqCompAssoc = self.readkf(section, "NumReqCompAssoc")

--- a/src/scm/plams/interfaces/adfsuite/forcefieldparams.py
+++ b/src/scm/plams/interfaces/adfsuite/forcefieldparams.py
@@ -152,7 +152,7 @@ class ForceFieldPatch:
 
         return ret
 
-    def read_from_kf(self, kf: "KFFile") -> None:
+    def read_from_kf(self, kf: "KFFile", ipatch: int = 0) -> None:
         """
         Read patch infor from kf
         """
@@ -161,7 +161,7 @@ class ForceFieldPatch:
         npatches = kf.read_int("AMSResults", "Config.nPatches")
         patch = ForceFieldPatch()
         if npatches > 0:
-            patchtext = kf.read_string("AMSResults", "Config.FFPatch(1)")
+            patchtext = kf.read_string("AMSResults", f"Config.FFPatch({ipatch + 1})")
             patch += ForceFieldPatch(patchtext)
 
         for key in vars(patch):
@@ -298,8 +298,12 @@ def forcefield_params_from_kf(kf: "KFFile") -> Tuple[List[float], List[str], Opt
     types = [alltypes[i - 1] for i in indices]
 
     # Read the force field patch
-    patch = ForceFieldPatch()
-    patch.read_from_kf(kf)
-    if len(patch) == 0:
+    npatches = kf.read_int("AMSResults", "Config.nPatches")
+    if npatches == 0:
         return charges, types, None
+    patch = ForceFieldPatch()
+    for i in range(npatches):
+        p = ForceFieldPatch()
+        p.read_from_kf(kf, i)
+        patch += p
     return charges, types, patch

--- a/src/scm/plams/interfaces/adfsuite/forcefieldparams.py
+++ b/src/scm/plams/interfaces/adfsuite/forcefieldparams.py
@@ -297,7 +297,7 @@ def forcefield_params_from_kf(kf: "KFFile") -> Tuple[List[float], List[str], Opt
     indices = kf.read_ints("AMSResults", "AtomTyping.atomIndexToType")
     types = [alltypes[i - 1] for i in indices]
 
-    # Read the force field patch
+    # Read the force field patches
     npatches = kf.read_int("AMSResults", "Config.nPatches")
     if npatches == 0:
         return charges, types, None


### PR DESCRIPTION
…efieldpatch from RKF before

- An RKF can hold multiple AMBER forcefield patches, which are all needed to accurately run a calculation. Data extraction from RKF by PLAMS only extracted a single patch. This resulted in a bug in the atomtyping tool.