### PR TITLE
Make iterative PackMol test deterministic with fixed seed SO---

### DIFF
--- a/unit_tests/test_packmol.py
+++ b/unit_tests/test_packmol.py
@@ -1004,7 +1004,7 @@ class TestPackMolAround:
         num_atoms = []
         box = empty
         for _ in range(6):
-            box = packmol_around(box, water, density=0.5)
+            box = packmol_around(box, water, density=0.5, seed=1)
             num_atoms.append(len(box))
 
         assert num_atoms == [51, 75, 87, 93, 96, 99]


### PR DESCRIPTION
Some seeds fail to pack a molecule in the final iterations. This fix makes sure the test passes deterministically.