### PR TITLE
add support for forceTransAmides option in newer RDKit versions

### DIFF
--- a/src/scm/plams/interfaces/molecule/rdkit.py
+++ b/src/scm/plams/interfaces/molecule/rdkit.py
@@ -526,6 +526,7 @@ def get_conformations(
     EmbedParameters: str = "EmbedParameters",
     randomSeed: int = 1,
     best_rms: float = -1,
+    forceTransAmides: bool = False,
 ) -> Molecule: ...
 
 
@@ -543,6 +544,7 @@ def get_conformations(
     EmbedParameters: str = "EmbedParameters",
     randomSeed: int = 1,
     best_rms: float = -1,
+    forceTransAmides: bool = False,
 ) -> Union[List[Molecule], Molecule]: ...
 
 
@@ -559,6 +561,7 @@ def get_conformations(
     EmbedParameters: str = "EmbedParameters",
     randomSeed: int = 1,
     best_rms: float = -1,
+    forceTransAmides: bool = False,
 ) -> Union[List[Molecule], Molecule]:
     """
     Generates 3D conformation(s) for an rdkit_mol or a PLAMS Molecule
@@ -579,6 +582,7 @@ def get_conformations(
     :parameter list constraint_ats: List of atom indices to be constrained
     :parameter str EmbedParameters: Name of RDKit EmbedParameters class ('EmbedParameters', 'ETKDG')
     :parameter int randomSeed: The seed for the random number generator. If set to None the generated conformers will be non-deterministic.
+    :parameter bool forceTransAmides: Force amides, esters, and related structures into trans/oid conformations during embedding.
     :return: A molecule with hydrogens and 3D coordinates or a list of molecules if nconfs > 1
     :rtype: |Molecule| or list of PLAMS Molecules
     """
@@ -677,6 +681,8 @@ def get_conformations(
     param_obj = getattr(AllChem, EmbedParameters)()
     param_obj.pruneRmsThresh = rms
     param_obj.enforceChirality = enforceChirality
+    if hasattr(param_obj, "forceTransAmides"):
+        param_obj.forceTransAmides = forceTransAmides
     if useExpTorsionAnglePrefs != "default":  # The default (True of False) changes with rdkit versions
         param_obj.useExpTorsionAnglePrefs = True
     if constraint_ats is not None:


### PR DESCRIPTION
Discovered when doing the RDKit update in the amshome repo: newer RDKits have gained the forceTransAmides option. The default in RDKit is "True", but "False" is actually needed to replicate the old conformer generation. (With "True", more conformers are considered duplicates, so our conformer ensembles would shrink.)

Since we need to change the default in AMS, we need to drag the option through PLAMS.