### PR TITLE
Wei lin chen/crs builder review cleanup

### DIFF
--- a/doc/source/interfaces/crs.rst
+++ b/doc/source/interfaces/crs.rst
@@ -1,116 +1,122 @@
 COSMO-RS
 --------
 
-(*contributed by* `Bas van Beek <https://www.researchgate.net/profile/Bas_van_Beek>`_\)
-
 .. currentmodule:: scm.plams.interfaces.adfsuite.crs
 
 COSMO-RS can be run from PLAMS using the |CRSJob| class and the corresponding |CRSResults|,
 both respectively being subclasses of |SCMJob| and |SCMResults|.
 
-.. note:: There is also `a tutorial showing full code examples <../../COSMO-RS/PLAMS_COSMO-RS_scripting.html>`__ available in the COSMO-RS documentation.  There are several templates available that can easily be customized for other problem types, workflows, etc.
+.. note:: There is also `a tutorial showing full code examples <../../COSMO-RS/PLAMS_COSMO-RS_scripting.html>`__ available in the COSMO-RS documentation. There are several templates available that can easily be customized for other problem types, workflows, etc.
 
 Settings
 ~~~~~~~~
 
-For example, considering the following input file for a COSMO-RS
-sigma-profile calculation [`1 <../../COSMO-RS/Analysis.html#sigma-profile>`_]:
+A COSMO-RS job is configured through the PLAMS |Settings| object. For most
+workflows, use :meth:`CRSJob.input_builder` to create these settings. The input
+builder provides a property-specific interface and converts the builder state to
+|Settings| with ``to_settings()`` or directly to a :class:`CRSJob` with
+``to_job()``.
 
-.. code::
+For advanced workflows, you can also construct or modify |Settings| manually.
 
-    compound /path/to/file.t21
+
+Input builders
+^^^^^^^^^^^^^^
+
+The recommended way to prepare COSMO-RS input from PLAMS is
+:meth:`CRSJob.input_builder`. This method returns a property-specific input
+builder. The builder exposes the input keys, compound roles, and calculation
+modes supported by the selected property type.
+
+For example, the following COSMO-RS input performs a pure sigma-profile
+calculation:
+
+.. code-block:: none
+
+    compound /path/to/file.coskf
         frac1 1.0
     end
 
     property puresigmaprofile
         nprofile 50
-        pure
         sigmamax 0.025
     end
 
-    temperature 298.15
+The same input can be prepared with :meth:`CRSJob.input_builder`:
 
-The input file displayed above corresponds to the following settings:
+.. code-block:: python
 
-.. code:: python
+    from scm.plams import CRSJob
 
-    >>> from scm.plams import Settings, CRSJob
+    builder = CRSJob.input_builder("PURESIGMAPROFILE")
+    builder.nprofile = 50
+    builder.sigmamax = 0.025
+    builder.add_compound_from_adfcrs_database("Water.coskf")
 
-    >>> s = Settings()
+    job = builder.to_job()
+    results = job.run()
 
-    >>> s.input.compound._h = '/path/to/file.t21'
-    >>> s.input.compound.frac1 = 1.0
-    >>> s.input.property._h = 'puresigmaprofile'
-    >>> s.input.property.nprofile = 50
-    >>> s.input.property.sigmamax = 0.025
-    >>> s.input.property.pure = ''
-    >>> s.input.temperature = 298.15
+Use ``builder.describe()`` to inspect the input keys accepted by a builder:
 
-    >>> my_job = CRSJob(settings=s)
-    >>> my_results = my_job.run()
+.. code-block:: python
 
-Alternatively one can create a :class:`CRSJob` instance from a runscript created by,
-for example, the ADF GUI (``File -> Save as``).
+    for line in builder.describe(include_values=True):
+        print(line)
 
-.. code:: python
+Some property types support calculation modes. For example, solubility can be
+set up for a gas-phase solute using ``mode="gas"``:
 
-    >>> from scm.plams import CRSJob
+.. code-block:: python
 
-    >>> filename = 'path/to/my/crs/inputfile.run'
-    >>> my_job = CRSJob.from_inputfile(filename)
-    >>> my_results = my_job.run()
+    builder = CRSJob.input_builder("SOLUBILITY", mode="gas", temperature=298.15)
+    builder.add_solvent_from_adfcrs_database("Water.coskf", frac1=1.0)
+    builder.add_solute_from_adfcrs_database("Benzene.coskf")
+
+    settings = builder.to_settings()
+
+The supported methods can be inspected from Python:
+
+.. code-block:: python
+
+    CRSJob.methods()
 
 
 Settings with multiple compounds
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-More often than not one is interested in the properties of
-multi-component mixtures (*e.g.* a dissolved solute).
-In such cases one has to pass multiple ``compound`` blocks to
-the input file, which is somewhat problematic as Python dictionaries
-(including |Settings|) can only contain a set of unique keys.
+Many COSMO-RS property types require more than one compound. With
+:meth:`CRSJob.input_builder`, compounds are added with the role-specific methods
+supported by the selected property type. The builder checks that compounds are
+added with roles and counts supported by that property type.
 
-This problem can be resolved by changing the value of ``compound``
-from a |Settings| instance into a list of multiple |Settings| instances.
-Each item within this list is expanded into its own ``compound`` block
-once :meth:`CRSJob.run` creates the actual input file.
+For mixture properties, use ``add_compound()``:
 
-Example |Settings| with three compounds:
+.. code-block:: python
 
-.. code:: python
+    from scm.plams import CRSJob
 
-    >>> from scm.plams import Settings, CRSJob
+    builder = CRSJob.input_builder("TERNARYMIX", temperature=298.15)
 
-    >>> compound1, compound2, compound3 = Settings(), Settings(), Settings()
+    builder.add_compound_from_adfcrs_database("Water.coskf", frac1=0.33)
+    builder.add_compound_from_adfcrs_database("Ethanol.coskf", frac1=0.33)
+    builder.add_compound_from_adfcrs_database("Benzene.coskf", frac1=0.34)
 
-    >>> compound1._h = '/path/to/compound1.t21'
-    >>> compound1.frac1 = 0.33
-    >>> compound2._h = '/path/to/compound2.t21'
-    >>> compound2.frac1 = 0.33
-    >>> compound3._h = '/path/to/compound3.t21'
-    >>> compound3.frac1 = 0.33
+    job = builder.to_job()
+    results = job.run()
 
-    >>> s = Settings()
-    >>> s.input.compound = [compound1, compound2, compound3]
+For solvent and solute roles, use ``add_solvent()`` and ``add_solute()``:
 
-    >>> my_job = CRSJob(settings=s)
-    >>> my_results = my_job.run()
+.. code-block:: python
 
-Which yields the following input:
+    builder = CRSJob.input_builder("SOLUBILITY", temperature=298.15)
+    builder.add_solvent_from_adfcrs_database("Water.coskf", frac1=1.0)
+    builder.add_solute_from_adfcrs_database(
+        "Benzene.coskf",
+        meltingpoint=278.7,
+        hfusion=2.37,
+    )
 
-.. code::
-
-    compound /path/to/compound1.t21
-        frac1 0.33
-    end
-
-    compound /path/to/compound2.t21
-        frac1 0.33
-    end
-
-    compound /path/to/compound3.t21
-        frac1 0.33
-    end
+    settings = builder.to_settings()
 
 
 ADF and CRSJob
@@ -119,140 +125,66 @@ ADF and CRSJob
 A workflow is presented in the `ADF and COSMO-RS workflow Python example <../../PythonExamples/ams-crs-workflow/index.html>`__.
 In this workflow, we follow the usual procedure of generating the inputs required to run COSMO-RS and COSMO-SAC calculations.
 
-
-COSMO-RS Parameters
-~~~~~~~~~~~~~~~~~~~
-
-A large number of configurable parameters_ is available for COSMO-RS.
-If one is interested in running multiple jobs it can be useful to store the parameters
-in separate dictionary / |Settings| instance and update the Job settings as needed,
-double so if one wants to use multiple different parameter sets.
-
-An example is provided below with the default COSMO-RS parameters (*i.e.* ADF Combi2005):
-
-.. code:: python
-
-    >>> from scm.plams import Settings
-
-    # ADF Combi2005 COSMO-RS parameters
-    >>> adf_combi2005 = {
-    ...     'crsparameters': {
-    ...         '_1': 'HB_HNOF',
-    ...         '_2': 'HB_TEMP',
-    ...         '_3': 'FAST',
-    ...         '_4': 'COMBI2005',
-    ...         'rav': 0.400,
-    ...         'aprime': 1510.0,
-    ...         'fcorr': 2.802,
-    ...         'chb': 8850.0,
-    ...         'sigmahbond': 0.00854,
-    ...         'aeff': 6.94,
-    ...         'lambda': 0.130,
-    ...         'omega': -0.212,
-    ...         'eta': -9.65,
-    ...         'chortf': 0.816
-    ...     },
-    ...     'dispersion': {
-    ...         'H': -0.0340,
-    ...         'C': -0.0356,
-    ...         'N': -0.0224,
-    ...         'O': -0.0333,
-    ...         'F': -0.026,
-    ...         'Si': -0.04,
-    ...         'P': -0.045,
-    ...         'S': -0.052,
-    ...         'Cl': -0.0485,
-    ...         'Br': -0.055,
-    ...         'I': -0.062
-    ...     }
-    ... }
-
-    >>> s_list = [Settings(), Settings(), Settings()]
-    >>> for s in s_list:
-    ...     s.input.update(adf_combi2005)
-
-    >>> print([s.input == adf_combi2005 for s in s_list])
-    [True, True, True]
-
 .. _parameters: ../../COSMO-RS/COSMO-RS_and_COSMO-SAC_parameters.html
 
 
-Data analyses and plotting
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+Data analysis
+~~~~~~~~~~~~~
 
-As COSMO-RS can produce a large variety of data series,
-a number of specialized methods are available in the :class:`CRSResults` for their extraction and analysis.
-The resulting data is stored in either a dictionary of NumPy arrays or (optionally) a `Pandas DataFrame`_.
+Use :meth:`CRSResults.get_results` to read the results section of a ``.crskf``
+file as a dictionary. If no section is supplied, PLAMS uses the property section
+from the most recent calculation.
 
-The extracted data can be further customized by altering the ``subsection`` argument.
-For example, by default :meth:`CRSResults.get_solubility` will extract the solubility in mol solute
-per liter solvent (``"subsection=mol_per_L_solvent"``). This can be changed in, for example,
-gram per liter solvent (``"subsection=m_per_L_solvent"``) or the solute mass fraction (``"massfrac"``).
+.. code-block:: python
 
-A complete overview of all available sections and subsections can be acquired
-by calling the :meth:`.KFFile.get_skeleton` method of the KF binary file
-(*e.g.* :code:`print(my_results._kf.get_skeleton())`).
+    from scm.plams import CRSJob
 
-============================ =======================================
-Quantity                     Method for data extraction
-============================ =======================================
-`Sigma profile`_             :meth:`CRSResults.get_sigma_profile`
-`Sigma potential`_           :meth:`CRSResults.get_sigma_potential`
-`Vapor pressure`_            :meth:`CRSResults.get_vapor_pressure`
-`Boiling point`_             :meth:`CRSResults.get_boiling_point`
-`Solubility`_                :meth:`CRSResults.get_solubility`
-`Binary mixture`_            :meth:`CRSResults.get_bi_mixture`
-`Ternary mixtures`_          :meth:`CRSResults.get_tri_mixture`
-`Solvents composition line`_ :meth:`CRSResults.get_composition_line`
-============================ =======================================
+    builder = CRSJob.input_builder("PURESIGMAPROFILE")
+    builder.nprofile = 50
+    builder.sigmamax = 0.025
+    builder.add_compound_from_adfcrs_database("Water.coskf")
 
-If the `Matplotlib <https://matplotlib.org/>`_ package is installed than the resulting data can easily plotted by passing
-it to the :meth:`CRSResults.plot` method (*e.g.* :code:`CRSResults.plot(my_sigma_profile)`):
+    results = builder.to_job().run()
+    data = results.get_results()
 
-.. code:: python
+    print(data["section"])
+    print(data["filename"])
+    print(data["chdval"])
+    print(data["profil"])
 
-    >>> from scm.plams import Settings, CRSJob
-    >>> import numpy as np
+A complete overview of all available sections and keys can be printed from the
+KF file skeleton:
 
-    >>> s = Settings()
+.. code-block:: python
 
-    >>> s.input.compound._h = '/path/to/Water.coskf'
-    >>> s.input.compound.frac1 = 1.0
-    >>> s.input.property._h = 'puresigmaprofile'
-    >>> s.input.property.nprofile = 50
-    >>> s.input.property.sigmamax = 0.025
-    >>> s.input.property.pure = ''
-    >>> s.input.temperature = 298.15
-
-    >>> my_job = CRSJob(settings=s)
-    >>> my_results = my_job.run()
-
-    >>> my_sigma_profile = my_results.get_sigma_profile()
-    >>> with np.printoptions(threshold=0, edgeitems=5):
-    ...     print(my_sigma_profile)
-    {'Water.coskf': array([0., 0., 0., 0., 0., ..., 0., 0., 0., 0., 0.]),
-     'σ (e/A**2)': array([-0.25, -0.24, -0.23, -0.22, -0.21, ...,  0.21,  0.22,  0.23,  0.24, 0.25])}
-
-    >>> my_results.plot(my_sigma_profile)
-
-.. image:: ../_static/sigma_profile.png
-
-
-.. _`Sigma profile`: ../../COSMO-RS/Analysis.html#sigma-profile
-.. _`Sigma potential`: ../../COSMO-RS/Analysis.html#sigma-potential
-.. _`Vapor pressure`: ../../COSMO-RS/Properties.html#vapor-pressure
-.. _`Boiling point`: ../../COSMO-RS/Properties.html#boiling-point
-.. _`Solubility`: ../../COSMO-RS/Properties.html#solubility
-.. _`Binary mixture`: ../../COSMO-RS/Properties.html#binary-mixture-vle-lle
-.. _`Ternary mixtures`: ../../COSMO-RS/Properties.html#ternary-mixture-vle-lle
-.. _`Solvents composition line`: ../../COSMO-RS/Properties.html#solvents-s1-s2-composition-line
-
-.. _`Pandas DataFrame`: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html
+    print(results._kf.get_skeleton())
 
 
 API
 ~~~
 
 .. autoclass:: CRSJob
+    :no-private-members:
+    :no-special-members:
+    :exclude-members: input_builder
+
+    .. py:staticmethod:: CRSJob.input_builder(property_type, *, method="COSMO-RS", mode=None, **kwargs)
+
+        Return a property-specific CRS input builder.
+
+        The ``property_type`` argument selects the builder class. The returned
+        builder validates the keys, modes, and compound roles supported by that
+        property type.
 
 .. autoclass:: CRSResults
+    :members:
+        get_multispecies_dist,
+        get_structure_energy,
+        get_activity_coefficient,
+        get_energy,
+        get_sigma_profile,
+        get_sigma_potential,
+        get_results,
+        get_prop_names
+    :no-private-members:
+    :no-special-members:

--- a/src/scm/plams/interfaces/adfsuite/crs.py
+++ b/src/scm/plams/interfaces/adfsuite/crs.py
@@ -139,6 +139,13 @@ class CRSResults(SCMResults):
         except:
             nstruct = ncomp
 
+        try:
+            nmoment = cast(int, self.readkf(section, "nmoment"))
+            nhb_moment = cast(int, self.readkf(section, "nhb_moment"))
+        except:
+            nmoment = 0
+            nhb_moment = 0
+
         np_dict: Dict[str, Any] = {"section": section}
         np_dict["ncomp"] = ncomp
         chunk_length = 160
@@ -160,6 +167,17 @@ class CRSResults(SCMResults):
                 else:
                     np_dict[prop] = tmp.split("\x00")
                     continue
+            if prop == "sigma_moment":
+                tmp = np.array(tmp)
+                tmp.shape = (ncomp, nmoment)
+                np_dict[prop] = tmp
+                continue
+            if prop == "sigma_hb_acc_moment" or prop == "sigma_hb_don_moment":
+                tmp = np.array(tmp)
+                tmp.shape = (ncomp, nhb_moment)
+                np_dict[prop] = tmp
+                continue
+
             if not isinstance(tmp, list):
                 np_dict[prop] = tmp
             else:

--- a/src/scm/plams/interfaces/adfsuite/crs.py
+++ b/src/scm/plams/interfaces/adfsuite/crs.py
@@ -2,7 +2,7 @@ import inspect
 import os
 import subprocess
 from itertools import cycle
-from typing import Optional, List, Dict, TYPE_CHECKING, Set, Union, Any, Tuple, cast
+from typing import Optional, List, Dict, TYPE_CHECKING, Set, Union, Any, Tuple, cast, overload, Literal
 
 import numpy as np
 
@@ -13,6 +13,11 @@ from scm.plams.core.functions import log
 if TYPE_CHECKING:
     import pandas as pd
     from matplotlib.figure import Figure
+    from scm.plams.interfaces.adfsuite.crs_input_builder import (
+        ACTIVITYCOEFInputBuilder,
+        BINMIXCOEFInputBuilder,
+        SOLUBILITYInputBuilder,
+    )
 
 __all__ = ["CRSResults", "CRSJob"]
 
@@ -503,17 +508,99 @@ class CRSJob(SCMJob):
         self.settings.ignore_molecule = True
 
     @staticmethod
-    def database() -> str:
+    def methods() -> Tuple[str, ...]:
+        """Return supported CRS method names."""
+        from scm.plams.interfaces.adfsuite.crs_input_builder import methods
+
+        return methods()
+
+    @staticmethod
+    def _normalize_method(method: str) -> str:
+        """Normalize and validate a CRS method name."""
+        from scm.plams.interfaces.adfsuite.crs_input_builder import normalize_method
+
+        return normalize_method(method)
+
+    @staticmethod
+    def _normalize_property_type(property_type: str) -> str:
+        """Normalize and validate a supported input-builder property type."""
+        from scm.plams.interfaces.adfsuite.crs_input_builder import normalize_property_type
+
+        return normalize_property_type(property_type)
+
+
+    @staticmethod
+    @overload
+    def input_builder(
+        property_type: "Literal['ACTIVITYCOEF']",
+        *,
+        method: str = "COSMO-RS",
+        mode: Optional[str] = None,
+        **kwargs: Any,
+    ) -> "ACTIVITYCOEFInputBuilder": ...
+
+    @staticmethod
+    @overload
+    def input_builder(
+        property_type: "Literal['SOLUBILITY']",
+        *,
+        method: str = "COSMO-RS",
+        mode: Optional[str] = None,
+        **kwargs: Any,
+    ) -> "SOLUBILITYInputBuilder": ...
+
+    @staticmethod
+    @overload
+    def input_builder(
+        property_type: "Literal['BINMIXCOEF']",
+        *,
+        method: str = "COSMO-RS",
+        mode: Optional[str] = None,
+        **kwargs: Any,
+    ) -> "BINMIXCOEFInputBuilder": ...
+
+    @staticmethod
+    def input_builder(
+        property_type: str,
+        *,
+        method: str = "COSMO-RS",
+        mode: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Return a property-specific CRS input builder."""
+        from scm.plams.interfaces.adfsuite.crs_input_builder import input_builder
+
+        return input_builder(property_type, method=method, mode=mode, job_cls=CRSJob, **kwargs)
+
+
+    @staticmethod
+    def adfcrs_database_path() -> str:
+        """Return the path to the bundled ADFCRS-2018 COSKF database directory."""
         database_path = os.path.join(os.environ["SCM_PKG_ADFCRSDIR"], "ADFCRS-2018")
         if not os.path.isdir(database_path):
             raise FileNotFoundError("The ADFCRS-2018 database does not seem to be installed")
         return database_path
 
     @staticmethod
-    def coskf_from_database(name: str) -> str:
+    def coskf_from_adfcrs_database(name: str) -> str:
+        """Return the path to a COSKF file in the bundled ADFCRS-2018 database."""
         if not name.endswith(".coskf"):
             name += ".coskf"
-        return os.path.join(CRSJob.database(), name)
+
+        path = os.path.join(CRSJob.adfcrs_database_path(), name)
+        if not os.path.isfile(path):
+            raise FileNotFoundError(f"COSKF file {name!r} was not found in the ADFCRS-2018 database")
+        return path
+
+    @staticmethod
+    def database() -> str:
+        """Legacy alias for adfcrs_database_path()."""
+        return CRSJob.adfcrs_database_path()
+
+    @staticmethod
+    def coskf_from_database(name: str) -> str:
+        """Legacy alias for coskf_from_adfcrs_database()."""
+        return CRSJob.coskf_from_adfcrs_database(name)
 
     @staticmethod
     def cos_to_coskf(filename: str) -> str:

--- a/src/scm/plams/interfaces/adfsuite/crs.py
+++ b/src/scm/plams/interfaces/adfsuite/crs.py
@@ -1,4 +1,3 @@
-import inspect
 import os
 import subprocess
 from itertools import cycle
@@ -8,7 +7,7 @@ import numpy as np
 
 from scm.plams.interfaces.adfsuite.scmjob import SCMJob, SCMResults
 from scm.plams.tools.units import Units
-from scm.plams.core.functions import log
+from scm.plams.core.functions import log, requires_optional_package
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -287,16 +286,11 @@ class CRSResults(SCMResults):
             dict_Asson = None  # type: ignore[assignment]
 
         if as_df:
-            try:
-                import pandas as pd
-
-                return pd.DataFrame(dict_species), pd.DataFrame(dict_Asson)
-            except ImportError:
-                method = inspect.stack()[2][3]
-                raise ImportError("{}: as_df=True requires the 'pandas' package".format(method))
+            return self._plain_dict_to_df(dict_species), self._plain_dict_to_df(dict_Asson)
         else:
             return dict_species, dict_Asson
 
+    @requires_optional_package("matplotlib")
     def plot(
         self,
         *arrays: "np.ndarray",
@@ -353,22 +347,17 @@ class CRSResults(SCMResults):
         except ImportError:
             terminal = "script"
 
-        # Check if matplotlib is installed
-        try:
-            import matplotlib
+        import matplotlib
 
-            if plot_fig:
-                if terminal == "jupyter" and ipython is not None:
-                    ipython.run_line_magic("matplotlib", "inline")
-                else:
-                    matplotlib.use("TkAgg")
-            elif not plot_fig:
-                matplotlib.use("Agg")
+        if plot_fig:
+            if terminal == "jupyter" and ipython is not None:
+                ipython.run_line_magic("matplotlib", "inline")
+            else:
+                matplotlib.use("TkAgg")
+        else:
+            matplotlib.use("Agg")
 
-            import matplotlib.pyplot as plt
-        except ImportError:
-            method = self.__class__.__name__ + ".plot"
-            raise ImportError("{}: this method requires the 'matplotlib' package".format(method))
+        import matplotlib.pyplot as plt
 
         self.get_results()
 
@@ -481,18 +470,26 @@ class CRSResults(SCMResults):
         return ret
 
     @staticmethod
+    @requires_optional_package("pandas")
     def _dict_to_df(array_dict: dict, section: str, x_axis: str) -> "pd.DataFrame":
         """Attempt to convert a dictionary into a DataFrame."""
-        try:
-            import pandas as pd
-        except ImportError:
-            method = inspect.stack()[2][3]
-            raise ImportError("{}: as_df=True requires the 'pandas' package".format(method))
+        import pandas as pd
 
         index = pd.Index(array_dict.pop(x_axis), name=x_axis)
         df = pd.DataFrame(array_dict, index=index)
         df.columns.name = section.lower()
         return df
+
+    @staticmethod
+    @requires_optional_package("pandas")
+    def _plain_dict_to_df(data: Optional[Dict[str, Any]]) -> Optional["pd.DataFrame"]:
+        """Convert a plain dictionary of columns into a DataFrame."""
+        if data is None:
+            return None
+
+        import pandas as pd
+
+        return pd.DataFrame(data)
 
 
 class CRSJob(SCMJob):

--- a/src/scm/plams/interfaces/adfsuite/crs.py
+++ b/src/scm/plams/interfaces/adfsuite/crs.py
@@ -15,7 +15,22 @@ if TYPE_CHECKING:
     from scm.plams.interfaces.adfsuite.crs_input_builder import (
         ACTIVITYCOEFInputBuilder,
         BINMIXCOEFInputBuilder,
+        BOILINGPOINTInputBuilder,
+        COMPOSITIONLINEInputBuilder,
+        FLASHPOINTInputBuilder,
+        LLEInputBuilder,
+        LOGPInputBuilder,
+        PUREBOILINGPOINTInputBuilder,
+        PURESIGMAPOTENTIALInputBuilder,
+        PURESIGMAPROFILEInputBuilder,
+        PURESOLUBILITYInputBuilder,
+        PUREVAPORPRESSUREInputBuilder,
+        SIGMAPOTENTIALInputBuilder,
+        SIGMAPROFILEInputBuilder,
         SOLUBILITYInputBuilder,
+        STABILITYInputBuilder,
+        TERNARYMIXInputBuilder,
+        VAPORPRESSUREInputBuilder,
     )
 
 __all__ = ["CRSResults", "CRSJob"]
@@ -539,6 +554,16 @@ class CRSJob(SCMJob):
     @staticmethod
     @overload
     def input_builder(
+        property_type: "Literal['LOGP']",
+        *,
+        method: str = "COSMO-RS",
+        mode: Optional[str] = None,
+        **kwargs: Any,
+    ) -> "LOGPInputBuilder": ...
+
+    @staticmethod
+    @overload
+    def input_builder(
         property_type: "Literal['SOLUBILITY']",
         *,
         method: str = "COSMO-RS",
@@ -549,12 +574,162 @@ class CRSJob(SCMJob):
     @staticmethod
     @overload
     def input_builder(
+        property_type: "Literal['PURESOLUBILITY']",
+        *,
+        method: str = "COSMO-RS",
+        mode: Optional[str] = None,
+        **kwargs: Any,
+    ) -> "PURESOLUBILITYInputBuilder": ...
+
+    @staticmethod
+    @overload
+    def input_builder(
+        property_type: "Literal['VAPORPRESSURE']",
+        *,
+        method: str = "COSMO-RS",
+        mode: Optional[str] = None,
+        **kwargs: Any,
+    ) -> "VAPORPRESSUREInputBuilder": ...
+
+    @staticmethod
+    @overload
+    def input_builder(
+        property_type: "Literal['PUREVAPORPRESSURE']",
+        *,
+        method: str = "COSMO-RS",
+        mode: Optional[str] = None,
+        **kwargs: Any,
+    ) -> "PUREVAPORPRESSUREInputBuilder": ...
+
+    @staticmethod
+    @overload
+    def input_builder(
+        property_type: "Literal['BOILINGPOINT']",
+        *,
+        method: str = "COSMO-RS",
+        mode: Optional[str] = None,
+        **kwargs: Any,
+    ) -> "BOILINGPOINTInputBuilder": ...
+
+    @staticmethod
+    @overload
+    def input_builder(
+        property_type: "Literal['PUREBOILINGPOINT']",
+        *,
+        method: str = "COSMO-RS",
+        mode: Optional[str] = None,
+        **kwargs: Any,
+    ) -> "PUREBOILINGPOINTInputBuilder": ...
+
+    @staticmethod
+    @overload
+    def input_builder(
+        property_type: "Literal['FLASHPOINT']",
+        *,
+        method: str = "COSMO-RS",
+        mode: Optional[str] = None,
+        **kwargs: Any,
+    ) -> "FLASHPOINTInputBuilder": ...
+
+    @staticmethod
+    @overload
+    def input_builder(
         property_type: "Literal['BINMIXCOEF']",
         *,
         method: str = "COSMO-RS",
         mode: Optional[str] = None,
         **kwargs: Any,
     ) -> "BINMIXCOEFInputBuilder": ...
+
+    @staticmethod
+    @overload
+    def input_builder(
+        property_type: "Literal['TERNARYMIX']",
+        *,
+        method: str = "COSMO-RS",
+        mode: Optional[str] = None,
+        **kwargs: Any,
+    ) -> "TERNARYMIXInputBuilder": ...
+
+    @staticmethod
+    @overload
+    def input_builder(
+        property_type: "Literal['COMPOSITIONLINE']",
+        *,
+        method: str = "COSMO-RS",
+        mode: Optional[str] = None,
+        **kwargs: Any,
+    ) -> "COMPOSITIONLINEInputBuilder": ...
+
+    @staticmethod
+    @overload
+    def input_builder(
+        property_type: "Literal['LLE']",
+        *,
+        method: str = "COSMO-RS",
+        mode: Optional[str] = None,
+        **kwargs: Any,
+    ) -> "LLEInputBuilder": ...
+
+    @staticmethod
+    @overload
+    def input_builder(
+        property_type: "Literal['STABILITY']",
+        *,
+        method: str = "COSMO-RS",
+        mode: Optional[str] = None,
+        **kwargs: Any,
+    ) -> "STABILITYInputBuilder": ...
+
+    @staticmethod
+    @overload
+    def input_builder(
+        property_type: "Literal['SIGMAPROFILE']",
+        *,
+        method: str = "COSMO-RS",
+        mode: Optional[str] = None,
+        **kwargs: Any,
+    ) -> "SIGMAPROFILEInputBuilder": ...
+
+    @staticmethod
+    @overload
+    def input_builder(
+        property_type: "Literal['PURESIGMAPROFILE']",
+        *,
+        method: str = "COSMO-RS",
+        mode: Optional[str] = None,
+        **kwargs: Any,
+    ) -> "PURESIGMAPROFILEInputBuilder": ...
+
+    @staticmethod
+    @overload
+    def input_builder(
+        property_type: "Literal['SIGMAPOTENTIAL']",
+        *,
+        method: str = "COSMO-RS",
+        mode: Optional[str] = None,
+        **kwargs: Any,
+    ) -> "SIGMAPOTENTIALInputBuilder": ...
+
+    @staticmethod
+    @overload
+    def input_builder(
+        property_type: "Literal['PURESIGMAPOTENTIAL']",
+        *,
+        method: str = "COSMO-RS",
+        mode: Optional[str] = None,
+        **kwargs: Any,
+    ) -> "PURESIGMAPOTENTIALInputBuilder": ...
+
+    @staticmethod
+    @overload
+    def input_builder(
+        property_type: str,
+        *,
+        method: str = "COSMO-RS",
+        mode: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Any: ...
 
     @staticmethod
     def input_builder(

--- a/src/scm/plams/interfaces/adfsuite/crs_definitions.py
+++ b/src/scm/plams/interfaces/adfsuite/crs_definitions.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import json
+import os
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, Iterable, Mapping, Tuple
+
+
+__all__ = [
+    "CRS_METHODS",
+    "CRSInputMetadata",
+    "CRSMethodParameterMetadata",
+    "get_block",
+    "get_block_child_names",
+    "get_block_keys",
+    "get_crs_input_data",
+    "get_crs_input_def_path",
+    "get_crs_method_parameters_metadata",
+    "get_crs_method_parameters_path",
+]
+
+
+CRSInputMetadata = Dict[str, Dict[str, Any]]
+CRSMethodParameterMetadata = Dict[str, Dict[str, Any]]
+
+CRS_METHODS = (
+    "COSMO-RS",
+    "COSMOSAC2013",
+    "COSMOSAC2016",
+    "COSMOSACDHB",
+    "COSMOSACDHB-MESP",
+)
+
+_CRS_METHOD_PARAMETER_BLOCKS = frozenset(
+    ("CRSParameters", "SACParameters", "Dispersion", "Epsilon")
+)
+
+
+def get_crs_input_def_path() -> Path:
+    """Return the path to ``data/input_def/crs.json``.
+
+    The lookup is lazy so importing this module does not require a configured AMS
+    environment.
+    """
+    return _find_file(
+        relative_parts=("data", "input_def", "crs.json"),
+        description="data/input_def/crs.json",
+    )
+
+
+def get_crs_method_parameters_path() -> Path:
+    """Return the path to ``data/crs/method_parameters.json``."""
+    return _find_file(
+        relative_parts=("data", "crs", "method_parameters.json"),
+        description="data/crs/method_parameters.json",
+    )
+
+
+@lru_cache(maxsize=None)
+def get_crs_input_data() -> CRSInputMetadata:
+    """Return normalized metadata from ``data/input_def/crs.json``."""
+    with get_crs_input_def_path().open(encoding="utf-8") as handle:
+        data = json.load(handle)
+
+    if not isinstance(data, dict):
+        raise ValueError(f"CRS input definition file {get_crs_input_def_path()} must contain a JSON object")
+
+    return _extract_crs_input_block_metadata(data)
+
+
+@lru_cache(maxsize=None)
+def get_crs_method_parameters_metadata() -> CRSMethodParameterMetadata:
+    """Return normalized metadata from ``data/crs/method_parameters.json``."""
+    with get_crs_method_parameters_path().open(encoding="utf-8") as handle:
+        data = json.load(handle)
+
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"CRS method parameter file {get_crs_method_parameters_path()} must contain a JSON object"
+        )
+
+    return _extract_crs_method_parameters_metadata(data, get_crs_method_parameters_path())
+
+
+def get_block(data: Mapping[str, Any], *path: str) -> Dict[str, Any]:
+    """Return a block metadata object by case-insensitive nested path.
+
+    Examples:
+        get_block(data, "compound") returns the COMPOUND block.
+        get_block(data, "compound", "required") returns the COMPOUND/REQUIRED block.
+    """
+    if not path:
+        raise ValueError("At least one block name must be provided")
+
+    block = data[_normalize_name(path[0])]
+    for name in path[1:]:
+        block = block["blocks"][_normalize_name(name)]
+    return block
+
+
+def get_block_keys(data: Mapping[str, Any], *path: str) -> Dict[str, Any]:
+    """Return scalar key metadata directly defined in the selected block."""
+    return dict(get_block(data, *path)["keys"])
+
+
+def get_block_child_names(data: Mapping[str, Any], *path: str) -> Tuple[str, ...]:
+    """Return key and child-block names directly accepted by the selected block."""
+    block = get_block(data, *path)
+    return tuple(dict.fromkeys((*block["keys"], *block["blocks"])))
+
+
+@lru_cache(maxsize=None)
+def _find_file(relative_parts: Tuple[str, ...], description: str) -> Path:
+    for root in _candidate_ams_roots():
+        candidate = root.joinpath(*relative_parts)
+        if candidate.is_file():
+            return candidate.resolve()
+
+    roots = ", ".join(str(root) for root in _candidate_ams_roots())
+    raise FileNotFoundError(
+        f"Could not locate {description}. Set AMSHOME or AMSBIN, or run from an AMS source tree. "
+        f"Searched roots: {roots}"
+    )
+
+
+def _candidate_ams_roots() -> Tuple[Path, ...]:
+    roots = []
+
+    amshome = os.environ.get("AMSHOME")
+    if amshome:
+        roots.append(Path(amshome))
+
+    amsbin = os.environ.get("AMSBIN")
+    if amsbin:
+        roots.append(Path(amsbin).resolve().parent)
+
+    source_tree_root = _source_tree_root()
+    if source_tree_root is not None:
+        roots.append(source_tree_root)
+
+    return tuple(dict.fromkeys(root.resolve() for root in roots))
+
+
+def _source_tree_root() -> Path:
+    # src/scm/plams/interfaces/adfsuite/crs_definitions.py -> AMS source root
+    return Path(__file__).resolve().parents[8]
+
+
+def _extract_crs_input_block_metadata(data: Mapping[str, Any]) -> CRSInputMetadata:
+    result: CRSInputMetadata = {}
+
+    for entry_name, entry_def in data.items():
+        if not isinstance(entry_def, dict):
+            continue
+        if _skip_top_level_input_block(entry_name):
+            continue
+
+        category = entry_def.get("_category")
+        if category == "key":
+            result[_normalize_name(entry_name)] = _key_metadata(entry_name, entry_def)
+        elif category == "block":
+            result[_normalize_name(entry_name)] = _block_metadata(entry_name, entry_def)
+
+    return result
+
+
+def _skip_top_level_input_block(name: str) -> bool:
+    return _normalize_name(name) in {
+        "dispersion",
+        "coef_cations",
+        "coef_anions",
+        "epsilon",
+        "crsparameters",
+        "sacparameters",
+    }
+
+
+def _key_metadata(name: str, key_def: Mapping[str, Any]) -> Dict[str, Any]:
+    metadata = {
+        "kind": "key",
+        "input_name": name,
+        "type": key_def.get("_type"),
+        "description": key_def.get("_comment", ""),
+        "unit": key_def.get("_unit"),
+        "choices": tuple(key_def.get("_choices", ())),
+        "hint": key_def.get("_hint", ""),
+    }
+
+    if "_default" in key_def:
+        metadata["default"] = key_def["_default"]
+
+    return metadata
+
+
+def _block_metadata(name: str, block_def: Mapping[str, Any]) -> Dict[str, Any]:
+    keys: Dict[str, Any] = {}
+    blocks: Dict[str, Any] = {}
+
+    for child_name, child_def in block_def.items():
+        if not isinstance(child_def, dict):
+            continue
+
+        child_category = child_def.get("_category")
+        if child_category == "key":
+            keys[_normalize_name(child_name)] = _key_metadata(child_name, child_def)
+        elif child_category == "block":
+            blocks[_normalize_name(child_name)] = _block_metadata(child_name, child_def)
+
+    return {
+        "kind": "block",
+        "input_name": name,
+        "description": block_def.get("_comment", ""),
+        "type": block_def.get("_type"),
+        "header": bool(block_def.get("_header", False)),
+        "unique": bool(block_def.get("_unique", False)),
+        "keys": keys,
+        "blocks": blocks,
+    }
+
+
+def _extract_crs_method_parameters_metadata(
+    data: Mapping[str, Any], json_path: Path
+) -> CRSMethodParameterMetadata:
+    if data.get("schema_version") != 1:
+        raise ValueError(f"Unsupported CRS method parameter schema_version in {json_path}")
+
+    presets = data.get("presets")
+    if not isinstance(presets, list):
+        raise ValueError(f"CRS method parameter file {json_path} must contain a presets list")
+
+    result: CRSMethodParameterMetadata = {}
+
+    for preset in presets:
+        if not isinstance(preset, dict):
+            raise ValueError(f"CRS method parameter preset in {json_path} must be an object")
+
+        parameter_set = preset.get("parameter_set")
+        if not isinstance(parameter_set, str) or not parameter_set.strip():
+            raise ValueError(f"CRS method parameter preset in {json_path} must define parameter_set")
+
+        normalized_parameter_set = _normalize_name(parameter_set)
+        if normalized_parameter_set in result:
+            raise ValueError(f"Duplicate CRS parameter_set={normalized_parameter_set!r} in {json_path}")
+
+        method = preset.get("method")
+        if not isinstance(method, str) or not method.strip():
+            raise ValueError(f"CRS parameter_set={normalized_parameter_set!r} must define method")
+
+        parameter_blocks = preset.get("parameter_blocks")
+        if not isinstance(parameter_blocks, dict):
+            raise ValueError(f"CRS parameter_set={normalized_parameter_set!r} must define parameter_blocks")
+
+        _validate_parameter_blocks(parameter_blocks, normalized_parameter_set, json_path)
+
+        normalized_preset = dict(preset)
+        normalized_preset["parameter_set"] = normalized_parameter_set
+        normalized_preset["method"] = method.strip()
+        result[normalized_parameter_set] = normalized_preset
+
+    return result
+
+
+def _validate_parameter_blocks(
+    parameter_blocks: Mapping[str, Any], parameter_set: str, json_path: Path
+) -> None:
+    for block_name, block in parameter_blocks.items():
+        if block_name not in _CRS_METHOD_PARAMETER_BLOCKS:
+            allowed = ", ".join(sorted(_CRS_METHOD_PARAMETER_BLOCKS))
+            raise ValueError(
+                f"Unsupported parameter block {block_name!r} in CRS parameter_set={parameter_set!r} "
+                f"from {json_path}. Allowed blocks: {allowed}"
+            )
+        if not isinstance(block, dict):
+            raise ValueError(f"{block_name} in CRS parameter_set={parameter_set!r} from {json_path} must be an object")
+
+
+def _normalize_name(name: str) -> str:
+    return name.strip().lower()

--- a/src/scm/plams/interfaces/adfsuite/crs_input_builder.py
+++ b/src/scm/plams/interfaces/adfsuite/crs_input_builder.py
@@ -58,14 +58,24 @@ _METHOD_ALIASES = {
 _VAPOR_PRESSURE_KEYS = ("pvap", "tvap", "vp_equation", "vp_params")
 _FUSION_KEYS = ("meltingpoint", "hfusion", "cpfusion")
 _VLE_SWEEP_PROPERTY_KEYS = ("nfrac", "isotherm", "isobar", "flashpoint")
-_SIGMA_PROPERTY_KEYS = (
-    "nprofile",
-    "sigmamax",
+_SIGMA_KEYS = ("nprofile", "sigmamax")
+_SIGMA_MOMENT_KEYS = (
     "sigmamomentpower",
     "sigmamomenthblevel",
     "sigmamomenthbcutoff",
     "sigmamomenthbcutoffbase",
-    "sigmamomenthbcutoffstep",
+    "sigmamomenthbcutoffstep"
+)
+# Technical top-level CRS inputs exposed through set_expert_options() for all properties.
+# The keys and value types are validated from crs.json; only the expert-option
+# grouping is kept here for now and may move to crs.json metadata later.
+_EXPERT_INPUT_KEYS = (
+    "usepolycombiforpolymer",
+    "pdh_correction",
+    "ignore_coskfatoms",
+    "output_energy_components",
+    "reuse_sigma_profile",
+    "update_sigma_profile",
 )
 
 
@@ -129,6 +139,8 @@ class CRSInputBuilder:
         "_job_cls",
         "_values",
         "_accepted_keys",
+        "_expert_keys",
+        "_expert_values",
         "_mode_config",
         "_mode",
         "_active_mode_input_keys",
@@ -170,6 +182,8 @@ class CRSInputBuilder:
         self._job_cls = job_cls
         self._values: Dict[str, Any] = {}
         self._accepted_keys = self._build_accepted_keys()
+        self._expert_keys = self._build_expert_keys()
+        self._expert_values: Dict[str, Any] = {}
         self._mode_config = self._MODE_CONFIG
         self._mode: Optional[str] = None
         self._active_mode_input_keys: Set[str] = set()
@@ -199,6 +213,20 @@ class CRSInputBuilder:
 
         return accepted
 
+    @classmethod
+    def _build_expert_keys(cls) -> Dict[str, _InputRoute]:
+        data = get_crs_input_data()
+        property_keys = get_block_keys(data, "property")
+        expert_keys: Dict[str, _InputRoute] = {}
+
+        for key in _EXPERT_INPUT_KEYS:
+            route = cls._input_route_from_schema(key, data, property_keys)
+            if route.scope != "top_level":
+                raise ValueError(f"CRS expert option {key!r} must be a top-level input key")
+            expert_keys[key] = route
+
+        return expert_keys
+
     @staticmethod
     def _input_route_from_schema(
         key: str,
@@ -216,9 +244,11 @@ class CRSInputBuilder:
     def __dir__(self) -> List[str]:
         entries = {
             "describe",
+            "expert_options",
             "get",
             "method",
             "set",
+            "set_expert_options",
             "to_job",
             "to_settings",
         }
@@ -247,7 +277,23 @@ class CRSInputBuilder:
             self._set_input_value(key, value)
         return self
 
-    def describe(self, *, include_values: bool = False, include_compound_details: bool = False) -> Tuple[str, ...]:
+    def expert_options(self) -> Tuple[str, ...]:
+        """Return supported expert option names."""
+        return tuple(sorted(self._expert_keys))
+
+    def set_expert_options(self: _CRSInputBuilderT, **kwargs: Any) -> _CRSInputBuilderT:
+        """Set technical top-level CRS options."""
+        for key, value in kwargs.items():
+            self._set_expert_option(key, value)
+        return self
+
+    def describe(
+        self,
+        *,
+        include_values: bool = False,
+        include_compound_details: bool = False,
+        include_expert_options: bool = False,
+    ) -> Tuple[str, ...]:
         """Return concise descriptions of supported inputs and compound roles."""
         lines = [f"{self.property_type}: {self._DESCRIPTION}", f"method [top_level]: {self.method}"]
 
@@ -266,6 +312,18 @@ class CRSInputBuilder:
                 lines.append(self._format_key_description(key, "compound", compound_key_metadata[key]))
         elif compound_keys:
             lines.append(f"compound_keys [compound]: {', '.join(compound_keys)}")
+
+        if include_expert_options:
+            for key, route in sorted(self._expert_keys.items()):
+                lines.append(
+                    self._format_key_description(
+                        key,
+                        "expert",
+                        route.metadata,
+                        include_values=include_values,
+                        values=self._expert_values,
+                    )
+                )
 
         return tuple(lines)
 
@@ -288,6 +346,9 @@ class CRSInputBuilder:
             elif route.scope == "property":
                 settings.input.property[key] = self._values[key]
 
+        for key in sorted(self._expert_values):
+            settings.input[key] = self._expert_values[key]
+
         if include_compounds:
             compounds = self._compound_blocks()
             if compounds:
@@ -305,11 +366,16 @@ class CRSInputBuilder:
 
     def _set_input_value(self, key: str, value: Any) -> None:
         self._validate_input_key(key)
-        value = self._normalize_input_value(key, value)
+        value = self._normalize_value_by_metadata(key, value, self._accepted_keys[key].metadata)
         self._values[key] = value
 
-    def _normalize_input_value(self, key: str, value: Any) -> Any:
-        input_type = self._accepted_keys[key].metadata.get("type")
+    def _set_expert_option(self, key: str, value: Any) -> None:
+        self._validate_expert_key(key)
+        route = self._expert_keys[key]
+        self._expert_values[key] = self._normalize_value_by_metadata(key, value, route.metadata)
+
+    def _normalize_value_by_metadata(self, key: str, value: Any, metadata: Mapping[str, Any]) -> Any:
+        input_type = metadata.get("type")
 
         if key in self._SINGLE_VALUE_INPUT_KEYS:
             if input_type == "float_list":
@@ -392,6 +458,11 @@ class CRSInputBuilder:
         if key not in self._accepted_keys:
             allowed = ", ".join(sorted(self._accepted_keys))
             raise AttributeError(f"{key!r} is not valid for {self.property_type}. Allowed input keys: {allowed}")
+
+    def _validate_expert_key(self, key: str) -> None:
+        if key not in self._expert_keys:
+            allowed = ", ".join(sorted(self._expert_keys))
+            raise ValueError(f"{key!r} is not a CRS expert input key. Supported expert options: {allowed}")
 
     def _set_mode_or_default(self, mode: Optional[str]) -> None:
         selected_mode = self._mode_config.default if mode is None else mode
@@ -540,13 +611,15 @@ class CRSInputBuilder:
         metadata: Mapping[str, Any],
         *,
         include_values: bool = False,
+        values: Optional[Mapping[str, Any]] = None,
     ) -> str:
         input_type = metadata.get("type", "")
         unit = metadata.get("unit")
         type_unit = f"{input_type} [{unit}]" if unit else input_type
         line = f"{key} [{scope}] {type_unit}: {metadata.get('description', '')}"
         if include_values:
-            line += f" value: {self._values.get(key)!r}"
+            value_source = self._values if values is None else values
+            line += f" value: {value_source.get(key)!r}"
         return line
 
 
@@ -591,7 +664,7 @@ class _TemperatureMixin:
 
     @property
     def temperature(self) -> Optional[_FloatInput]:
-        """Temperature in K as a single value."""
+        """Temperature in K."""
         return self.get("temperature")
 
     @temperature.setter
@@ -604,7 +677,7 @@ class _TemperatureListMixin:
 
     @property
     def temperature(self) -> Optional[_FloatListInput]:
-        """Temperature in K as a single value or range [temperature, temperature_high, nsteps]."""
+        """Temperature in K, as one value or [low, high, nsteps]."""
         return self.get("temperature")
 
     @temperature.setter
@@ -617,7 +690,7 @@ class _PressureMixin:
 
     @property
     def pressure(self) -> Optional[_FloatInput]:
-        """Pressure in bar as a single value."""
+        """Pressure in bar."""
         return self.get("pressure")
 
     @pressure.setter
@@ -630,7 +703,7 @@ class _PressureListMixin:
 
     @property
     def pressure(self) -> Optional[_FloatListInput]:
-        """Pressure in bar as a single value or range [pressure, pressure_high, nsteps]."""
+        """Pressure in bar, as one value or [low, high, nsteps]."""
         return self.get("pressure")
 
     @pressure.setter
@@ -643,7 +716,7 @@ class _MassFractionMixin:
 
     @property
     def massfraction(self) -> Optional[bool]:
-        """Use mass fractions instead of molar fractions."""
+        """Interpret compound fractions as mass fractions instead of mole fractions."""
         return self.get("massfraction")
 
     @massfraction.setter
@@ -656,25 +729,12 @@ class _DensitySolventMixin:
 
     @property
     def densitysolvent(self) -> Optional[_FloatInput]:
-        """Density of the solvent."""
+        """Solvent density in kg/L."""
         return self.get("densitysolvent")
 
     @densitysolvent.setter
     def densitysolvent(self, value: _FloatInput) -> None:
         self._set_input_value("densitysolvent", value)
-
-
-class _NFracMixin:
-    __slots__ = ()
-
-    @property
-    def nfrac(self) -> Optional[int]:
-        """Number of different mixtures for mixture sweeps."""
-        return self.get("nfrac")
-
-    @nfrac.setter
-    def nfrac(self, value: int) -> None:
-        self._set_input_value("nfrac", value)
 
 
 class _SigmaMomentMixin:
@@ -691,7 +751,7 @@ class _SigmaMomentMixin:
 
     @property
     def sigmamomenthblevel(self) -> Optional[_IntegerListInput]:
-        """Hydrogen-bond sigma moment cutoff levels."""
+        """Hydrogen-bond sigma moment levels; level 1 uses cutoff, higher levels use cutoffbase + level * cutoffstep."""
         return self.get("sigmamomenthblevel")
 
     @sigmamomenthblevel.setter
@@ -700,7 +760,7 @@ class _SigmaMomentMixin:
 
     @property
     def sigmamomenthbcutoff(self) -> Optional[_FloatInput]:
-        """Hydrogen-bond sigma moment cutoff for level 1."""
+        """Cutoff for level 1 hydrogen-bond sigma moment in e/Angstrom^2."""
         return self.get("sigmamomenthbcutoff")
 
     @sigmamomenthbcutoff.setter
@@ -709,7 +769,7 @@ class _SigmaMomentMixin:
 
     @property
     def sigmamomenthbcutoffbase(self) -> Optional[_FloatInput]:
-        """Base cutoff used for hydrogen-bond sigma moment levels above 1."""
+        """Cutoff base for higher-level hydrogen-bond sigma moment in e/Angstrom^2."""
         return self.get("sigmamomenthbcutoffbase")
 
     @sigmamomenthbcutoffbase.setter
@@ -718,12 +778,25 @@ class _SigmaMomentMixin:
 
     @property
     def sigmamomenthbcutoffstep(self) -> Optional[_FloatInput]:
-        """Cutoff increment used for hydrogen-bond sigma moment levels above 1."""
+        """Cutoff step for higher-level hydrogen-bond sigma moment in e/Angstrom^2."""
         return self.get("sigmamomenthbcutoffstep")
 
     @sigmamomenthbcutoffstep.setter
     def sigmamomenthbcutoffstep(self, value: _FloatInput) -> None:
         self._set_input_value("sigmamomenthbcutoffstep", value)
+
+
+class _SigmaPotentialMixin:
+    __slots__ = ()
+
+    @property
+    def estpotential(self) -> Optional[bool]:
+        """Estimate sigma potential where the sigma profile has no area."""
+        return self.get("estpotential")
+
+    @estpotential.setter
+    def estpotential(self, value: bool) -> None:
+        self._set_input_value("estpotential", value)
 
 
 class _SigmaMixin:
@@ -747,6 +820,7 @@ class _SigmaMixin:
     def sigmamax(self, value: _FloatInput) -> None:
         self._set_input_value("sigmamax", value)
 
+
 class _SolubilityModeMixin:
     __slots__ = ()
 
@@ -765,7 +839,8 @@ class _SolubilityModeMixin:
         return tuple(self._mode_config.options)
 
 
-class _VLESweepModeMixin:
+class _VLESweepMixin:
+    """Inputs for VLE-style sweep properties."""
     __slots__ = ()
 
     @property
@@ -781,6 +856,15 @@ class _VLESweepModeMixin:
     def mode_options(self) -> Tuple[str, ...]:
         """Supported VLE sweep mode names."""
         return tuple(self._mode_config.options)
+
+    @property
+    def nfrac(self) -> Optional[int]:
+        """Mixture-fraction resolution: binary n+5, ternary (n+1)*(n+2)/2, composition line n+1."""
+        return self.get("nfrac")
+
+    @nfrac.setter
+    def nfrac(self, value: int) -> None:
+        self._set_input_value("nfrac", value)
 
 
 class ACTIVITYCOEFInputBuilder(
@@ -1020,8 +1104,7 @@ class BINMIXCOEFInputBuilder(
     _TemperatureMixin,
     _PressureMixin,
     _MassFractionMixin,
-    _NFracMixin,
-    _VLESweepModeMixin,
+    _VLESweepMixin,
     _CompoundRoleMixin,
     CRSInputBuilder,
 ):
@@ -1052,8 +1135,7 @@ class TERNARYMIXInputBuilder(
     _TemperatureMixin,
     _PressureMixin,
     _MassFractionMixin,
-    _NFracMixin,
-    _VLESweepModeMixin,
+    _VLESweepMixin,
     _CompoundRoleMixin,
     CRSInputBuilder,
 ):
@@ -1081,8 +1163,7 @@ class COMPOSITIONLINEInputBuilder(
     _TemperatureMixin,
     _PressureMixin,
     _MassFractionMixin,
-    _NFracMixin,
-    _VLESweepModeMixin,
+    _VLESweepMixin,
     _SolventRoleMixin,
     CRSInputBuilder,
 ):
@@ -1164,7 +1245,7 @@ class SIGMAPROFILEInputBuilder(
 
     _PROPERTY_TYPE: ClassVar[str] = "SIGMAPROFILE"
     _DESCRIPTION: ClassVar[str] = "Sigma profile for a solvent mixture."
-    _EXPOSED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("massfraction", *_SIGMA_PROPERTY_KEYS)
+    _EXPOSED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("massfraction", *_SIGMA_KEYS, *_SIGMA_MOMENT_KEYS)
     _CALCULATION_COMPOUND_KEYS: ClassVar[Tuple[str, ...]] = ("frac1",)
     _COMPOUND_ROLE_CONFIG: ClassVar[Mapping[str, _CompoundRoleConfig]] = {
         "compound": _CompoundRoleConfig(required_keys=("frac1",)),
@@ -1183,7 +1264,7 @@ class PURESIGMAPROFILEInputBuilder(
 
     _PROPERTY_TYPE: ClassVar[str] = "PURESIGMAPROFILE"
     _DESCRIPTION: ClassVar[str] = "Sigma profile for pure compounds."
-    _EXPOSED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = _SIGMA_PROPERTY_KEYS
+    _EXPOSED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = (*_SIGMA_KEYS, *_SIGMA_MOMENT_KEYS)
     _COMPOUND_ROLE_CONFIG: ClassVar[Mapping[str, _CompoundRoleConfig]] = {
         "compound": _CompoundRoleConfig(),
     }
@@ -1193,6 +1274,7 @@ class SIGMAPOTENTIALInputBuilder(
     _TemperatureMixin,
     _MassFractionMixin,
     _SigmaMixin,
+    _SigmaPotentialMixin,
     _CompoundRoleMixin,
     CRSInputBuilder,
 ):
@@ -1202,7 +1284,7 @@ class SIGMAPOTENTIALInputBuilder(
 
     _PROPERTY_TYPE: ClassVar[str] = "SIGMAPOTENTIAL"
     _DESCRIPTION: ClassVar[str] = "Sigma potential for a solvent mixture."
-    _EXPOSED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature", "massfraction", *_SIGMA_PROPERTY_KEYS)
+    _EXPOSED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature", "massfraction", *_SIGMA_KEYS, "estpotential")
     _REQUIRED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature",)
     _SINGLE_VALUE_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature",)
     _CALCULATION_COMPOUND_KEYS: ClassVar[Tuple[str, ...]] = ("frac1",)
@@ -1214,6 +1296,7 @@ class SIGMAPOTENTIALInputBuilder(
 class PURESIGMAPOTENTIALInputBuilder(
     _TemperatureMixin,
     _SigmaMixin,
+    _SigmaPotentialMixin,
     _CompoundRoleMixin,
     CRSInputBuilder,
 ):
@@ -1223,7 +1306,7 @@ class PURESIGMAPOTENTIALInputBuilder(
 
     _PROPERTY_TYPE: ClassVar[str] = "PURESIGMAPOTENTIAL"
     _DESCRIPTION: ClassVar[str] = "Sigma potential for pure compounds."
-    _EXPOSED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature", *_SIGMA_PROPERTY_KEYS)
+    _EXPOSED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature", *_SIGMA_KEYS, "estpotential")
     _REQUIRED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature",)
     _SINGLE_VALUE_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature",)
     _COMPOUND_ROLE_CONFIG: ClassVar[Mapping[str, _CompoundRoleConfig]] = {

--- a/src/scm/plams/interfaces/adfsuite/crs_input_builder.py
+++ b/src/scm/plams/interfaces/adfsuite/crs_input_builder.py
@@ -282,7 +282,13 @@ class CRSInputBuilder:
         return tuple(sorted(self._expert_keys))
 
     def set_expert_options(self: _CRSInputBuilderT, **kwargs: Any) -> _CRSInputBuilderT:
-        """Set technical top-level CRS options."""
+        """Set technical top-level CRS options.
+
+        Use expert_options() to list supported names.
+
+        Example:
+            builder.set_expert_options(pdh_correction=True)
+        """
         for key, value in kwargs.items():
             self._set_expert_option(key, value)
         return self

--- a/src/scm/plams/interfaces/adfsuite/crs_input_builder.py
+++ b/src/scm/plams/interfaces/adfsuite/crs_input_builder.py
@@ -1,0 +1,741 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any, ClassVar, Dict, List, Literal, Mapping, Optional, Sequence, Set, Tuple, Type, TypeVar, Union
+
+from scm.plams.core.settings import Settings
+from scm.plams.interfaces.adfsuite.crs_definitions import CRS_METHODS, get_block_keys, get_crs_input_data
+
+
+__all__ = [
+    "ACTIVITYCOEFInputBuilder",
+    "BINMIXCOEFInputBuilder",
+    "CRSInputBuilder",
+    "SOLUBILITYInputBuilder",
+    "input_builder",
+    "methods",
+]
+
+CRSMethodName = Literal[
+    "COSMO-RS",
+    "COSMOSAC2013",
+    "COSMOSAC2016",
+    "COSMOSACDHB",
+    "COSMOSACDHB-MESP",
+]
+
+_PathLike = Union[str, os.PathLike]
+_SolubilityMode = Literal["solid", "liquid", "gas"]
+_VLESweepMode = Literal["isotherm", "isobar", "flashpoint"]
+_FloatInput = Union[float, int]
+_FloatListInput = Union[_FloatInput, str, Sequence[_FloatInput]]
+
+_CRSInputBuilderT = TypeVar("_CRSInputBuilderT", bound="CRSInputBuilder")
+
+_METHOD_ALIASES = {
+    "COSMORS": "COSMO-RS",
+    "COSMOSAC": "COSMOSAC2013",
+}
+
+_VAPOR_PRESSURE_KEYS = ("pvap", "tvap", "vp_equation", "vp_params")
+_FUSION_KEYS = ("meltingpoint", "hfusion", "cpfusion")
+
+@dataclass(frozen=True)
+class _InputRoute:
+    """Route from a builder key to a PLAMS Settings location."""
+
+    scope: str
+    metadata: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class _CompoundRoleConfig:
+    """Compound role count limits and required keys."""
+
+    min_count: Optional[int] = None
+    max_count: Optional[int] = None
+    required_keys: Tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class _ModeOptionConfig:
+    """Input values enabled by one property mode."""
+
+    input_values: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class _ModeConfig:
+    """Mode-controlled input-key configuration."""
+
+    default: Optional[str] = None
+    options: Mapping[str, _ModeOptionConfig] = field(default_factory=dict)
+
+
+_SOLUBILITY_MODE_CONFIG = _ModeConfig(
+    default="solid",
+    options={
+        "solid": _ModeOptionConfig(),
+        "liquid": _ModeOptionConfig(),
+        "gas": _ModeOptionConfig(input_values={"isobar": True}),
+    },
+)
+
+_BINMIXCOEF_MODE_CONFIG = _ModeConfig(
+    default="isotherm",
+    options={
+        "isotherm": _ModeOptionConfig(input_values={"isotherm": True}),
+        "isobar": _ModeOptionConfig(input_values={"isobar": True}),
+        "flashpoint": _ModeOptionConfig(input_values={"flashpoint": True}),
+    },
+)
+
+
+class CRSInputBuilder:
+    """Base class for property-specific CRS input builders."""
+
+    __slots__ = (
+        "property_type",
+        "_job_cls",
+        "_values",
+        "_accepted_keys",
+        "_mode_config",
+        "_mode",
+        "_active_mode_input_keys",
+        "_compounds_by_role",
+        "_method",
+    )
+
+    _PROPERTY_TYPE: ClassVar[Optional[str]] = None
+    _DESCRIPTION: ClassVar[str] = ""
+
+    # Explicit builder input keys. Routes are derived from crs.json so values are
+    # written to either settings.input or settings.input.property. Mode config
+    # controls property-specific input keys such as isobar/isotherm/flashpoint.
+    _EXPOSED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ()
+    _REQUIRED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ()
+    _MODE_CONFIG: ClassVar[_ModeConfig] = _ModeConfig()
+
+    # Compound kwargs accepted by add_compound/add_solvent/add_solute methods.
+    # These keys can affect CRS calculations; role config defines supported roles, count limits, and required keys.
+    _CALCULATION_COMPOUND_KEYS: ClassVar[Tuple[str, ...]] = ()
+    _COMPOUND_ROLE_CONFIG: ClassVar[Mapping[str, _CompoundRoleConfig]] = {}
+
+
+    def __init__(
+        self,
+        *,
+        method: CRSMethodName = "COSMO-RS",
+        mode: Optional[str] = None,
+        job_cls: Optional[Type[Any]] = None,
+        **kwargs: Any,
+    ) -> None:
+        if self._PROPERTY_TYPE is None:
+            raise TypeError("CRSInputBuilder is a base class; use input_builder()")
+
+        self.property_type = self._PROPERTY_TYPE
+        self._job_cls = job_cls
+        self._values: Dict[str, Any] = {}
+        self._accepted_keys = self._build_accepted_keys()
+        self._mode_config = self._MODE_CONFIG
+        self._mode: Optional[str] = None
+        self._active_mode_input_keys: Set[str] = set()
+        self._compounds_by_role: Dict[str, List[Settings]] = {role: [] for role in self._compound_roles()}
+
+        self.method = method
+        self._set_mode_or_default(mode)
+        self.set(**kwargs)
+
+    @property
+    def method(self) -> str:
+        """COSMO-RS/SAC method name."""
+        return self._method
+
+    @method.setter
+    def method(self, method: CRSMethodName) -> None:
+        self._method = normalize_method(method)
+
+    @classmethod
+    def _build_accepted_keys(cls) -> Dict[str, _InputRoute]:
+        data = get_crs_input_data()
+        property_keys = get_block_keys(data, "property")
+        accepted: Dict[str, _InputRoute] = {}
+
+        for key in cls._EXPOSED_INPUT_KEYS:
+            accepted[key] = cls._input_route_from_schema(key, data, property_keys)
+
+        return accepted
+
+    @staticmethod
+    def _input_route_from_schema(
+        key: str,
+        data: Mapping[str, Any],
+        property_keys: Mapping[str, Any],
+    ) -> _InputRoute:
+        if key in data and data[key].get("kind") == "key":
+            return _InputRoute(scope="top_level", metadata=data[key])
+
+        if key in property_keys:
+            return _InputRoute(scope="property", metadata=property_keys[key])
+
+        raise ValueError(f"{key!r} is not a CRS top-level or PROPERTY input key")
+
+    def __dir__(self) -> List[str]:
+        entries = {
+            "describe",
+            "get",
+            "method",
+            "set",
+            "to_job",
+            "to_settings",
+        }
+        entries.update(self._accepted_keys)
+        if self._mode_config.options:
+            entries.update(("mode", "mode_options"))
+            entries.difference_update(self._mode_controlled_input_keys())
+        for role in self._compound_roles():
+            entries.add(f"add_{role}")
+            entries.add(f"add_{role}_from_database")
+        return sorted(entries)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Return a builder input value if set."""
+        if key == "method":
+            return self.method
+        if key == "mode":
+            return self.mode
+        self._validate_input_key(key)
+        return self._values.get(key, default)
+
+    def set(self: _CRSInputBuilderT, **kwargs: Any) -> _CRSInputBuilderT:
+        """Set one or more schema-backed CRS input values."""
+        self._reject_mode_controlled_keys(kwargs)
+        for key, value in kwargs.items():
+            self._set_input_value(key, value)
+        return self
+
+    def describe(self, *, include_values: bool = False, include_compound_details: bool = False) -> Tuple[str, ...]:
+        """Return concise descriptions of supported inputs and compound roles."""
+        lines = [f"{self.property_type}: {self._DESCRIPTION}", f"method [top_level]: {self.method}"]
+
+        for key, route in sorted(self._accepted_keys.items()):
+            if key in self._mode_controlled_input_keys():
+                continue
+            lines.append(self._format_key_description(key, route.scope, route.metadata, include_values=include_values))
+
+        if self._mode_config.options:
+            lines.append(f"mode: {', '.join(self._mode_config.options)}")
+
+        compound_keys = self._CALCULATION_COMPOUND_KEYS
+        if compound_keys and include_compound_details:
+            compound_key_metadata = get_block_keys(get_crs_input_data(), "compound")
+            for key in compound_keys:
+                lines.append(self._format_key_description(key, "compound", compound_key_metadata[key]))
+        elif compound_keys:
+            lines.append(f"compound_keys [compound]: {', '.join(compound_keys)}")
+
+        return tuple(lines)
+
+    def to_settings(self, *, include_compounds: bool = True) -> Settings:
+        """Build PLAMS Settings for this CRS input."""
+        self._validate_required_inputs()
+        if include_compounds:
+            self._validate_compound_role_counts()
+            self._validate_required_compound_keys()
+
+        settings = Settings()
+        settings.input.method = self.method
+        settings.input.property._h = self.property_type
+
+        for key, route in sorted(self._accepted_keys.items()):
+            if key not in self._values:
+                continue
+            if route.scope == "top_level":
+                settings.input[key] = self._values[key]
+            elif route.scope == "property":
+                settings.input.property[key] = self._values[key]
+
+        if include_compounds:
+            compounds = self._compound_blocks()
+            if compounds:
+                settings.input.compound = compounds
+
+        return settings
+
+    def to_job(self, name: Optional[str] = None, **kwargs: Any) -> Any:
+        """Build a CRSJob from this builder."""
+        if self._job_cls is None:
+            raise ValueError("to_job() requires a job class; use CRSJob.input_builder()")
+        if name is not None:
+            kwargs["name"] = name
+        return self._job_cls(settings=self.to_settings(), **kwargs)
+
+    def _set_input_value(self, key: str, value: Any) -> None:
+        self._validate_input_key(key)
+        self._values[key] = value
+
+    def _validate_input_key(self, key: str) -> None:
+        if key not in self._accepted_keys:
+            allowed = ", ".join(sorted(self._accepted_keys))
+            raise AttributeError(f"{key!r} is not valid for {self.property_type}. Allowed input keys: {allowed}")
+
+    def _set_mode_or_default(self, mode: Optional[str]) -> None:
+        selected_mode = self._mode_config.default if mode is None else mode
+        if selected_mode is not None:
+            self._set_mode(selected_mode)
+
+    def _set_mode(self, mode: str) -> None:
+        if not self._mode_config.options:
+            raise ValueError(f"{self.property_type} does not support mode")
+
+        normalized_mode = mode.lower()
+        option = self._mode_config.options.get(normalized_mode)
+        if option is None:
+            allowed = ", ".join(self._mode_config.options)
+            raise ValueError(f"Unsupported mode {mode!r} for {self.property_type}. Supported modes: {allowed}")
+
+        for key in self._active_mode_input_keys:
+            self._values.pop(key, None)
+
+        values = dict(option.input_values)
+        self._values.update(values)
+        self._active_mode_input_keys = set(values)
+        self._mode = normalized_mode
+
+    def _mode_controlled_input_keys(self) -> Set[str]:
+        keys: Set[str] = set()
+        for option in self._mode_config.options.values():
+            keys.update(option.input_values)
+        return keys
+
+    def _reject_mode_controlled_keys(self, values: Mapping[str, Any]) -> None:
+        provided = self._mode_controlled_input_keys().intersection(values)
+        if provided:
+            allowed_modes = ", ".join(self._mode_config.options)
+            raise ValueError(
+                f"{self.property_type} mode-controlled key(s) must be set with mode=, "
+                f"not directly: {', '.join(sorted(provided))}. Supported modes: {allowed_modes}"
+            )
+
+    def _add_compound_role(
+        self: _CRSInputBuilderT,
+        role: str,
+        compound: Union[Settings, _PathLike],
+        **kwargs: Any,
+    ) -> _CRSInputBuilderT:
+        if role not in self._compound_roles():
+            allowed = ", ".join(self._compound_roles()) or "none"
+            raise ValueError(f"{self.property_type} does not support {role!r} compounds. Supported roles: {allowed}")
+
+        self._validate_compound_role_max_count(role)
+        normalized = self._normalize_compound(compound)
+        self._set_compound_overrides(normalized, kwargs)
+        self._compounds_by_role[role].append(normalized)
+        return self
+
+    def _add_compound_role_from_database(
+        self: _CRSInputBuilderT,
+        role: str,
+        name: str,
+        **kwargs: Any,
+    ) -> _CRSInputBuilderT:
+        if self._job_cls is None:
+            raise ValueError("Database compounds require a job class; use CRSJob.input_builder()")
+        return self._add_compound_role(role, self._job_cls.coskf_from_adfcrs_database(name), **kwargs)
+
+    def _normalize_compound(self, compound: Union[Settings, _PathLike]) -> Settings:
+        if isinstance(compound, Settings):
+            return compound.copy()
+
+        settings = Settings()
+        settings._h = os.fspath(compound)
+        return settings
+
+    def _set_compound_overrides(self, compound: Settings, overrides: Mapping[str, Any]) -> None:
+        for key, value in overrides.items():
+            if value is None:
+                continue
+            self._validate_compound_key(key)
+            compound[key] = value
+
+    def _validate_compound_key(self, key: str) -> None:
+        allowed = set(self._CALCULATION_COMPOUND_KEYS)
+        if key not in allowed:
+            allowed_keys = ", ".join(sorted(allowed))
+            raise ValueError(f"{key!r} is not valid for {self.property_type} compounds. Supported keys: {allowed_keys}")
+
+        compound_keys = get_block_keys(get_crs_input_data(), "compound")
+        if key not in compound_keys:
+            raise ValueError(f"{key!r} is not a COMPOUND input key in crs.json")
+
+    def _compound_blocks(self) -> List[Settings]:
+        compounds: List[Settings] = []
+        for role in self._compound_roles():
+            compounds.extend(self._compounds_by_role[role])
+        return compounds
+
+    def _validate_required_inputs(self) -> None:
+        missing = [key for key in self._REQUIRED_INPUT_KEYS if key not in self._values]
+        if missing:
+            raise ValueError(f"{self.property_type} missing required input key(s): {', '.join(missing)}")
+
+    def _validate_compound_role_max_count(self, role: str) -> None:
+        config = self._COMPOUND_ROLE_CONFIG.get(role)
+        if config is not None and config.max_count is not None:
+            if len(self._compounds_by_role[role]) >= config.max_count:
+                raise ValueError(f"{self.property_type} supports at most {config.max_count} {role} compound(s)")
+
+    def _validate_compound_role_counts(self) -> None:
+        for role in self._compound_roles():
+            config = self._COMPOUND_ROLE_CONFIG.get(role, _CompoundRoleConfig())
+            count = len(self._compounds_by_role[role])
+            if config.min_count is not None and count < config.min_count:
+                raise ValueError(
+                    f"{self.property_type} requires at least {config.min_count} {role} compound(s); got {count}"
+                )
+            if config.max_count is not None and count > config.max_count:
+                raise ValueError(
+                    f"{self.property_type} supports at most {config.max_count} {role} compound(s); got {count}"
+                )
+
+    @classmethod
+    def _compound_roles(cls) -> Tuple[str, ...]:
+        return tuple(cls._COMPOUND_ROLE_CONFIG)
+
+    def _validate_required_compound_keys(self) -> None:
+        for role, config in self._COMPOUND_ROLE_CONFIG.items():
+            required_keys = config.required_keys
+            if not required_keys:
+                continue
+            for index, compound in enumerate(self._compounds_by_role.get(role, ()), start=1):
+                missing = [key for key in required_keys if not _has_compound_key(compound, key)]
+                if missing:
+                    raise ValueError(
+                        f"{self.property_type} {role} #{index} missing required key(s): {', '.join(missing)}"
+                    )
+
+    def _format_key_description(
+        self,
+        key: str,
+        scope: str,
+        metadata: Mapping[str, Any],
+        *,
+        include_values: bool = False,
+    ) -> str:
+        input_type = metadata.get("type", "")
+        unit = metadata.get("unit")
+        type_unit = f"{input_type} [{unit}]" if unit else input_type
+        line = f"{key} [{scope}] {type_unit}: {metadata.get('description', '')}"
+        if include_values:
+            line += f" value: {self._values.get(key)!r}"
+        return line
+
+
+class _SolventRoleMixin:
+    __slots__ = ()
+
+    def add_solvent(self: _CRSInputBuilderT, compound: Union[Settings, _PathLike], **kwargs: Any) -> _CRSInputBuilderT:
+        """Add a COMPOUND block as a solvent."""
+        return self._add_compound_role("solvent", compound, **kwargs)
+
+    def add_solvent_from_database(self: _CRSInputBuilderT, name: str, **kwargs: Any) -> _CRSInputBuilderT:
+        """Add a database COMPOUND block as a solvent."""
+        return self._add_compound_role_from_database("solvent", name, **kwargs)
+
+
+class _SoluteRoleMixin:
+    __slots__ = ()
+
+    def add_solute(self: _CRSInputBuilderT, compound: Union[Settings, _PathLike], **kwargs: Any) -> _CRSInputBuilderT:
+        """Add a COMPOUND block as a solute."""
+        return self._add_compound_role("solute", compound, **kwargs)
+
+    def add_solute_from_database(self: _CRSInputBuilderT, name: str, **kwargs: Any) -> _CRSInputBuilderT:
+        """Add a database COMPOUND block as a solute."""
+        return self._add_compound_role_from_database("solute", name, **kwargs)
+
+
+class _CompoundRoleMixin:
+    __slots__ = ()
+
+    def add_compound(self: _CRSInputBuilderT, compound: Union[Settings, _PathLike], **kwargs: Any) -> _CRSInputBuilderT:
+        """Add a generic COMPOUND block."""
+        return self._add_compound_role("compound", compound, **kwargs)
+
+    def add_compound_from_database(self: _CRSInputBuilderT, name: str, **kwargs: Any) -> _CRSInputBuilderT:
+        """Add a generic database COMPOUND block."""
+        return self._add_compound_role_from_database("compound", name, **kwargs)
+
+
+class _TemperatureMixin:
+    __slots__ = ()
+
+    @property
+    def temperature(self) -> Optional[_FloatInput]:
+        """Temperature input as a single value."""
+        return self.get("temperature")
+
+    @temperature.setter
+    def temperature(self, value: _FloatInput) -> None:
+        self._set_input_value("temperature", value)
+
+
+class _TemperatureListMixin:
+    __slots__ = ()
+
+    @property
+    def temperature(self) -> Optional[_FloatListInput]:
+        """Temperature input as a single value, range string, or sequence of values."""
+        return self.get("temperature")
+
+    @temperature.setter
+    def temperature(self, value: _FloatListInput) -> None:
+        self._set_input_value("temperature", value)
+
+
+class _PressureMixin:
+    __slots__ = ()
+
+    @property
+    def pressure(self) -> Optional[_FloatInput]:
+        """Pressure input as a single value."""
+        return self.get("pressure")
+
+    @pressure.setter
+    def pressure(self, value: _FloatInput) -> None:
+        self._set_input_value("pressure", value)
+
+
+class _PressureListMixin:
+    __slots__ = ()
+
+    @property
+    def pressure(self) -> Optional[_FloatListInput]:
+        """Pressure input as a single value, range string, or sequence of values."""
+        return self.get("pressure")
+
+    @pressure.setter
+    def pressure(self, value: _FloatListInput) -> None:
+        self._set_input_value("pressure", value)
+
+
+class _MassFractionMixin:
+    __slots__ = ()
+
+    @property
+    def massfraction(self) -> Optional[bool]:
+        """Use mass fractions instead of molar fractions."""
+        return self.get("massfraction")
+
+    @massfraction.setter
+    def massfraction(self, value: bool) -> None:
+        self._set_input_value("massfraction", value)
+
+
+class _DensitySolventMixin:
+    __slots__ = ()
+
+    @property
+    def densitysolvent(self) -> Optional[_FloatInput]:
+        """Density of the solvent."""
+        return self.get("densitysolvent")
+
+    @densitysolvent.setter
+    def densitysolvent(self, value: _FloatInput) -> None:
+        self._set_input_value("densitysolvent", value)
+
+
+class _NFracMixin:
+    __slots__ = ()
+
+    @property
+    def nfrac(self) -> Optional[int]:
+        """Number of different mixtures for mixture sweeps."""
+        return self.get("nfrac")
+
+    @nfrac.setter
+    def nfrac(self, value: int) -> None:
+        self._set_input_value("nfrac", value)
+
+
+class _SolubilityModeMixin:
+    __slots__ = ()
+
+    @property
+    def mode(self) -> Optional[_SolubilityMode]:
+        """Solubility mode: solid, liquid, or gas."""
+        return self._mode
+
+    @mode.setter
+    def mode(self, mode: _SolubilityMode) -> None:
+        self._set_mode(mode)
+
+    @property
+    def mode_options(self) -> Tuple[str, ...]:
+        """Supported solubility mode names."""
+        return self._mode_config.options
+
+
+class _VLESweepModeMixin:
+    __slots__ = ()
+
+    @property
+    def mode(self) -> Optional[_VLESweepMode]:
+        """VLE sweep mode: isotherm, isobar, or flashpoint."""
+        return self._mode
+
+    @mode.setter
+    def mode(self, mode: _VLESweepMode) -> None:
+        self._set_mode(mode)
+
+    @property
+    def mode_options(self) -> Tuple[str, ...]:
+        """Supported VLE sweep mode names."""
+        return self._mode_config.options
+
+
+class ACTIVITYCOEFInputBuilder(
+    _TemperatureListMixin,
+    _MassFractionMixin,
+    _DensitySolventMixin,
+    _SolventRoleMixin,
+    _SoluteRoleMixin,
+    CRSInputBuilder,
+):
+    """Builder for ACTIVITYCOEF CRS input settings."""
+
+    __slots__ = ()
+
+    _PROPERTY_TYPE: ClassVar[str] = "ACTIVITYCOEF"
+    _DESCRIPTION: ClassVar[str] = "Activity coefficients in a solvent mixture."
+    _EXPOSED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature", "massfraction", "densitysolvent")
+    _CALCULATION_COMPOUND_KEYS: ClassVar[Tuple[str, ...]] = ("frac1", "density") + _VAPOR_PRESSURE_KEYS
+    _REQUIRED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature",)
+    _COMPOUND_ROLE_CONFIG: ClassVar[Mapping[str, _CompoundRoleConfig]] = {
+        "solvent": _CompoundRoleConfig(required_keys=("frac1",)),
+        "solute": _CompoundRoleConfig(),
+    }
+
+
+class SOLUBILITYInputBuilder(
+    _TemperatureListMixin,
+    _PressureMixin,
+    _MassFractionMixin,
+    _DensitySolventMixin,
+    _SolubilityModeMixin,
+    _SolventRoleMixin,
+    _SoluteRoleMixin,
+    CRSInputBuilder,
+):
+    """Builder for SOLUBILITY CRS input settings."""
+
+    __slots__ = ()
+
+    _PROPERTY_TYPE: ClassVar[str] = "SOLUBILITY"
+    _DESCRIPTION: ClassVar[str] = "Solubility of solutes in a solvent mixture or under gas-pressure conditions."
+    _EXPOSED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = (
+        "temperature",
+        "pressure",
+        "massfraction",
+        "densitysolvent",
+        "isobar",
+    )
+    _REQUIRED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature",)
+    _CALCULATION_COMPOUND_KEYS: ClassVar[Tuple[str, ...]] = ("frac1", "density") + _FUSION_KEYS + _VAPOR_PRESSURE_KEYS
+    _COMPOUND_ROLE_CONFIG: ClassVar[Mapping[str, _CompoundRoleConfig]] = {
+        "solvent": _CompoundRoleConfig(required_keys=("frac1",)),
+        "solute": _CompoundRoleConfig(),
+    }
+    _MODE_CONFIG: ClassVar[_ModeConfig] = _SOLUBILITY_MODE_CONFIG
+
+    def _validate_required_compound_keys(self) -> None:
+        super()._validate_required_compound_keys()
+        if self.mode != "solid":
+            return
+
+        for index, compound in enumerate(self._compounds_by_role.get("solute", ()), start=1):
+            if not (_has_compound_key(compound, "meltingpoint") and _has_compound_key(compound, "hfusion")):
+                raise ValueError(
+                    f"{self.property_type} solute #{index} requires meltingpoint and hfusion for mode='solid'"
+                )
+
+
+class BINMIXCOEFInputBuilder(
+    _TemperatureMixin,
+    _PressureMixin,
+    _MassFractionMixin,
+    _NFracMixin,
+    _VLESweepModeMixin,
+    _CompoundRoleMixin,
+    CRSInputBuilder,
+):
+    """Builder for BINMIXCOEF CRS input settings."""
+
+    __slots__ = ()
+
+    _PROPERTY_TYPE: ClassVar[str] = "BINMIXCOEF"
+    _DESCRIPTION: ClassVar[str] = "Binary-mixture coefficients over a composition range."
+    _EXPOSED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = (
+        "temperature",
+        "pressure",
+        "massfraction",
+        "isotherm",
+        "isobar",
+        "flashpoint",
+        "nfrac",
+    )
+    _CALCULATION_COMPOUND_KEYS: ClassVar[Tuple[str, ...]] = ("frac1",) + _VAPOR_PRESSURE_KEYS + ("flashpoint",)
+    _REQUIRED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature",)
+    _COMPOUND_ROLE_CONFIG: ClassVar[Mapping[str, _CompoundRoleConfig]] = {
+        "compound": _CompoundRoleConfig(min_count=2, max_count=2),
+    }
+    _MODE_CONFIG: ClassVar[_ModeConfig] = _BINMIXCOEF_MODE_CONFIG
+
+
+_CRS_INPUT_BUILDER_CLASSES: Dict[str, Type[CRSInputBuilder]] = {
+    "ACTIVITYCOEF": ACTIVITYCOEFInputBuilder,
+    "SOLUBILITY": SOLUBILITYInputBuilder,
+    "BINMIXCOEF": BINMIXCOEFInputBuilder,
+}
+
+
+def input_builder(
+    property_type: str,
+    *,
+    method: CRSMethodName = "COSMO-RS",
+    mode: Optional[str] = None,
+    job_cls: Optional[Type[Any]] = None,
+    **kwargs: Any,
+) -> CRSInputBuilder:
+    """Return a property-specific CRS input builder."""
+    normalized_property_type = normalize_property_type(property_type)
+    builder_class = _CRS_INPUT_BUILDER_CLASSES[normalized_property_type]
+    return builder_class(method=method, mode=mode, job_cls=job_cls, **kwargs)
+
+
+def methods() -> Tuple[str, ...]:
+    """Return supported CRS method names."""
+    return CRS_METHODS
+
+
+def normalize_method(method: CRSMethodName) -> str:
+    """Normalize and validate a CRS method name."""
+    normalized = _METHOD_ALIASES.get(method.upper(), method.upper())
+    if normalized not in CRS_METHODS:
+        allowed = ", ".join(CRS_METHODS)
+        raise ValueError(f"Unsupported CRS method {method!r}. Supported methods: {allowed}")
+    return normalized
+
+
+def normalize_property_type(property_type: str) -> str:
+    """Normalize and validate a supported builder property type."""
+    normalized = property_type.upper()
+    if normalized not in _CRS_INPUT_BUILDER_CLASSES:
+        allowed = ", ".join(sorted(_CRS_INPUT_BUILDER_CLASSES))
+        raise ValueError(f"Unsupported CRS input builder property {property_type!r}. Supported properties: {allowed}")
+    return normalized
+
+
+def _has_compound_key(compound: Settings, key: str) -> bool:
+    return key in compound and compound[key] is not None

--- a/src/scm/plams/interfaces/adfsuite/crs_input_builder.py
+++ b/src/scm/plams/interfaces/adfsuite/crs_input_builder.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
-from typing import Any, ClassVar, Dict, List, Literal, Mapping, Optional, Sequence, Set, Tuple, Type, TypeVar, Union
+from typing import Any, Callable, ClassVar, Dict, List, Literal, Mapping, Optional, Sequence, Set, Tuple, Type, TypeVar, Union
 
 from scm.plams.core.functions import log
 from scm.plams.core.settings import Settings
@@ -12,8 +12,23 @@ from scm.plams.interfaces.adfsuite.crs_definitions import CRS_METHODS, get_block
 __all__ = [
     "ACTIVITYCOEFInputBuilder",
     "BINMIXCOEFInputBuilder",
+    "BOILINGPOINTInputBuilder",
+    "COMPOSITIONLINEInputBuilder",
     "CRSInputBuilder",
+    "FLASHPOINTInputBuilder",
+    "LLEInputBuilder",
+    "LOGPInputBuilder",
+    "PUREBOILINGPOINTInputBuilder",
+    "PURESIGMAPOTENTIALInputBuilder",
+    "PURESIGMAPROFILEInputBuilder",
+    "PURESOLUBILITYInputBuilder",
+    "PUREVAPORPRESSUREInputBuilder",
+    "SIGMAPOTENTIALInputBuilder",
+    "SIGMAPROFILEInputBuilder",
     "SOLUBILITYInputBuilder",
+    "STABILITYInputBuilder",
+    "TERNARYMIXInputBuilder",
+    "VAPORPRESSUREInputBuilder",
     "input_builder",
     "methods",
 ]
@@ -31,6 +46,7 @@ _SolubilityMode = Literal["solid", "liquid", "gas"]
 _VLESweepMode = Literal["isotherm", "isobar", "flashpoint"]
 _FloatInput = Union[float, int]
 _FloatListInput = Union[_FloatInput, str, Sequence[_FloatInput]]
+_IntegerListInput = Union[int, str, Sequence[int]]
 
 _CRSInputBuilderT = TypeVar("_CRSInputBuilderT", bound="CRSInputBuilder")
 
@@ -41,6 +57,17 @@ _METHOD_ALIASES = {
 
 _VAPOR_PRESSURE_KEYS = ("pvap", "tvap", "vp_equation", "vp_params")
 _FUSION_KEYS = ("meltingpoint", "hfusion", "cpfusion")
+_VLE_SWEEP_PROPERTY_KEYS = ("nfrac", "isotherm", "isobar", "flashpoint")
+_SIGMA_PROPERTY_KEYS = (
+    "nprofile",
+    "sigmamax",
+    "sigmamomentpower",
+    "sigmamomenthblevel",
+    "sigmamomenthbcutoff",
+    "sigmamomenthbcutoffbase",
+    "sigmamomenthbcutoffstep",
+)
+
 
 @dataclass(frozen=True)
 class _InputRoute:
@@ -64,6 +91,7 @@ class _ModeOptionConfig:
     """Input values enabled by one property mode."""
 
     input_values: Mapping[str, Any] = field(default_factory=dict)
+    required_input_keys: Tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -83,11 +111,11 @@ _SOLUBILITY_MODE_CONFIG = _ModeConfig(
     },
 )
 
-_BINMIXCOEF_MODE_CONFIG = _ModeConfig(
+_VLE_SWEEP_MODE_CONFIG = _ModeConfig(
     default="isotherm",
     options={
-        "isotherm": _ModeOptionConfig(input_values={"isotherm": True}),
-        "isobar": _ModeOptionConfig(input_values={"isobar": True}),
+        "isotherm": _ModeOptionConfig(input_values={"isotherm": True}, required_input_keys=("temperature",)),
+        "isobar": _ModeOptionConfig(input_values={"isobar": True}, required_input_keys=("pressure",)),
         "flashpoint": _ModeOptionConfig(input_values={"flashpoint": True}),
     },
 )
@@ -117,12 +145,9 @@ class CRSInputBuilder:
     _EXPOSED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ()
     _REQUIRED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ()
     _MODE_CONFIG: ClassVar[_ModeConfig] = _ModeConfig()
-    # Runtime value normalization for explicit builder inputs. These groups keep
-    # constructor kwargs, set(**kwargs), and property setters consistent.
-    _FLOAT_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ()
-    _FLOAT_LIST_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ()
-    _INT_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ()
-    _BOOL_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ()
+    # crs.json defines primitive input types. This builder-level override only
+    # constrains schema float_list keys that are semantically single values here.
+    _SINGLE_VALUE_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ()
 
     # Compound kwargs accepted by add_compound/add_solvent/add_solute methods.
     # These keys can affect CRS calculations; role config defines supported roles, count limits, and required keys.
@@ -284,13 +309,25 @@ class CRSInputBuilder:
         self._values[key] = value
 
     def _normalize_input_value(self, key: str, value: Any) -> Any:
-        if key in self._FLOAT_LIST_INPUT_KEYS:
-            return self._normalize_float_range_input(key, value)
-        if key in self._FLOAT_INPUT_KEYS:
+        input_type = self._accepted_keys[key].metadata.get("type")
+
+        if key in self._SINGLE_VALUE_INPUT_KEYS:
+            if input_type == "float_list":
+                self._validate_float_input(key, value)
+                return value
+            if input_type == "integer_list":
+                self._validate_int_input(key, value)
+                return value
+
+        if input_type == "float_list":
+            return self._normalize_float_list_input(key, value)
+        if input_type == "integer_list":
+            return self._normalize_integer_list_input(key, value)
+        if input_type == "float":
             self._validate_float_input(key, value)
-        elif key in self._INT_INPUT_KEYS:
+        elif input_type == "integer":
             self._validate_int_input(key, value)
-        elif key in self._BOOL_INPUT_KEYS:
+        elif input_type == "bool":
             self._validate_bool_input(key, value)
         return value
 
@@ -298,43 +335,50 @@ class CRSInputBuilder:
         if isinstance(value, bool) or not isinstance(value, (float, int)):
             raise TypeError(f"{key} must be a single float value")
 
-    def _normalize_float_range_input(self, key: str, value: _FloatListInput) -> Union[_FloatInput, str]:
+    def _normalize_float_list_input(self, key: str, value: _FloatListInput) -> Union[_FloatInput, str]:
         if isinstance(value, str):
-            self._validate_float_range_string(key, value)
+            self._validate_list_string(key, value, float, "float")
             return value
         if isinstance(value, bool):
-            raise TypeError(f"{key} must be a float value or a range [low, high, nsteps]")
+            raise TypeError(f"{key} must be a float value or a list of float values")
         if isinstance(value, (float, int)):
             return value
         if isinstance(value, Sequence):
-            if len(value) != 3:
-                raise ValueError(f"{key} range must contain [low, high, nsteps]")
-            low, high, nsteps = value
-            if (
-                isinstance(low, bool)
-                or isinstance(high, bool)
-                or isinstance(nsteps, bool)
-                or not isinstance(low, (float, int))
-                or not isinstance(high, (float, int))
-                or not isinstance(nsteps, int)
-            ):
-                raise TypeError(f"{key} range must be [float, float, int]")
-            return f"{low} {high} {nsteps}"
+            if not value:
+                raise ValueError(f"{key} float list must not be empty")
+            if any(isinstance(item, bool) or not isinstance(item, (float, int)) for item in value):
+                raise TypeError(f"{key} must be a float value or a list of float values")
+            return " ".join(str(item) for item in value)
 
-        raise TypeError(f"{key} must be a float value or a range [low, high, nsteps]")
+        raise TypeError(f"{key} must be a float value or a list of float values")
 
-    def _validate_float_range_string(self, key: str, value: str) -> None:
+    def _normalize_integer_list_input(self, key: str, value: _IntegerListInput) -> Union[int, str]:
+        if isinstance(value, str):
+            self._validate_list_string(key, value, int, "integer")
+            return value
+        if isinstance(value, bool):
+            raise TypeError(f"{key} must be an integer value or a list of integer values")
+        if isinstance(value, int):
+            return value
+        if isinstance(value, Sequence):
+            if not value:
+                raise ValueError(f"{key} integer list must not be empty")
+            if any(isinstance(item, bool) or not isinstance(item, int) for item in value):
+                raise TypeError(f"{key} must be an integer value or a list of integer values")
+            return " ".join(str(item) for item in value)
+
+        raise TypeError(f"{key} must be an integer value or a list of integer values")
+
+    def _validate_list_string(self, key: str, value: str, converter: Callable[[str], Any], value_name: str) -> None:
         fields = value.split()
-        if len(fields) not in (1, 3):
-            raise ValueError(f"{key} must be a single value or range: low high nsteps")
+        if not fields:
+            raise ValueError(f"{key} {value_name} list must not be empty")
 
         try:
-            float(fields[0])
-            if len(fields) == 3:
-                float(fields[1])
-                int(fields[2])
+            for field in fields:
+                converter(field)
         except ValueError as exc:
-            raise TypeError(f"{key} range string must be: float float int") from exc
+            raise TypeError(f"{key} string must contain only {value_name} values") from exc
 
     def _validate_int_input(self, key: str, value: Any) -> None:
         if isinstance(value, bool) or not isinstance(value, int):
@@ -446,7 +490,11 @@ class CRSInputBuilder:
         return compounds
 
     def _validate_required_inputs(self) -> None:
-        missing = [key for key in self._REQUIRED_INPUT_KEYS if key not in self._values]
+        required_keys = list(self._REQUIRED_INPUT_KEYS)
+        if self._mode is not None:
+            required_keys.extend(self._mode_config.options[self._mode].required_input_keys)
+
+        missing = [key for key in required_keys if key not in self._values]
         if missing:
             raise ValueError(f"{self.property_type} missing required input key(s): {', '.join(missing)}")
 
@@ -629,6 +677,76 @@ class _NFracMixin:
         self._set_input_value("nfrac", value)
 
 
+class _SigmaMomentMixin:
+    __slots__ = ()
+
+    @property
+    def sigmamomentpower(self) -> Optional[_IntegerListInput]:
+        """Powers used for sigma moment output."""
+        return self.get("sigmamomentpower")
+
+    @sigmamomentpower.setter
+    def sigmamomentpower(self, value: _IntegerListInput) -> None:
+        self._set_input_value("sigmamomentpower", value)
+
+    @property
+    def sigmamomenthblevel(self) -> Optional[_IntegerListInput]:
+        """Hydrogen-bond sigma moment cutoff levels."""
+        return self.get("sigmamomenthblevel")
+
+    @sigmamomenthblevel.setter
+    def sigmamomenthblevel(self, value: _IntegerListInput) -> None:
+        self._set_input_value("sigmamomenthblevel", value)
+
+    @property
+    def sigmamomenthbcutoff(self) -> Optional[_FloatInput]:
+        """Hydrogen-bond sigma moment cutoff for level 1."""
+        return self.get("sigmamomenthbcutoff")
+
+    @sigmamomenthbcutoff.setter
+    def sigmamomenthbcutoff(self, value: _FloatInput) -> None:
+        self._set_input_value("sigmamomenthbcutoff", value)
+
+    @property
+    def sigmamomenthbcutoffbase(self) -> Optional[_FloatInput]:
+        """Base cutoff used for hydrogen-bond sigma moment levels above 1."""
+        return self.get("sigmamomenthbcutoffbase")
+
+    @sigmamomenthbcutoffbase.setter
+    def sigmamomenthbcutoffbase(self, value: _FloatInput) -> None:
+        self._set_input_value("sigmamomenthbcutoffbase", value)
+
+    @property
+    def sigmamomenthbcutoffstep(self) -> Optional[_FloatInput]:
+        """Cutoff increment used for hydrogen-bond sigma moment levels above 1."""
+        return self.get("sigmamomenthbcutoffstep")
+
+    @sigmamomenthbcutoffstep.setter
+    def sigmamomenthbcutoffstep(self, value: _FloatInput) -> None:
+        self._set_input_value("sigmamomenthbcutoffstep", value)
+
+
+class _SigmaMixin:
+    __slots__ = ()
+
+    @property
+    def nprofile(self) -> Optional[int]:
+        """Number of sigma profile or sigma potential data points."""
+        return self.get("nprofile")
+
+    @nprofile.setter
+    def nprofile(self, value: int) -> None:
+        self._set_input_value("nprofile", value)
+
+    @property
+    def sigmamax(self) -> Optional[_FloatInput]:
+        """Maximum sigma value for sigma profile or sigma potential output."""
+        return self.get("sigmamax")
+
+    @sigmamax.setter
+    def sigmamax(self, value: _FloatInput) -> None:
+        self._set_input_value("sigmamax", value)
+
 class _SolubilityModeMixin:
     __slots__ = ()
 
@@ -644,7 +762,7 @@ class _SolubilityModeMixin:
     @property
     def mode_options(self) -> Tuple[str, ...]:
         """Supported solubility mode names."""
-        return self._mode_config.options
+        return tuple(self._mode_config.options)
 
 
 class _VLESweepModeMixin:
@@ -662,7 +780,7 @@ class _VLESweepModeMixin:
     @property
     def mode_options(self) -> Tuple[str, ...]:
         """Supported VLE sweep mode names."""
-        return self._mode_config.options
+        return tuple(self._mode_config.options)
 
 
 class ACTIVITYCOEFInputBuilder(
@@ -681,13 +799,44 @@ class ACTIVITYCOEFInputBuilder(
     _DESCRIPTION: ClassVar[str] = "Activity coefficients in a solvent mixture."
     _EXPOSED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature", "massfraction", "densitysolvent")
     _REQUIRED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature",)
-    _FLOAT_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature", "densitysolvent")
-    _BOOL_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("massfraction",)
+    _SINGLE_VALUE_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature",)
     _CALCULATION_COMPOUND_KEYS: ClassVar[Tuple[str, ...]] = ("frac1", "density") + _VAPOR_PRESSURE_KEYS
     _COMPOUND_ROLE_CONFIG: ClassVar[Mapping[str, _CompoundRoleConfig]] = {
         "solvent": _CompoundRoleConfig(required_keys=("frac1",)),
         "solute": _CompoundRoleConfig(),
     }
+
+
+class LOGPInputBuilder(
+    _TemperatureMixin,
+    _MassFractionMixin,
+    _SolventRoleMixin,
+    _SoluteRoleMixin,
+    CRSInputBuilder,
+):
+    """Builder for LOGP CRS input settings."""
+
+    __slots__ = ()
+
+    _PROPERTY_TYPE: ClassVar[str] = "LOGP"
+    _DESCRIPTION: ClassVar[str] = "Partition coefficients between two immiscible solvent phases."
+    _EXPOSED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature", "massfraction", "volumequotient")
+    _REQUIRED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature",)
+    _SINGLE_VALUE_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature",)
+    _CALCULATION_COMPOUND_KEYS: ClassVar[Tuple[str, ...]] = ("frac1", "frac2", "density")
+    _COMPOUND_ROLE_CONFIG: ClassVar[Mapping[str, _CompoundRoleConfig]] = {
+        "solvent": _CompoundRoleConfig(min_count=2, required_keys=("frac1", "frac2")),
+        "solute": _CompoundRoleConfig(min_count=1),
+    }
+
+    @property
+    def volumequotient(self) -> Optional[_FloatInput]:
+        """Molar-volume ratio of solvent 1 to solvent 2."""
+        return self.get("volumequotient")
+
+    @volumequotient.setter
+    def volumequotient(self, value: _FloatInput) -> None:
+        self._set_input_value("volumequotient", value)
 
 
 class SOLUBILITYInputBuilder(
@@ -714,9 +863,7 @@ class SOLUBILITYInputBuilder(
         "isobar",
     )
     _REQUIRED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature",)
-    _FLOAT_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("pressure", "densitysolvent")
-    _FLOAT_LIST_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature",)
-    _BOOL_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("massfraction",)
+    _SINGLE_VALUE_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("pressure",)
     _CALCULATION_COMPOUND_KEYS: ClassVar[Tuple[str, ...]] = ("frac1", "density") + _FUSION_KEYS + _VAPOR_PRESSURE_KEYS
     _COMPOUND_ROLE_CONFIG: ClassVar[Mapping[str, _CompoundRoleConfig]] = {
         "solvent": _CompoundRoleConfig(required_keys=("frac1",)),
@@ -734,6 +881,139 @@ class SOLUBILITYInputBuilder(
                 raise ValueError(
                     f"{self.property_type} solute #{index} requires meltingpoint and hfusion for mode='solid'"
                 )
+
+
+class PURESOLUBILITYInputBuilder(
+    _TemperatureListMixin,
+    _PressureMixin,
+    _SolubilityModeMixin,
+    _SolventRoleMixin,
+    _SoluteRoleMixin,
+    CRSInputBuilder,
+):
+    """Builder for PURESOLUBILITY CRS input settings."""
+
+    __slots__ = ()
+
+    _PROPERTY_TYPE: ClassVar[str] = "PURESOLUBILITY"
+    _DESCRIPTION: ClassVar[str] = "Solubility of a solute in pure solvents over a temperature range."
+    _EXPOSED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature", "pressure", "isobar")
+    _REQUIRED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature",)
+    _SINGLE_VALUE_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("pressure",)
+    _CALCULATION_COMPOUND_KEYS: ClassVar[Tuple[str, ...]] = ("frac1", "density") + _FUSION_KEYS + _VAPOR_PRESSURE_KEYS
+    _COMPOUND_ROLE_CONFIG: ClassVar[Mapping[str, _CompoundRoleConfig]] = {
+        "solvent": _CompoundRoleConfig(min_count=1),
+        "solute": _CompoundRoleConfig(min_count=1, max_count=1),
+    }
+    _MODE_CONFIG: ClassVar[_ModeConfig] = _SOLUBILITY_MODE_CONFIG
+
+    def _validate_required_compound_keys(self) -> None:
+        super()._validate_required_compound_keys()
+        if self.mode != "solid":
+            return
+
+        for index, compound in enumerate(self._compounds_by_role.get("solute", ()), start=1):
+            if not (_has_compound_key(compound, "meltingpoint") and _has_compound_key(compound, "hfusion")):
+                raise ValueError(
+                    f"{self.property_type} solute #{index} requires meltingpoint and hfusion for mode='solid'"
+                )
+
+
+class VAPORPRESSUREInputBuilder(
+    _TemperatureMixin,
+    _MassFractionMixin,
+    _CompoundRoleMixin,
+    CRSInputBuilder,
+):
+    """Builder for VAPORPRESSURE CRS input settings."""
+
+    __slots__ = ()
+
+    _PROPERTY_TYPE: ClassVar[str] = "VAPORPRESSURE"
+    _DESCRIPTION: ClassVar[str] = "Vapor pressure of a mixture at fixed temperature."
+    _EXPOSED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature", "massfraction")
+    _REQUIRED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature",)
+    _SINGLE_VALUE_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature",)
+    _CALCULATION_COMPOUND_KEYS: ClassVar[Tuple[str, ...]] = ("frac1",) + _VAPOR_PRESSURE_KEYS
+    _COMPOUND_ROLE_CONFIG: ClassVar[Mapping[str, _CompoundRoleConfig]] = {
+        "compound": _CompoundRoleConfig(required_keys=("frac1",)),
+    }
+
+
+class PUREVAPORPRESSUREInputBuilder(
+    _TemperatureListMixin,
+    _CompoundRoleMixin,
+    CRSInputBuilder,
+):
+    """Builder for PUREVAPORPRESSURE CRS input settings."""
+
+    __slots__ = ()
+
+    _PROPERTY_TYPE: ClassVar[str] = "PUREVAPORPRESSURE"
+    _DESCRIPTION: ClassVar[str] = "Pure-compound vapor pressure over a temperature range."
+    _EXPOSED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature",)
+    _REQUIRED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature",)
+    _CALCULATION_COMPOUND_KEYS: ClassVar[Tuple[str, ...]] = _VAPOR_PRESSURE_KEYS
+    _COMPOUND_ROLE_CONFIG: ClassVar[Mapping[str, _CompoundRoleConfig]] = {
+        "compound": _CompoundRoleConfig(),
+    }
+
+
+class BOILINGPOINTInputBuilder(
+    _PressureListMixin,
+    _MassFractionMixin,
+    _CompoundRoleMixin,
+    CRSInputBuilder,
+):
+    """Builder for BOILINGPOINT CRS input settings."""
+
+    __slots__ = ()
+
+    _PROPERTY_TYPE: ClassVar[str] = "BOILINGPOINT"
+    _DESCRIPTION: ClassVar[str] = "Boiling temperature of a mixture for a pressure range."
+    _EXPOSED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("pressure", "massfraction")
+    _REQUIRED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("pressure",)
+    _CALCULATION_COMPOUND_KEYS: ClassVar[Tuple[str, ...]] = ("frac1",) + _VAPOR_PRESSURE_KEYS
+    _COMPOUND_ROLE_CONFIG: ClassVar[Mapping[str, _CompoundRoleConfig]] = {
+        "compound": _CompoundRoleConfig(),
+    }
+
+
+class PUREBOILINGPOINTInputBuilder(
+    _PressureListMixin,
+    _CompoundRoleMixin,
+    CRSInputBuilder,
+):
+    """Builder for PUREBOILINGPOINT CRS input settings."""
+
+    __slots__ = ()
+
+    _PROPERTY_TYPE: ClassVar[str] = "PUREBOILINGPOINT"
+    _DESCRIPTION: ClassVar[str] = "Pure-compound boiling point over a pressure range."
+    _EXPOSED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("pressure",)
+    _REQUIRED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("pressure",)
+    _CALCULATION_COMPOUND_KEYS: ClassVar[Tuple[str, ...]] = _VAPOR_PRESSURE_KEYS
+    _COMPOUND_ROLE_CONFIG: ClassVar[Mapping[str, _CompoundRoleConfig]] = {
+        "compound": _CompoundRoleConfig(),
+    }
+
+
+class FLASHPOINTInputBuilder(
+    _MassFractionMixin,
+    _CompoundRoleMixin,
+    CRSInputBuilder,
+):
+    """Builder for FLASHPOINT CRS input settings."""
+
+    __slots__ = ()
+
+    _PROPERTY_TYPE: ClassVar[str] = "FLASHPOINT"
+    _DESCRIPTION: ClassVar[str] = "Flash point of a mixture using user-supplied pure-compound flash points."
+    _EXPOSED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("massfraction",)
+    _CALCULATION_COMPOUND_KEYS: ClassVar[Tuple[str, ...]] = ("frac1", "flashpoint") + _VAPOR_PRESSURE_KEYS
+    _COMPOUND_ROLE_CONFIG: ClassVar[Mapping[str, _CompoundRoleConfig]] = {
+        "compound": _CompoundRoleConfig(required_keys=("frac1",)),
+    }
 
 
 class BINMIXCOEFInputBuilder(
@@ -761,20 +1041,215 @@ class BINMIXCOEFInputBuilder(
         "nfrac",
     )
     _CALCULATION_COMPOUND_KEYS: ClassVar[Tuple[str, ...]] = ("frac1",) + _VAPOR_PRESSURE_KEYS + ("flashpoint",)
-    _REQUIRED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature",)
-    _FLOAT_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature", "pressure")
-    _INT_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("nfrac",)
-    _BOOL_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("massfraction",)
+    _SINGLE_VALUE_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature", "pressure")
     _COMPOUND_ROLE_CONFIG: ClassVar[Mapping[str, _CompoundRoleConfig]] = {
         "compound": _CompoundRoleConfig(min_count=2, max_count=2),
     }
-    _MODE_CONFIG: ClassVar[_ModeConfig] = _BINMIXCOEF_MODE_CONFIG
+    _MODE_CONFIG: ClassVar[_ModeConfig] = _VLE_SWEEP_MODE_CONFIG
+
+
+class TERNARYMIXInputBuilder(
+    _TemperatureMixin,
+    _PressureMixin,
+    _MassFractionMixin,
+    _NFracMixin,
+    _VLESweepModeMixin,
+    _CompoundRoleMixin,
+    CRSInputBuilder,
+):
+    """Builder for TERNARYMIX CRS input settings."""
+
+    __slots__ = ()
+
+    _PROPERTY_TYPE: ClassVar[str] = "TERNARYMIX"
+    _DESCRIPTION: ClassVar[str] = "Ternary mixture property sweep over composition space."
+    _EXPOSED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = (
+        "temperature",
+        "pressure",
+        "massfraction",
+        *_VLE_SWEEP_PROPERTY_KEYS,
+    )
+    _SINGLE_VALUE_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature", "pressure")
+    _CALCULATION_COMPOUND_KEYS: ClassVar[Tuple[str, ...]] = ("frac1",) + _VAPOR_PRESSURE_KEYS + ("flashpoint",)
+    _COMPOUND_ROLE_CONFIG: ClassVar[Mapping[str, _CompoundRoleConfig]] = {
+        "compound": _CompoundRoleConfig(min_count=3, max_count=3),
+    }
+    _MODE_CONFIG: ClassVar[_ModeConfig] = _VLE_SWEEP_MODE_CONFIG
+
+
+class COMPOSITIONLINEInputBuilder(
+    _TemperatureMixin,
+    _PressureMixin,
+    _MassFractionMixin,
+    _NFracMixin,
+    _VLESweepModeMixin,
+    _SolventRoleMixin,
+    CRSInputBuilder,
+):
+    """Builder for COMPOSITIONLINE CRS input settings."""
+
+    __slots__ = ()
+
+    _PROPERTY_TYPE: ClassVar[str] = "COMPOSITIONLINE"
+    _DESCRIPTION: ClassVar[str] = "Composition-line calculation between two endpoint phase compositions."
+    _EXPOSED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = (
+        "temperature",
+        "pressure",
+        "massfraction",
+        *_VLE_SWEEP_PROPERTY_KEYS,
+    )
+    _SINGLE_VALUE_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature", "pressure")
+    _CALCULATION_COMPOUND_KEYS: ClassVar[Tuple[str, ...]] = (
+        "frac1",
+        "frac2",
+    ) + _VAPOR_PRESSURE_KEYS + ("flashpoint",)
+    _COMPOUND_ROLE_CONFIG: ClassVar[Mapping[str, _CompoundRoleConfig]] = {
+        "solvent": _CompoundRoleConfig(),
+    }
+    _MODE_CONFIG: ClassVar[_ModeConfig] = _VLE_SWEEP_MODE_CONFIG
+
+
+class LLEInputBuilder(
+    _TemperatureMixin,
+    _MassFractionMixin,
+    _CompoundRoleMixin,
+    CRSInputBuilder,
+):
+    """Builder for LLE CRS input settings."""
+
+    __slots__ = ()
+
+    _PROPERTY_TYPE: ClassVar[str] = "LLE"
+    _DESCRIPTION: ClassVar[str] = "Liquid-liquid equilibrium for a ternary mixture."
+    _EXPOSED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature", "massfraction")
+    _REQUIRED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature",)
+    _SINGLE_VALUE_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature",)
+    _CALCULATION_COMPOUND_KEYS: ClassVar[Tuple[str, ...]] = ("frac1",)
+    _COMPOUND_ROLE_CONFIG: ClassVar[Mapping[str, _CompoundRoleConfig]] = {
+        "compound": _CompoundRoleConfig(required_keys=("frac1",)),
+    }
+
+
+class STABILITYInputBuilder(
+    _TemperatureMixin,
+    _MassFractionMixin,
+    _CompoundRoleMixin,
+    CRSInputBuilder,
+):
+    """Builder for STABILITY CRS input settings."""
+
+    __slots__ = ()
+
+    _PROPERTY_TYPE: ClassVar[str] = "STABILITY"
+    _DESCRIPTION: ClassVar[str] = "Michelsen tangent-plane-distance stability test for a feed composition."
+    _EXPOSED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature", "massfraction")
+    _REQUIRED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature",)
+    _SINGLE_VALUE_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature",)
+    _CALCULATION_COMPOUND_KEYS: ClassVar[Tuple[str, ...]] = ("frac1",)
+    _COMPOUND_ROLE_CONFIG: ClassVar[Mapping[str, _CompoundRoleConfig]] = {
+        "compound": _CompoundRoleConfig(required_keys=("frac1",)),
+    }
+
+
+class SIGMAPROFILEInputBuilder(
+    _MassFractionMixin,
+    _SigmaMixin,
+    _SigmaMomentMixin,
+    _CompoundRoleMixin,
+    CRSInputBuilder,
+):
+    """Builder for SIGMAPROFILE CRS input settings."""
+
+    __slots__ = ()
+
+    _PROPERTY_TYPE: ClassVar[str] = "SIGMAPROFILE"
+    _DESCRIPTION: ClassVar[str] = "Sigma profile for a solvent mixture."
+    _EXPOSED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("massfraction", *_SIGMA_PROPERTY_KEYS)
+    _CALCULATION_COMPOUND_KEYS: ClassVar[Tuple[str, ...]] = ("frac1",)
+    _COMPOUND_ROLE_CONFIG: ClassVar[Mapping[str, _CompoundRoleConfig]] = {
+        "compound": _CompoundRoleConfig(required_keys=("frac1",)),
+    }
+
+
+class PURESIGMAPROFILEInputBuilder(
+    _SigmaMixin,
+    _SigmaMomentMixin,
+    _CompoundRoleMixin,
+    CRSInputBuilder,
+):
+    """Builder for PURESIGMAPROFILE CRS input settings."""
+
+    __slots__ = ()
+
+    _PROPERTY_TYPE: ClassVar[str] = "PURESIGMAPROFILE"
+    _DESCRIPTION: ClassVar[str] = "Sigma profile for pure compounds."
+    _EXPOSED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = _SIGMA_PROPERTY_KEYS
+    _COMPOUND_ROLE_CONFIG: ClassVar[Mapping[str, _CompoundRoleConfig]] = {
+        "compound": _CompoundRoleConfig(),
+    }
+
+
+class SIGMAPOTENTIALInputBuilder(
+    _TemperatureMixin,
+    _MassFractionMixin,
+    _SigmaMixin,
+    _CompoundRoleMixin,
+    CRSInputBuilder,
+):
+    """Builder for SIGMAPOTENTIAL CRS input settings."""
+
+    __slots__ = ()
+
+    _PROPERTY_TYPE: ClassVar[str] = "SIGMAPOTENTIAL"
+    _DESCRIPTION: ClassVar[str] = "Sigma potential for a solvent mixture."
+    _EXPOSED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature", "massfraction", *_SIGMA_PROPERTY_KEYS)
+    _REQUIRED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature",)
+    _SINGLE_VALUE_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature",)
+    _CALCULATION_COMPOUND_KEYS: ClassVar[Tuple[str, ...]] = ("frac1",)
+    _COMPOUND_ROLE_CONFIG: ClassVar[Mapping[str, _CompoundRoleConfig]] = {
+        "compound": _CompoundRoleConfig(required_keys=("frac1",)),
+    }
+
+
+class PURESIGMAPOTENTIALInputBuilder(
+    _TemperatureMixin,
+    _SigmaMixin,
+    _CompoundRoleMixin,
+    CRSInputBuilder,
+):
+    """Builder for PURESIGMAPOTENTIAL CRS input settings."""
+
+    __slots__ = ()
+
+    _PROPERTY_TYPE: ClassVar[str] = "PURESIGMAPOTENTIAL"
+    _DESCRIPTION: ClassVar[str] = "Sigma potential for pure compounds."
+    _EXPOSED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature", *_SIGMA_PROPERTY_KEYS)
+    _REQUIRED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature",)
+    _SINGLE_VALUE_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature",)
+    _COMPOUND_ROLE_CONFIG: ClassVar[Mapping[str, _CompoundRoleConfig]] = {
+        "compound": _CompoundRoleConfig(),
+    }
 
 
 _CRS_INPUT_BUILDER_CLASSES: Dict[str, Type[CRSInputBuilder]] = {
     "ACTIVITYCOEF": ACTIVITYCOEFInputBuilder,
+    "LOGP": LOGPInputBuilder,
     "SOLUBILITY": SOLUBILITYInputBuilder,
+    "PURESOLUBILITY": PURESOLUBILITYInputBuilder,
+    "VAPORPRESSURE": VAPORPRESSUREInputBuilder,
+    "PUREVAPORPRESSURE": PUREVAPORPRESSUREInputBuilder,
+    "BOILINGPOINT": BOILINGPOINTInputBuilder,
+    "PUREBOILINGPOINT": PUREBOILINGPOINTInputBuilder,
+    "FLASHPOINT": FLASHPOINTInputBuilder,
     "BINMIXCOEF": BINMIXCOEFInputBuilder,
+    "TERNARYMIX": TERNARYMIXInputBuilder,
+    "COMPOSITIONLINE": COMPOSITIONLINEInputBuilder,
+    "LLE": LLEInputBuilder,
+    "STABILITY": STABILITYInputBuilder,
+    "SIGMAPROFILE": SIGMAPROFILEInputBuilder,
+    "PURESIGMAPROFILE": PURESIGMAPROFILEInputBuilder,
+    "SIGMAPOTENTIAL": SIGMAPOTENTIALInputBuilder,
+    "PURESIGMAPOTENTIAL": PURESIGMAPOTENTIALInputBuilder,
 }
 
 

--- a/src/scm/plams/interfaces/adfsuite/crs_input_builder.py
+++ b/src/scm/plams/interfaces/adfsuite/crs_input_builder.py
@@ -116,6 +116,12 @@ class CRSInputBuilder:
     _EXPOSED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ()
     _REQUIRED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ()
     _MODE_CONFIG: ClassVar[_ModeConfig] = _ModeConfig()
+    # Runtime value normalization for explicit builder inputs. These groups keep
+    # constructor kwargs, set(**kwargs), and property setters consistent.
+    _FLOAT_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ()
+    _FLOAT_LIST_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ()
+    _INT_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ()
+    _BOOL_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ()
 
     # Compound kwargs accepted by add_compound/add_solvent/add_solute methods.
     # These keys can affect CRS calculations; role config defines supported roles, count limits, and required keys.
@@ -273,7 +279,69 @@ class CRSInputBuilder:
 
     def _set_input_value(self, key: str, value: Any) -> None:
         self._validate_input_key(key)
+        value = self._normalize_input_value(key, value)
         self._values[key] = value
+
+    def _normalize_input_value(self, key: str, value: Any) -> Any:
+        if key in self._FLOAT_LIST_INPUT_KEYS:
+            return self._normalize_float_range_input(key, value)
+        if key in self._FLOAT_INPUT_KEYS:
+            self._validate_float_input(key, value)
+        elif key in self._INT_INPUT_KEYS:
+            self._validate_int_input(key, value)
+        elif key in self._BOOL_INPUT_KEYS:
+            self._validate_bool_input(key, value)
+        return value
+
+    def _validate_float_input(self, key: str, value: Any) -> None:
+        if isinstance(value, bool) or not isinstance(value, (float, int)):
+            raise TypeError(f"{key} must be a single float value")
+
+    def _normalize_float_range_input(self, key: str, value: _FloatListInput) -> Union[_FloatInput, str]:
+        if isinstance(value, str):
+            self._validate_float_range_string(key, value)
+            return value
+        if isinstance(value, bool):
+            raise TypeError(f"{key} must be a float value or a range [low, high, nsteps]")
+        if isinstance(value, (float, int)):
+            return value
+        if isinstance(value, Sequence):
+            if len(value) != 3:
+                raise ValueError(f"{key} range must contain [low, high, nsteps]")
+            low, high, nsteps = value
+            if (
+                isinstance(low, bool)
+                or isinstance(high, bool)
+                or isinstance(nsteps, bool)
+                or not isinstance(low, (float, int))
+                or not isinstance(high, (float, int))
+                or not isinstance(nsteps, int)
+            ):
+                raise TypeError(f"{key} range must be [float, float, int]")
+            return f"{low} {high} {nsteps}"
+
+        raise TypeError(f"{key} must be a float value or a range [low, high, nsteps]")
+
+    def _validate_float_range_string(self, key: str, value: str) -> None:
+        fields = value.split()
+        if len(fields) not in (1, 3):
+            raise ValueError(f"{key} must be a single value or range: low high nsteps")
+
+        try:
+            float(fields[0])
+            if len(fields) == 3:
+                float(fields[1])
+                int(fields[2])
+        except ValueError as exc:
+            raise TypeError(f"{key} range string must be: float float int") from exc
+
+    def _validate_int_input(self, key: str, value: Any) -> None:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError(f"{key} must be an integer value")
+
+    def _validate_bool_input(self, key: str, value: Any) -> None:
+        if not isinstance(value, bool):
+            raise TypeError(f"{key} must be a boolean value")
 
     def _validate_input_key(self, key: str) -> None:
         if key not in self._accepted_keys:
@@ -473,7 +541,7 @@ class _TemperatureMixin:
 
     @property
     def temperature(self) -> Optional[_FloatInput]:
-        """Temperature input as a single value."""
+        """Temperature in K as a single value."""
         return self.get("temperature")
 
     @temperature.setter
@@ -486,7 +554,7 @@ class _TemperatureListMixin:
 
     @property
     def temperature(self) -> Optional[_FloatListInput]:
-        """Temperature input as a single value, range string, or sequence of values."""
+        """Temperature in K as a single value or range [temperature, temperature_high, nsteps]."""
         return self.get("temperature")
 
     @temperature.setter
@@ -499,7 +567,7 @@ class _PressureMixin:
 
     @property
     def pressure(self) -> Optional[_FloatInput]:
-        """Pressure input as a single value."""
+        """Pressure in bar as a single value."""
         return self.get("pressure")
 
     @pressure.setter
@@ -512,7 +580,7 @@ class _PressureListMixin:
 
     @property
     def pressure(self) -> Optional[_FloatListInput]:
-        """Pressure input as a single value, range string, or sequence of values."""
+        """Pressure in bar as a single value or range [pressure, pressure_high, nsteps]."""
         return self.get("pressure")
 
     @pressure.setter
@@ -596,7 +664,7 @@ class _VLESweepModeMixin:
 
 
 class ACTIVITYCOEFInputBuilder(
-    _TemperatureListMixin,
+    _TemperatureMixin,
     _MassFractionMixin,
     _DensitySolventMixin,
     _SolventRoleMixin,
@@ -610,8 +678,10 @@ class ACTIVITYCOEFInputBuilder(
     _PROPERTY_TYPE: ClassVar[str] = "ACTIVITYCOEF"
     _DESCRIPTION: ClassVar[str] = "Activity coefficients in a solvent mixture."
     _EXPOSED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature", "massfraction", "densitysolvent")
-    _CALCULATION_COMPOUND_KEYS: ClassVar[Tuple[str, ...]] = ("frac1", "density") + _VAPOR_PRESSURE_KEYS
     _REQUIRED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature",)
+    _FLOAT_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature", "densitysolvent")
+    _BOOL_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("massfraction",)
+    _CALCULATION_COMPOUND_KEYS: ClassVar[Tuple[str, ...]] = ("frac1", "density") + _VAPOR_PRESSURE_KEYS
     _COMPOUND_ROLE_CONFIG: ClassVar[Mapping[str, _CompoundRoleConfig]] = {
         "solvent": _CompoundRoleConfig(required_keys=("frac1",)),
         "solute": _CompoundRoleConfig(),
@@ -642,6 +712,9 @@ class SOLUBILITYInputBuilder(
         "isobar",
     )
     _REQUIRED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature",)
+    _FLOAT_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("pressure", "densitysolvent")
+    _FLOAT_LIST_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature",)
+    _BOOL_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("massfraction",)
     _CALCULATION_COMPOUND_KEYS: ClassVar[Tuple[str, ...]] = ("frac1", "density") + _FUSION_KEYS + _VAPOR_PRESSURE_KEYS
     _COMPOUND_ROLE_CONFIG: ClassVar[Mapping[str, _CompoundRoleConfig]] = {
         "solvent": _CompoundRoleConfig(required_keys=("frac1",)),
@@ -687,6 +760,9 @@ class BINMIXCOEFInputBuilder(
     )
     _CALCULATION_COMPOUND_KEYS: ClassVar[Tuple[str, ...]] = ("frac1",) + _VAPOR_PRESSURE_KEYS + ("flashpoint",)
     _REQUIRED_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature",)
+    _FLOAT_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("temperature", "pressure")
+    _INT_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("nfrac",)
+    _BOOL_INPUT_KEYS: ClassVar[Tuple[str, ...]] = ("massfraction",)
     _COMPOUND_ROLE_CONFIG: ClassVar[Mapping[str, _CompoundRoleConfig]] = {
         "compound": _CompoundRoleConfig(min_count=2, max_count=2),
     }

--- a/src/scm/plams/interfaces/adfsuite/crs_input_builder.py
+++ b/src/scm/plams/interfaces/adfsuite/crs_input_builder.py
@@ -196,7 +196,7 @@ class CRSInputBuilder:
             entries.difference_update(self._mode_controlled_input_keys())
         for role in self._compound_roles():
             entries.add(f"add_{role}")
-            entries.add(f"add_{role}_from_database")
+            entries.add(f"add_{role}_from_adfcrs_database")
         return sorted(entries)
 
     def get(self, key: str, default: Any = None) -> Any:
@@ -334,7 +334,7 @@ class CRSInputBuilder:
         self._compounds_by_role[role].append(normalized)
         return self
 
-    def _add_compound_role_from_database(
+    def _add_compound_role_from_adfcrs_database(
         self: _CRSInputBuilderT,
         role: str,
         name: str,
@@ -439,9 +439,9 @@ class _SolventRoleMixin:
         """Add a COMPOUND block as a solvent."""
         return self._add_compound_role("solvent", compound, **kwargs)
 
-    def add_solvent_from_database(self: _CRSInputBuilderT, name: str, **kwargs: Any) -> _CRSInputBuilderT:
+    def add_solvent_from_adfcrs_database(self: _CRSInputBuilderT, name: str, **kwargs: Any) -> _CRSInputBuilderT:
         """Add a database COMPOUND block as a solvent."""
-        return self._add_compound_role_from_database("solvent", name, **kwargs)
+        return self._add_compound_role_from_adfcrs_database("solvent", name, **kwargs)
 
 
 class _SoluteRoleMixin:
@@ -451,9 +451,9 @@ class _SoluteRoleMixin:
         """Add a COMPOUND block as a solute."""
         return self._add_compound_role("solute", compound, **kwargs)
 
-    def add_solute_from_database(self: _CRSInputBuilderT, name: str, **kwargs: Any) -> _CRSInputBuilderT:
+    def add_solute_from_adfcrs_database(self: _CRSInputBuilderT, name: str, **kwargs: Any) -> _CRSInputBuilderT:
         """Add a database COMPOUND block as a solute."""
-        return self._add_compound_role_from_database("solute", name, **kwargs)
+        return self._add_compound_role_from_adfcrs_database("solute", name, **kwargs)
 
 
 class _CompoundRoleMixin:
@@ -463,9 +463,9 @@ class _CompoundRoleMixin:
         """Add a generic COMPOUND block."""
         return self._add_compound_role("compound", compound, **kwargs)
 
-    def add_compound_from_database(self: _CRSInputBuilderT, name: str, **kwargs: Any) -> _CRSInputBuilderT:
+    def add_compound_from_adfcrs_database(self: _CRSInputBuilderT, name: str, **kwargs: Any) -> _CRSInputBuilderT:
         """Add a generic database COMPOUND block."""
-        return self._add_compound_role_from_database("compound", name, **kwargs)
+        return self._add_compound_role_from_adfcrs_database("compound", name, **kwargs)
 
 
 class _TemperatureMixin:

--- a/src/scm/plams/interfaces/adfsuite/crs_input_builder.py
+++ b/src/scm/plams/interfaces/adfsuite/crs_input_builder.py
@@ -4,6 +4,7 @@ import os
 from dataclasses import dataclass, field
 from typing import Any, ClassVar, Dict, List, Literal, Mapping, Optional, Sequence, Set, Tuple, Type, TypeVar, Union
 
+from scm.plams.core.functions import log
 from scm.plams.core.settings import Settings
 from scm.plams.interfaces.adfsuite.crs_definitions import CRS_METHODS, get_block_keys, get_crs_input_data
 
@@ -424,18 +425,19 @@ class CRSInputBuilder:
         for key, value in overrides.items():
             if value is None:
                 continue
-            self._validate_compound_key(key)
+            if not self._accepts_compound_key(key):
+                log(
+                    f"Ignoring compound key {key!r} for {self.property_type}: it does not affect this calculation.",
+                    3,
+                )
+                continue
             compound[key] = value
 
-    def _validate_compound_key(self, key: str) -> None:
-        allowed = set(self._CALCULATION_COMPOUND_KEYS)
-        if key not in allowed:
-            allowed_keys = ", ".join(sorted(allowed))
-            raise ValueError(f"{key!r} is not valid for {self.property_type} compounds. Supported keys: {allowed_keys}")
-
+    def _accepts_compound_key(self, key: str) -> bool:
         compound_keys = get_block_keys(get_crs_input_data(), "compound")
         if key not in compound_keys:
             raise ValueError(f"{key!r} is not a COMPOUND input key in crs.json")
+        return key in self._CALCULATION_COMPOUND_KEYS
 
     def _compound_blocks(self) -> List[Settings]:
         compounds: List[Settings] = []

--- a/unit_tests/test_crs_definitions.py
+++ b/unit_tests/test_crs_definitions.py
@@ -1,0 +1,25 @@
+import importlib
+
+
+def test_crs_definitions_import_without_ams_environment(monkeypatch):
+    monkeypatch.delenv("AMSBIN", raising=False)
+    monkeypatch.delenv("AMSHOME", raising=False)
+
+    from scm.plams.interfaces.adfsuite import crs_definitions
+
+    importlib.reload(crs_definitions)
+
+    assert crs_definitions.CRS_METHODS
+
+
+def test_crs_input_definition_metadata_helpers_support_nested_blocks():
+    from scm.plams.interfaces.adfsuite import crs_definitions
+
+    data = crs_definitions.get_crs_input_data()
+
+    compound_keys = crs_definitions.get_block_keys(data, "compound")
+    required_keys = crs_definitions.get_block_keys(data, "compound", "required")
+
+    assert compound_keys["frac1"]["type"] == "float"
+    assert set(required_keys) == {"name", "count"}
+


### PR DESCRIPTION
For instructions on using the property-aware CRS input builder, see the
https://github.com/SCM-NV/PLAMS/blob/WeiLinChen/crs-builder-review-cleanup/doc/source/interfaces/crs.rst

I’m not sure whether class CRSInputBuilder.to_inputs() is the structure we want, but it provides a convenient way to convert the builder state into a typed scm.inputs.CRS model. This also allows users to configure additional CRS options that are not exposed by the property-specific builder.